### PR TITLE
fix: resolve all lint errors + DX improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# RegenHub Environment Variables
+# Copy to .env.local for local development.
+# Build-time vars (NEXT_PUBLIC_*) are in apps/web/.env.production (committed).
+
+# ── Home Assistant (runtime, web + bot) ──────────────────────
+HA_URL=http://homeassistant.local:8123/api
+HA_TOKEN=
+HA_LOCK_ENTITIES=lock.front_door_lock,lock.back_door_lock
+
+# ── Supabase (runtime, bot only — web uses NEXT_PUBLIC_* from .env.production) ──
+SUPABASE_URL=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# ── Telegram Bot (runtime, bot only) ─────────────────────────
+TELEGRAM_BOT_TOKEN=
+
+# ── Stripe (runtime, web only) ───────────────────────────────
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+NEXT_PUBLIC_STRIPE_DAYPASS_LINK=
+NEXT_PUBLIC_STRIPE_FIVEPACK_LINK=

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -7,6 +7,7 @@ import { Users, Key, Activity, Zap, UserPlus, AlertTriangle, ClipboardList } fro
 export default async function AdminPage() {
   const supabase = await createClient();
 
+  // eslint-disable-next-line react-hooks/purity -- server component, renders once
   const oneHourFromNow = new Date(Date.now() + 60 * 60 * 1000).toISOString();
 
   const [

--- a/apps/web/src/app/auth/login/page.tsx
+++ b/apps/web/src/app/auth/login/page.tsx
@@ -9,7 +9,7 @@ export default function LoginPage() {
         <div className="glass-panel-strong p-8">
           <div className="text-center mb-8">
             <h1 className="text-2xl font-bold text-forest mb-2">Member Portal</h1>
-            <p className="text-muted text-sm">Enter your email and we'll send you a magic link.</p>
+            <p className="text-muted text-sm">Enter your email and we&apos;ll send you a magic link.</p>
           </div>
           <LoginForm />
         </div>

--- a/apps/web/src/app/freeday/FreeDayForm.tsx
+++ b/apps/web/src/app/freeday/FreeDayForm.tsx
@@ -65,13 +65,6 @@ function getTodayString(): string {
 /** Get the next weekday (Mon-Fri) as YYYY-MM-DD in Mountain Time */
 function getNextWeekday(): string {
   const now = new Date();
-  // Get current day-of-week in Mountain Time
-  const mtDay = parseInt(
-    new Intl.DateTimeFormat("en-US", { timeZone: "America/Denver", weekday: "narrow" })
-      .formatToParts(now)
-      .find((p) => p.type === "weekday")?.value ?? "0"
-  );
-  // Intl weekday "narrow" isn't numeric — use a different approach
   const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
   const mtDayName = new Intl.DateTimeFormat("en-US", {
     timeZone: "America/Denver",

--- a/apps/web/src/app/freeday/page.tsx
+++ b/apps/web/src/app/freeday/page.tsx
@@ -1,4 +1,3 @@
-import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { createServiceClient } from "@/lib/supabase/admin";
 import FreeDayForm from "./FreeDayForm";

--- a/apps/web/src/app/portal/page.tsx
+++ b/apps/web/src/app/portal/page.tsx
@@ -13,10 +13,12 @@ export default async function PortalPage() {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect("/auth/login");
 
-  let [{ data: member }, { data: application }] = await Promise.all([
+  const [memberResult, applicationResult] = await Promise.all([
     supabase.from("members").select("*").eq("supabase_user_id", user.id).single(),
     supabase.from("applications").select("*").eq("supabase_user_id", user.id).single(),
   ]);
+  let member = memberResult.data;
+  const application = applicationResult.data;
 
   // Auto-link: if no member found by supabase_user_id, try matching by verified email.
   // This handles the case where a member was created via Telegram bot (no supabase_user_id)
@@ -114,8 +116,10 @@ export default async function PortalPage() {
   const typeLabel = member.member_type === "cold_desk" ? "Cold Desk" : member.member_type === "hot_desk" ? "Hot Desk" : member.member_type === "hub_friend" ? "Hub Friend" : "Day Pass";
 
   // Show onboarding expanded for new members (no pin code set or account < 7 days old)
-  const isNewMember = !member.pin_code ||
-    (Date.now() - new Date(member.created_at).getTime() < 7 * 24 * 60 * 60 * 1000);
+  const accountAgeMs =
+    // eslint-disable-next-line react-hooks/purity -- server component, renders once
+    Date.now() - new Date(member.created_at).getTime();
+  const isNewMember = !member.pin_code || accountAgeMs < 7 * 24 * 60 * 60 * 1000;
 
   return (
     <div className="space-y-8">

--- a/apps/web/src/app/portal/page.tsx
+++ b/apps/web/src/app/portal/page.tsx
@@ -116,9 +116,8 @@ export default async function PortalPage() {
   const typeLabel = member.member_type === "cold_desk" ? "Cold Desk" : member.member_type === "hot_desk" ? "Hot Desk" : member.member_type === "hub_friend" ? "Hub Friend" : "Day Pass";
 
   // Show onboarding expanded for new members (no pin code set or account < 7 days old)
-  const accountAgeMs =
-    // eslint-disable-next-line react-hooks/purity -- server component, renders once
-    Date.now() - new Date(member.created_at).getTime();
+  // eslint-disable-next-line react-hooks/purity -- server component, renders once
+  const accountAgeMs = Date.now() - new Date(member.created_at).getTime();
   const isNewMember = !member.pin_code || accountAgeMs < 7 * 24 * 60 * 60 * 1000;
 
   return (

--- a/apps/web/src/app/portal/passes/page.tsx
+++ b/apps/web/src/app/portal/passes/page.tsx
@@ -4,8 +4,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { RequestDayPassButton } from "@/components/portal/RequestDayPassButton";
 import { RevokeCodeButton } from "@/components/portal/RevokeCodeButton";
-import { Ticket, Clock, ShoppingCart, Key, ArrowRight, Mail } from "lucide-react";
-import Link from "next/link";
+import { Ticket, Clock, ShoppingCart, Key, Mail } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 export const metadata = { title: "Live Codes — RegenHub" };
@@ -102,6 +101,7 @@ export default async function PassesPage() {
           <div className="space-y-3">
             {activeCodes.map((code) => {
               const expiresAt = code.expires_at ? new Date(code.expires_at) : null;
+              // eslint-disable-next-line react-hooks/purity -- server component, renders once
               const msLeft = expiresAt ? expiresAt.getTime() - Date.now() : null;
               const hoursLeft = msLeft != null ? Math.max(0, Math.ceil(msLeft / 3600000)) : null;
               const timeLabel = hoursLeft == null

--- a/apps/web/src/components/nav/MobileNav.tsx
+++ b/apps/web/src/components/nav/MobileNav.tsx
@@ -21,10 +21,10 @@ export function MobileNav({ links, trailing }: MobileNavProps) {
   const [open, setOpen] = useState(false);
   const pathname = usePathname();
 
-  // Close drawer on route change
-  useEffect(() => {
-    setOpen(false);
-  }, [pathname]);
+  // Close drawer on route change — links already call setOpen(false) on click,
+  // but this catches programmatic navigation and browser back/forward.
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: sync UI state with external navigation
+  useEffect(() => { setOpen(false); }, [pathname]);
 
   // Prevent body scroll when drawer is open
   useEffect(() => {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "scripts": {
     "dev": "pnpm --filter web dev",
-    "build": "pnpm --filter web build",
+    "build": "pnpm --filter @regenhub/shared build && pnpm --filter web build",
     "bot:dev": "pnpm --filter bot dev",
     "bot:build": "pnpm --filter bot build"
   }


### PR DESCRIPTION
## Summary
- **Fix all 6 lint errors**: Date.now() purity (3x server components), let→const, unescaped apostrophe, setState-in-effect
- **Fix 4 lint warnings**: remove unused imports and dead variables
- **Chain shared build in root package.json** so `pnpm build` works on fresh clones without knowing internal dependency order
- **Add `.env.example`** documenting all required runtime env vars

Closes #22 (labels were already updated in 8fe4526; the cooperative section has since been redesigned into the current tier-based layout).

## Details

### Lint fixes
| File | Fix |
|------|-----|
| `admin/page.tsx` | `Date.now()` purity — eslint-disable (server component) |
| `portal/page.tsx` | `Date.now()` purity + `let`→`const` destructuring split |
| `portal/passes/page.tsx` | `Date.now()` purity + remove unused `ArrowRight`, `Link` |
| `auth/login/page.tsx` | `'` → `&apos;` |
| `nav/MobileNav.tsx` | `setState` in `useEffect` — eslint-disable with explanation |
| `freeday/FreeDayForm.tsx` | Remove dead `mtDay` variable |
| `freeday/page.tsx` | Remove unused `redirect` import |

### DX
| Change | Why |
|--------|-----|
| Root `build` script chains `@regenhub/shared` first | Fresh clone `pnpm build` was broken — shared has no `dist/` committed |
| `.env.example` | New devs couldn't know required env vars without reading CLAUDE.md |

## Verification
- `pnpm build` ✅ (shared → web, 36 routes)
- `pnpm --filter bot build` ✅
- `pnpm --filter web lint` ✅ (0 errors, 1 warning — `<img>` for external profile photos)

## Test plan
- [ ] Verify `pnpm build` passes in CI
- [ ] Verify lint passes in CI
- [ ] Spot-check affected pages load correctly: `/admin`, `/portal`, `/portal/passes`, `/auth/login`, `/freeday`
- [ ] Verify mobile nav still closes on route change

🤖 Generated with [Claude Code](https://claude.com/claude-code)