### PR TITLE
feat: implement mascot hopping animation along bottom of screen

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -310,6 +310,18 @@ All colors MUST be HSL for glassmorphism effects.
         }
     }
 
+    @keyframes hop-move {
+        0% {
+            transform: translateY(0px);
+        }
+        50% {
+            transform: translateY(-40px);
+        }
+        100% {
+            transform: translateY(0px);
+        }
+    }
+
     .animate-sway {
         animation: gentle-sway 4s ease-in-out infinite;
     }
@@ -320,5 +332,9 @@ All colors MUST be HSL for glassmorphism effects.
 
     .animate-shimmer {
         animation: shimmer 2s infinite;
+    }
+
+    .animate-hop {
+        animation: hop-move 0.8s ease-in-out infinite;
     }
 }


### PR DESCRIPTION
Implemented the mascot hopping animation as requested in issue #20.

## Changes:
- Added CSS keyframes for hopping motion (vertical bounce)
- Repositioned mascot to hop along bottom of screen instead of floating randomly
- Mascot now moves horizontally left-to-right with continuous hopping
- Click to reverse direction instead of random positioning
- Reduced mascot size and made animation more subtle
- Mascot wraps around screen edges when reaching boundaries

Closes #20

Generated with [Claude Code](https://claude.ai/code)