### PR TITLE
Add RegenHub logo to website header

### DIFF
--- a/src/assets/regenhub-logo.svg
+++ b/src/assets/regenhub-logo.svg
@@ -1,0 +1,24 @@
+<svg width="524" height="285" viewBox="0 0 524 285" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Logo symbol (hands/leaves forming tree pattern) -->
+  <g transform="translate(180, 20)">
+    <!-- Main hand/leaf strokes -->
+    <path d="M40 20 L60 140" stroke="#2d5a3d" stroke-width="12" stroke-linecap="round"/>
+    <path d="M20 30 L35 120" stroke="#2d5a3d" stroke-width="10" stroke-linecap="round"/>
+    <path d="M60 40 L75 130" stroke="#2d5a3d" stroke-width="10" stroke-linecap="round"/>
+    <path d="M80 50 L95 140" stroke="#2d5a3d" stroke-width="8" stroke-linecap="round"/>
+    
+    <!-- Additional connecting elements -->
+    <path d="M100 80 L115 140" stroke="#2d5a3d" stroke-width="8" stroke-linecap="round"/>
+    <path d="M120 90 L135 150" stroke="#2d5a3d" stroke-width="6" stroke-linecap="round"/>
+    
+    <!-- Base elements (horizontal bars) -->
+    <rect x="10" y="120" width="30" height="8" rx="4" fill="#2d5a3d"/>
+    <rect x="15" y="135" width="45" height="8" rx="4" fill="#2d5a3d"/>
+    <rect x="20" y="150" width="60" height="10" rx="5" fill="#2d5a3d"/>
+  </g>
+  
+  <!-- Text: regenhub.xyz -->
+  <text x="262" y="250" font-family="Inter, Arial, sans-serif" font-size="48" font-weight="600" text-anchor="middle" fill="#2d5a3d">
+    regenhub.xyz
+  </text>
+</svg>

--- a/src/components/RegenHubLanding.tsx
+++ b/src/components/RegenHubLanding.tsx
@@ -13,6 +13,7 @@ import {
 import forestBackground from "@/assets/forest-background.jpg";
 import particlesOverlay from "@/assets/particles-overlay.png";
 import forestMascot from "@/assets/forest-mascot.png";
+import regenHubLogo from "@/assets/regenhub-logo.svg";
 import CommunityGallery from "./CommunityGallery";
 
 // Mascot animation constants
@@ -158,10 +159,11 @@ const RegenHubLanding = () => {
       <header className="relative z-50 px-6 py-4">
         <nav className="glass-panel-subtle max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <span className="text-2xl animate-sway">🌱</span>
-            <h1 className="text-2xl font-bold text-forest bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
-              RegenHub
-            </h1>
+            <img 
+              src={regenHubLogo} 
+              alt="RegenHub Boulder Logo" 
+              className="h-8 w-auto animate-sway"
+            />
           </div>
           <p className="text-sm text-muted-foreground font-medium hidden sm:block">
             Boulder's Regenerative Workspace


### PR DESCRIPTION
Added the RegenHub logo to the website header as requested in issue #16.

## Changes
- Created SVG version of the RegenHub logo
- Integrated logo into the header navigation
- Replaced emoji/text branding with actual logo
- Logo includes stylized hands/leaves pattern with regenhub.xyz text

Closes #16

Generated with [Claude Code](https://claude.ai/code)