### PR TITLE
feat: admin overhaul — dashboard stats, claims page, filters

### DIFF
--- a/apps/web/src/app/admin/applications/page.tsx
+++ b/apps/web/src/app/admin/applications/page.tsx
@@ -1,21 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
-import { Badge } from "@/components/ui/badge";
-import { ApplicationActions } from "@/components/admin/ApplicationActions";
-import type { Application, ApplicationStatus } from "@/lib/supabase/types";
-
-const interestLabels: Record<string, string> = {
-  daypass_single: "Day Pass",
-  daypass_5pack: "5-Pack",
-  hot_desk: "Hot Desk",
-  reserved_desk: "Reserved Desk",
-  community: "Community",
-};
-
-const statusStyle: Record<ApplicationStatus, string> = {
-  pending: "border-amber-400/50 text-amber-400",
-  approved: "border-emerald-400/50 text-emerald-400",
-  rejected: "border-red-400/50 text-red-400",
-};
+import { ApplicationsFilter } from "@/components/admin/ApplicationsFilter";
+import type { Application } from "@/lib/supabase/types";
 
 export default async function ApplicationsPage() {
   const supabase = await createClient();
@@ -30,84 +15,13 @@ export default async function ApplicationsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-forest">Applications</h1>
-          <p className="text-muted text-sm mt-1">
-            {apps.length} total · {pendingCount} pending review
-          </p>
-        </div>
+      <div>
+        <h1 className="text-2xl font-bold text-forest">Applications</h1>
+        <p className="text-muted text-sm mt-1">
+          {apps.length} total · {pendingCount} pending review
+        </p>
       </div>
-
-      {apps.length === 0 ? (
-        <div className="glass-panel p-8 text-center text-muted">
-          No applications yet.
-        </div>
-      ) : (
-        <>
-          {/* Application cards */}
-          <div className="space-y-4">
-            {apps.map((app) => (
-              <div key={app.id} className="glass-panel p-5 space-y-4">
-                {/* Header: name, meta, status */}
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-                  <div className="flex items-center gap-3 flex-wrap">
-                    <h3 className="font-semibold text-lg">{app.name}</h3>
-                    <Badge variant="outline" className={`text-xs ${statusStyle[app.status]}`}>
-                      {app.status}
-                    </Badge>
-                  </div>
-                  <div className="flex items-center gap-3 text-xs text-muted">
-                    <span>{app.email}</span>
-                    <Badge variant="outline" className="text-xs border-white/20 text-muted">
-                      {interestLabels[app.membership_interest] ?? app.membership_interest}
-                    </Badge>
-                    <span>
-                      {new Date(app.created_at).toLocaleDateString("en-US", {
-                        timeZone: "America/Denver",
-                        month: "short",
-                        day: "numeric",
-                      })}
-                    </span>
-                  </div>
-                </div>
-
-                {/* Questions & answers */}
-                {(app.about || app.why_join) && (
-                  <div className="grid sm:grid-cols-2 gap-4">
-                    {app.about && (
-                      <div>
-                        <p className="text-xs text-muted mb-1 font-medium">What are you working on?</p>
-                        <p className="text-sm text-foreground/80">{app.about}</p>
-                      </div>
-                    )}
-                    {app.why_join && (
-                      <div>
-                        <p className="text-xs text-muted mb-1 font-medium">Why do you want to join?</p>
-                        <p className="text-sm text-foreground/80">{app.why_join}</p>
-                      </div>
-                    )}
-                  </div>
-                )}
-
-                {/* Admin notes */}
-                {app.admin_notes && (
-                  <p className="text-xs text-sage border-l-2 border-sage/30 pl-3">
-                    {app.admin_notes}
-                  </p>
-                )}
-
-                {/* Actions */}
-                <ApplicationActions
-                  applicationId={app.id}
-                  currentStatus={app.status}
-                  adminNotes={app.admin_notes}
-                />
-              </div>
-            ))}
-          </div>
-        </>
-      )}
+      <ApplicationsFilter applications={apps} />
     </div>
   );
 }

--- a/apps/web/src/app/admin/claims/page.tsx
+++ b/apps/web/src/app/admin/claims/page.tsx
@@ -4,6 +4,8 @@ import { ClaimsFilter } from "@/components/admin/ClaimsFilter";
 export const metadata = { title: "Free Day Claims — Admin" };
 
 export default async function ClaimsPage() {
+  // Service client needed because free_day_claims isn't in the typed schema.
+  // Auth is enforced by the admin layout (session + is_admin check).
   const admin = createServiceClient();
 
   const { data: claims } = await admin

--- a/apps/web/src/app/admin/claims/page.tsx
+++ b/apps/web/src/app/admin/claims/page.tsx
@@ -1,0 +1,39 @@
+import { createServiceClient } from "@/lib/supabase/admin";
+import { ClaimsFilter } from "@/components/admin/ClaimsFilter";
+
+export const metadata = { title: "Free Day Claims — Admin" };
+
+export default async function ClaimsPage() {
+  const admin = createServiceClient();
+
+  const { data: claims } = await admin
+    .from("free_day_claims")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  const allClaims = (claims ?? []) as Array<{
+    id: number;
+    email: string;
+    name: string;
+    claimed_date: string;
+    status: string;
+    created_at: string;
+    about?: string | null;
+    why_join?: string | null;
+    invite_code?: string | null;
+  }>;
+
+  const pendingCount = allClaims.filter((c) => c.status === "pending").length;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-forest">Free Day Claims</h1>
+        <p className="text-muted text-sm mt-1">
+          {allClaims.length} total · {pendingCount} pending review
+        </p>
+      </div>
+      <ClaimsFilter claims={allClaims} />
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/layout.tsx
+++ b/apps/web/src/app/admin/layout.tsx
@@ -7,6 +7,7 @@ export const metadata = { title: "Admin — RegenHub" };
 
 const links: NavLink[] = [
   { href: "/admin", label: "Overview" },
+  { href: "/admin/claims", label: "Free Days" },
   { href: "/admin/applications", label: "Applications" },
   { href: "/admin/members", label: "Members" },
   { href: "/admin/codes", label: "Live Codes" },
@@ -38,6 +39,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
             <span className="text-xs bg-gold/20 text-gold px-2 py-0.5 rounded-full font-medium">Admin</span>
             <div className="hidden sm:flex gap-4 text-sm">
               <Link href="/admin" className="text-muted hover:text-foreground transition-colors">Overview</Link>
+              <Link href="/admin/claims" className="text-muted hover:text-foreground transition-colors">Free Days</Link>
               <Link href="/admin/applications" className="text-muted hover:text-foreground transition-colors">Applications</Link>
               <Link href="/admin/members" className="text-muted hover:text-foreground transition-colors">Members</Link>
               <Link href="/admin/codes" className="text-muted hover:text-foreground transition-colors">Live Codes</Link>

--- a/apps/web/src/app/admin/members/[id]/page.tsx
+++ b/apps/web/src/app/admin/members/[id]/page.tsx
@@ -3,6 +3,9 @@ import { notFound } from "next/navigation";
 import { MemberForm } from "@/components/admin/MemberForm";
 import { AddPassesCard } from "@/components/admin/AddPassesCard";
 import { PaymentLinkCard } from "@/components/admin/PaymentLinkCard";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { Key } from "lucide-react";
 
 export const metadata = { title: "Edit Member — Admin" };
 
@@ -10,11 +13,19 @@ export default async function EditMemberPage({ params }: { params: Promise<{ id:
   const { id } = await params;
   const supabase = await createClient();
 
-  const { data: member } = await supabase
-    .from("members")
-    .select("*")
-    .eq("id", Number(id))
-    .single();
+  const [{ data: member }, { data: codeHistory }] = await Promise.all([
+    supabase
+      .from("members")
+      .select("*")
+      .eq("id", Number(id))
+      .single(),
+    supabase
+      .from("day_codes")
+      .select("id, code, label, pin_slot, is_active, expires_at, revoked_at, created_at")
+      .eq("member_id", Number(id))
+      .order("created_at", { ascending: false })
+      .limit(20),
+  ]);
 
   if (!member) notFound();
 
@@ -35,6 +46,64 @@ export default async function EditMemberPage({ params }: { params: Promise<{ id:
           ? `${process.env.NEXT_PUBLIC_STRIPE_FIVEPACK_LINK}?client_reference_id=${member.id}&prefilled_email=${encodeURIComponent(member.email ?? "")}`
           : null}
       />
+
+      {/* Code history */}
+      {codeHistory && codeHistory.length > 0 && (
+        <Card className="glass-panel">
+          <CardContent className="p-6">
+            <div className="flex items-center gap-2 mb-4">
+              <Key className="w-5 h-5 text-sage" />
+              <h3 className="font-semibold">Code History</h3>
+              <span className="text-xs text-muted">Last {codeHistory.length}</span>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-white/10 text-left text-muted text-xs">
+                    <th className="pb-2 pr-4 font-medium">Code</th>
+                    <th className="pb-2 pr-4 font-medium">Slot</th>
+                    <th className="pb-2 pr-4 font-medium">Status</th>
+                    <th className="pb-2 pr-4 font-medium">Issued</th>
+                    <th className="pb-2 font-medium">Expires</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {codeHistory.map((c) => (
+                    <tr key={c.id} className="border-b border-white/5">
+                      <td className="py-2 pr-4 font-mono text-gold">{c.code}</td>
+                      <td className="py-2 pr-4 text-muted">{c.pin_slot}</td>
+                      <td className="py-2 pr-4">
+                        {c.is_active ? (
+                          <Badge className="text-xs bg-emerald-500/20 text-emerald-400 border-emerald-500/30">Active</Badge>
+                        ) : c.revoked_at ? (
+                          <Badge className="text-xs bg-red-500/20 text-red-400 border-red-500/30">Revoked</Badge>
+                        ) : (
+                          <Badge className="text-xs bg-white/10 text-muted border-white/20">Expired</Badge>
+                        )}
+                      </td>
+                      <td className="py-2 pr-4 text-xs text-muted">
+                        {new Date(c.created_at).toLocaleDateString("en-US", {
+                          month: "short", day: "numeric", hour: "numeric", minute: "2-digit",
+                          timeZone: "America/Denver",
+                        })}
+                      </td>
+                      <td className="py-2 text-xs text-muted">
+                        {c.expires_at
+                          ? new Date(c.expires_at).toLocaleDateString("en-US", {
+                              month: "short", day: "numeric", hour: "numeric", minute: "2-digit",
+                              timeZone: "America/Denver",
+                            })
+                          : "—"
+                        }
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/admin/members/page.tsx
+++ b/apps/web/src/app/admin/members/page.tsx
@@ -65,6 +65,7 @@ function AuthUserRow({ u }: { u: AdminUser }) {
     <>
       {displayName ?? <span className="text-muted italic">—</span>}
       {u.member?.is_admin && <span className="ml-2 text-xs text-gold">[Admin]</span>}
+      {u.member?.is_coop_member && <span className="ml-1 text-xs text-sage">[Co-op]</span>}
       {!u.member && u.application && (
         <span className="ml-2 text-xs text-muted italic">({u.application.membership_interest.replace(/_/g, " ")})</span>
       )}
@@ -115,6 +116,7 @@ function LegacyMemberRow({ m }: { m: Member }) {
     <>
       {m.name}
       {m.is_admin && <span className="ml-2 text-xs text-gold">[Admin]</span>}
+      {m.is_coop_member && <span className="ml-1 text-xs text-sage">[Co-op]</span>}
     </>
   );
   const action = (
@@ -153,6 +155,8 @@ export default function UsersPage() {
   const [data, setData] = useState<AdminUsersResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
+  const [typeFilter, setTypeFilter] = useState<string>("all");
+  const [statusFilter, setStatusFilter] = useState<string>("all");
 
   useEffect(() => {
     fetch("/api/admin/users")
@@ -163,28 +167,69 @@ export default function UsersPage() {
 
   const noProfileCount = data?.users.filter((u) => !u.member).length ?? 0;
 
-  // Client-side search filter
+  // Client-side search + filter
   const filteredUsers = useMemo(() => {
-    if (!data || !search.trim()) return data?.users ?? [];
-    const q = search.toLowerCase();
-    return data.users.filter((u) => {
-      const name = (u.member?.name ?? u.application?.name ?? "").toLowerCase();
-      const email = u.email.toLowerCase();
-      const tg = (u.member?.telegram_username ?? "").toLowerCase();
-      return name.includes(q) || email.includes(q) || tg.includes(q);
-    });
-  }, [data, search]);
+    if (!data) return [];
+    let result = data.users;
+
+    // Type filter
+    if (typeFilter === "no_profile") {
+      result = result.filter((u) => !u.member);
+    } else if (typeFilter !== "all") {
+      result = result.filter((u) => u.member?.member_type === typeFilter);
+    }
+
+    // Status filter
+    if (statusFilter === "active") {
+      result = result.filter((u) => u.member && !u.member.disabled);
+    } else if (statusFilter === "disabled") {
+      result = result.filter((u) => u.member?.disabled);
+    }
+
+    // Search
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      result = result.filter((u) => {
+        const name = (u.member?.name ?? u.application?.name ?? "").toLowerCase();
+        const email = u.email.toLowerCase();
+        const tg = (u.member?.telegram_username ?? "").toLowerCase();
+        return name.includes(q) || email.includes(q) || tg.includes(q);
+      });
+    }
+
+    return result;
+  }, [data, search, typeFilter, statusFilter]);
 
   const filteredLegacy = useMemo(() => {
-    if (!data || !search.trim()) return data?.legacyMembers ?? [];
-    const q = search.toLowerCase();
-    return data.legacyMembers.filter((m) => {
-      const name = m.name.toLowerCase();
-      const email = (m.email ?? "").toLowerCase();
-      const tg = (m.telegram_username ?? "").toLowerCase();
-      return name.includes(q) || email.includes(q) || tg.includes(q);
-    });
-  }, [data, search]);
+    if (!data) return [];
+    let result = data.legacyMembers;
+
+    // Type filter
+    if (typeFilter === "no_profile") return [];
+    if (typeFilter !== "all") {
+      result = result.filter((m) => m.member_type === typeFilter);
+    }
+
+    // Status filter
+    if (statusFilter === "active") {
+      result = result.filter((m) => !m.disabled);
+    } else if (statusFilter === "disabled") {
+      result = result.filter((m) => m.disabled);
+    }
+
+    // Search
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      result = result.filter((m) => {
+        const name = m.name.toLowerCase();
+        const email = (m.email ?? "").toLowerCase();
+        const tg = (m.telegram_username ?? "").toLowerCase();
+        return name.includes(q) || email.includes(q) || tg.includes(q);
+      });
+    }
+
+    return result;
+  }, [data, search, typeFilter, statusFilter]);
 
   return (
     <div className="space-y-6">
@@ -202,24 +247,47 @@ export default function UsersPage() {
         </Link>
       </div>
 
-      {/* Search bar */}
+      {/* Search + filters */}
       {data && (
-        <div className="relative max-w-sm">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted" />
-          <Input
-            placeholder="Search by name, email, or Telegram..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="glass-input pl-9 pr-8"
-          />
-          {search && (
-            <button
-              onClick={() => setSearch("")}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted hover:text-foreground"
-            >
-              <X className="w-4 h-4" />
-            </button>
-          )}
+        <div className="flex flex-wrap gap-3 items-center">
+          <div className="relative max-w-sm flex-1 min-w-[200px]">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted" />
+            <Input
+              placeholder="Search by name, email, or Telegram..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="glass-input pl-9 pr-8"
+            />
+            {search && (
+              <button
+                onClick={() => setSearch("")}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted hover:text-foreground"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+          <select
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value)}
+            className="rounded-md px-3 py-2 text-sm glass-input"
+          >
+            <option value="all">All types</option>
+            <option value="cold_desk">Cold Desk</option>
+            <option value="hot_desk">Hot Desk</option>
+            <option value="hub_friend">Hub Friend</option>
+            <option value="day_pass">Day Pass</option>
+            <option value="no_profile">No Profile</option>
+          </select>
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="rounded-md px-3 py-2 text-sm glass-input"
+          >
+            <option value="all">All statuses</option>
+            <option value="active">Active</option>
+            <option value="disabled">Disabled</option>
+          </select>
         </div>
       )}
 

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -1,11 +1,13 @@
 import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/admin";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { Users, Key, Activity, Zap, UserPlus, AlertTriangle, ClipboardList } from "lucide-react";
+import { Users, Key, Zap, UserPlus, AlertTriangle, ClipboardList, Calendar } from "lucide-react";
 
 export default async function AdminPage() {
   const supabase = await createClient();
+  const admin = createServiceClient();
 
   // eslint-disable-next-line react-hooks/purity -- server component, renders once
   const oneHourFromNow = new Date(Date.now() + 60 * 60 * 1000).toISOString();
@@ -16,6 +18,18 @@ export default async function AdminPage() {
     { count: expiringSoonCount },
     { count: disabledCount },
     { count: pendingAppCount },
+    // Member type breakdown
+    { count: coldDeskCount },
+    { count: hotDeskCount },
+    { count: hubFriendCount },
+    { count: dayPassCount },
+    // Free day stats
+    { count: pendingClaimCount },
+    { count: reservedClaimCount },
+    // Recent activity
+    { data: recentMembers },
+    { data: recentApps },
+    { data: recentCodes },
   ] = await Promise.all([
     supabase.from("members").select("*", { count: "exact", head: true }).eq("disabled", false),
     supabase.from("day_codes").select("*", { count: "exact", head: true }).eq("is_active", true),
@@ -25,7 +39,26 @@ export default async function AdminPage() {
       .gt("expires_at", new Date().toISOString()),
     supabase.from("members").select("*", { count: "exact", head: true }).eq("disabled", true),
     supabase.from("applications").select("*", { count: "exact", head: true }).eq("status", "pending"),
+    // Type breakdown
+    supabase.from("members").select("*", { count: "exact", head: true }).eq("disabled", false).eq("member_type", "cold_desk"),
+    supabase.from("members").select("*", { count: "exact", head: true }).eq("disabled", false).eq("member_type", "hot_desk"),
+    supabase.from("members").select("*", { count: "exact", head: true }).eq("disabled", false).eq("member_type", "hub_friend"),
+    supabase.from("members").select("*", { count: "exact", head: true }).eq("disabled", false).eq("member_type", "day_pass"),
+    // Free day claims
+    admin.from("free_day_claims").select("*", { count: "exact", head: true }).eq("status", "pending"),
+    admin.from("free_day_claims").select("*", { count: "exact", head: true }).eq("status", "reserved"),
+    // Recent activity
+    supabase.from("members").select("id, name, member_type, created_at").eq("disabled", false).order("created_at", { ascending: false }).limit(5),
+    supabase.from("applications").select("id, name, email, status, created_at").order("created_at", { ascending: false }).limit(5),
+    supabase.from("day_codes").select("id, code, label, pin_slot, is_active, created_at, members(name)").order("created_at", { ascending: false }).limit(5),
   ]);
+
+  const typeBreakdown = [
+    { label: "Cold Desk", count: coldDeskCount ?? 0, color: "text-green-400" },
+    { label: "Hot Desk", count: hotDeskCount ?? 0, color: "text-emerald-400" },
+    { label: "Hub Friend", count: hubFriendCount ?? 0, color: "text-purple-400" },
+    { label: "Day Pass", count: dayPassCount ?? 0, color: "text-blue-400" },
+  ];
 
   return (
     <div className="space-y-8">
@@ -42,6 +75,13 @@ export default async function AdminPage() {
               <Users className="w-6 h-6 text-sage mb-2" />
               <p className="text-xs text-muted mb-1">Active Members</p>
               <p className="text-3xl font-bold text-foreground">{memberCount ?? 0}</p>
+              <div className="flex flex-wrap gap-x-2 gap-y-0.5 mt-2">
+                {typeBreakdown.map((t) => (
+                  <span key={t.label} className={`text-xs ${t.color}`}>
+                    {t.count} {t.label.split(" ")[0]}
+                  </span>
+                ))}
+              </div>
               {(disabledCount ?? 0) > 0 && (
                 <p className="text-xs text-muted mt-1">{disabledCount} disabled</p>
               )}
@@ -78,12 +118,20 @@ export default async function AdminPage() {
           </Card>
         </Link>
 
-        <Link href="/admin/lock">
+        <Link href="/admin/claims">
           <Card className="glass-panel hover-lift cursor-pointer">
             <CardContent className="p-5">
-              <Activity className="w-6 h-6 text-sage mb-2" />
-              <p className="text-xs text-muted mb-1">Lock Sync</p>
-              <p className="text-xl font-bold text-foreground mt-1">Manage</p>
+              <Calendar className="w-6 h-6 text-sage mb-2" />
+              <p className="text-xs text-muted mb-1">Free Days</p>
+              <p className="text-3xl font-bold text-foreground">{(pendingClaimCount ?? 0) + (reservedClaimCount ?? 0)}</p>
+              <div className="flex gap-2 mt-1 text-xs">
+                {(pendingClaimCount ?? 0) > 0 && (
+                  <span className="text-amber-400">{pendingClaimCount} pending</span>
+                )}
+                {(reservedClaimCount ?? 0) > 0 && (
+                  <span className="text-sage">{reservedClaimCount} reserved</span>
+                )}
+              </div>
             </CardContent>
           </Card>
         </Link>
@@ -102,6 +150,101 @@ export default async function AdminPage() {
                   <UserPlus className="w-3.5 h-3.5" /> Add Member
                 </Button>
               </Link>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Recent activity */}
+      <div className="grid lg:grid-cols-3 gap-6">
+        {/* Recent members */}
+        <Card className="glass-panel">
+          <CardContent className="p-5">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-sm font-semibold flex items-center gap-2">
+                <Users className="w-4 h-4 text-sage" /> Recent Members
+              </h3>
+              <Link href="/admin/members" className="text-xs text-muted hover:text-foreground">View all</Link>
+            </div>
+            <div className="space-y-3">
+              {(recentMembers ?? []).length === 0 ? (
+                <p className="text-xs text-muted">No members yet.</p>
+              ) : (
+                recentMembers!.map((m) => (
+                  <Link key={m.id} href={`/admin/members/${m.id}`} className="flex items-center justify-between gap-2 group">
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium truncate group-hover:text-sage transition-colors">{m.name}</p>
+                      <p className="text-xs text-muted capitalize">{m.member_type.replace(/_/g, " ")}</p>
+                    </div>
+                    <span className="text-xs text-muted shrink-0">
+                      {new Date(m.created_at).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+                    </span>
+                  </Link>
+                ))
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Recent applications */}
+        <Card className="glass-panel">
+          <CardContent className="p-5">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-sm font-semibold flex items-center gap-2">
+                <ClipboardList className="w-4 h-4 text-sage" /> Recent Applications
+              </h3>
+              <Link href="/admin/applications" className="text-xs text-muted hover:text-foreground">View all</Link>
+            </div>
+            <div className="space-y-3">
+              {(recentApps ?? []).length === 0 ? (
+                <p className="text-xs text-muted">No applications yet.</p>
+              ) : (
+                recentApps!.map((a) => (
+                  <div key={a.id} className="flex items-center justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium truncate">{a.name}</p>
+                      <p className="text-xs text-muted">{a.email}</p>
+                    </div>
+                    <span className={`text-xs shrink-0 ${
+                      a.status === "pending" ? "text-amber-400" :
+                      a.status === "approved" ? "text-emerald-400" : "text-red-400"
+                    }`}>
+                      {a.status}
+                    </span>
+                  </div>
+                ))
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Recent codes */}
+        <Card className="glass-panel">
+          <CardContent className="p-5">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-sm font-semibold flex items-center gap-2">
+                <Key className="w-4 h-4 text-sage" /> Recent Codes
+              </h3>
+              <Link href="/admin/codes" className="text-xs text-muted hover:text-foreground">View all</Link>
+            </div>
+            <div className="space-y-3">
+              {(recentCodes ?? []).length === 0 ? (
+                <p className="text-xs text-muted">No codes yet.</p>
+              ) : (
+                recentCodes!.map((c: Record<string, unknown>) => (
+                  <div key={c.id as number} className="flex items-center justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="text-sm font-mono text-gold">{c.code as string}</p>
+                      <p className="text-xs text-muted">
+                        {(c.label as string) ?? (c.members as { name: string } | null)?.name ?? `Slot ${c.pin_slot}`}
+                      </p>
+                    </div>
+                    <span className={`text-xs shrink-0 ${c.is_active ? "text-sage" : "text-muted"}`}>
+                      {c.is_active ? "active" : "revoked"}
+                    </span>
+                  </div>
+                ))
+              )}
             </div>
           </CardContent>
         </Card>

--- a/apps/web/src/app/api/admin/claims/route.ts
+++ b/apps/web/src/app/api/admin/claims/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/admin";
+import { createServiceClient } from "@/lib/supabase/admin";
+
+export async function GET() {
+  if (!await requireAdmin()) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const admin = createServiceClient();
+
+  const { data: claims, error } = await admin
+    .from("free_day_claims")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ claims: claims ?? [] });
+}
+
+export async function PATCH(request: Request) {
+  if (!await requireAdmin()) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const admin = createServiceClient();
+  const body = await request.json();
+  const { id, status } = body;
+
+  if (!id || !status) {
+    return NextResponse.json({ error: "id and status required" }, { status: 400 });
+  }
+
+  const validStatuses = ["pending", "reserved", "activated", "expired", "cancelled"];
+  if (!validStatuses.includes(status)) {
+    return NextResponse.json({ error: `status must be one of: ${validStatuses.join(", ")}` }, { status: 400 });
+  }
+
+  const { error } = await admin
+    .from("free_day_claims")
+    .update({ status })
+    .eq("id", id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/src/app/api/admin/members/[id]/add-passes/route.ts
+++ b/apps/web/src/app/api/admin/members/[id]/add-passes/route.ts
@@ -15,23 +15,41 @@ export async function POST(
   const body = await request.json();
   const count = parseInt(body.count);
 
-  if (!count || count < 1 || count > 1000) {
-    return NextResponse.json({ error: "count must be 1–1000" }, { status: 400 });
+  if (!count || count === 0 || Math.abs(count) > 1000) {
+    return NextResponse.json({ error: "count must be between -1000 and 1000, non-zero" }, { status: 400 });
   }
 
-  // Atomic increment — prevents lost updates from concurrent admin operations
-  const { data: newBalance, error } = await supabase.rpc(
-    "increment_day_pass_balance",
-    { p_member_id: Number(id), p_amount: count }
-  );
+  if (count > 0) {
+    // Atomic increment
+    const { data: newBalance, error } = await supabase.rpc(
+      "increment_day_pass_balance",
+      { p_member_id: Number(id), p_amount: count }
+    );
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    if (newBalance === -1) {
+      return NextResponse.json({ error: "Member not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ balance: newBalance });
+  } else {
+    // Atomic decrement
+    const { data: newBalance, error } = await supabase.rpc(
+      "decrement_day_pass_balance",
+      { p_member_id: Number(id), p_amount: Math.abs(count) }
+    );
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    if (newBalance === -1) {
+      return NextResponse.json({ error: "Member not found or insufficient balance" }, { status: 400 });
+    }
+
+    return NextResponse.json({ balance: newBalance });
   }
-
-  if (newBalance === -1) {
-    return NextResponse.json({ error: "Member not found" }, { status: 404 });
-  }
-
-  return NextResponse.json({ balance: newBalance });
 }

--- a/apps/web/src/components/admin/AddPassesCard.tsx
+++ b/apps/web/src/components/admin/AddPassesCard.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
-import { Ticket, Plus } from "lucide-react";
+import { Ticket, Plus, Minus } from "lucide-react";
 
 interface Props {
   memberId: number;
@@ -17,16 +17,20 @@ export function AddPassesCard({ memberId, initialBalance }: Props) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function handleAdd() {
+  async function handleAdjust(direction: "add" | "subtract") {
     const n = parseInt(count);
     if (!n || n < 1) return;
+    if (direction === "subtract" && n > balance) {
+      setError(`Cannot subtract ${n} — current balance is ${balance}`);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
       const res = await fetch(`/api/admin/members/${memberId}/add-passes`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ count: n }),
+        body: JSON.stringify({ count: direction === "add" ? n : -n }),
       });
       const json = await res.json();
       if (!res.ok) throw new Error(json.error ?? "Failed");
@@ -46,7 +50,7 @@ export function AddPassesCard({ memberId, initialBalance }: Props) {
           <h3 className="font-semibold">Day Pass Balance</h3>
         </div>
 
-        <div className="flex items-end gap-4">
+        <div className="flex items-end gap-4 flex-wrap">
           <div>
             <p className="text-xs text-muted mb-1">Current balance</p>
             <p className={`text-4xl font-bold ${balance > 0 ? "text-gold" : "text-muted"}`}>{balance}</p>
@@ -63,12 +67,21 @@ export function AddPassesCard({ memberId, initialBalance }: Props) {
             />
             <Button
               type="button"
-              onClick={handleAdd}
+              onClick={() => handleAdjust("add")}
               disabled={loading}
               className="btn-primary-glass gap-1.5"
             >
               <Plus className="w-4 h-4" />
-              {loading ? "Adding…" : `Add passes`}
+              Add
+            </Button>
+            <Button
+              type="button"
+              onClick={() => handleAdjust("subtract")}
+              disabled={loading || balance === 0}
+              className="bg-red-600/20 hover:bg-red-600/40 text-red-400 border border-red-500/30 gap-1.5"
+            >
+              <Minus className="w-4 h-4" />
+              Subtract
             </Button>
           </div>
         </div>

--- a/apps/web/src/components/admin/ApplicationsFilter.tsx
+++ b/apps/web/src/components/admin/ApplicationsFilter.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Search, X } from "lucide-react";
+import { ApplicationActions } from "@/components/admin/ApplicationActions";
+import type { Application, ApplicationStatus } from "@/lib/supabase/types";
+
+const interestLabels: Record<string, string> = {
+  daypass_single: "Day Pass",
+  daypass_5pack: "5-Pack",
+  hot_desk: "Hot Desk",
+  reserved_desk: "Reserved Desk",
+  community: "Community",
+};
+
+const statusStyle: Record<ApplicationStatus, string> = {
+  pending: "border-amber-400/50 text-amber-400",
+  approved: "border-emerald-400/50 text-emerald-400",
+  rejected: "border-red-400/50 text-red-400",
+};
+
+const statusTabs = ["all", "pending", "approved", "rejected"] as const;
+
+export function ApplicationsFilter({ applications }: { applications: Application[] }) {
+  const [activeTab, setActiveTab] = useState<string>("all");
+  const [search, setSearch] = useState("");
+
+  const filtered = useMemo(() => {
+    let result = applications;
+    if (activeTab !== "all") {
+      result = result.filter((a) => a.status === activeTab);
+    }
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      result = result.filter((a) =>
+        a.name.toLowerCase().includes(q) ||
+        a.email.toLowerCase().includes(q)
+      );
+    }
+    return result;
+  }, [applications, activeTab, search]);
+
+  const counts = useMemo(() => {
+    const c: Record<string, number> = { all: applications.length };
+    for (const app of applications) {
+      c[app.status] = (c[app.status] ?? 0) + 1;
+    }
+    return c;
+  }, [applications]);
+
+  return (
+    <div className="space-y-4">
+      {/* Filter tabs */}
+      <div className="flex flex-wrap gap-2">
+        {statusTabs.map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+              activeTab === tab
+                ? "bg-sage/20 text-sage border border-sage/30"
+                : "bg-white/5 text-muted border border-white/10 hover:bg-white/10"
+            }`}
+          >
+            {tab === "all" ? "All" : tab.charAt(0).toUpperCase() + tab.slice(1)}
+            {(counts[tab] ?? 0) > 0 && (
+              <span className="ml-1.5 opacity-70">{counts[tab]}</span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Search */}
+      <div className="relative max-w-sm">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted" />
+        <Input
+          placeholder="Search by name or email..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="glass-input pl-9 pr-8"
+        />
+        {search && (
+          <button
+            onClick={() => setSearch("")}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-muted hover:text-foreground"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Applications list */}
+      {filtered.length === 0 ? (
+        <div className="glass-panel p-8 text-center text-muted">
+          {search || activeTab !== "all" ? "No matching applications." : "No applications yet."}
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {filtered.map((app) => (
+            <div key={app.id} className="glass-panel p-5 space-y-4">
+              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+                <div className="flex items-center gap-3 flex-wrap">
+                  <h3 className="font-semibold text-lg">{app.name}</h3>
+                  <Badge variant="outline" className={`text-xs ${statusStyle[app.status]}`}>
+                    {app.status}
+                  </Badge>
+                </div>
+                <div className="flex items-center gap-3 text-xs text-muted">
+                  <span>{app.email}</span>
+                  <Badge variant="outline" className="text-xs border-white/20 text-muted">
+                    {interestLabels[app.membership_interest] ?? app.membership_interest}
+                  </Badge>
+                  <span>
+                    {new Date(app.created_at).toLocaleDateString("en-US", {
+                      timeZone: "America/Denver",
+                      month: "short",
+                      day: "numeric",
+                    })}
+                  </span>
+                </div>
+              </div>
+
+              {(app.about || app.why_join) && (
+                <div className="grid sm:grid-cols-2 gap-4">
+                  {app.about && (
+                    <div>
+                      <p className="text-xs text-muted mb-1 font-medium">What are you working on?</p>
+                      <p className="text-sm text-foreground/80">{app.about}</p>
+                    </div>
+                  )}
+                  {app.why_join && (
+                    <div>
+                      <p className="text-xs text-muted mb-1 font-medium">Why do you want to join?</p>
+                      <p className="text-sm text-foreground/80">{app.why_join}</p>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {app.admin_notes && (
+                <p className="text-xs text-sage border-l-2 border-sage/30 pl-3">
+                  {app.admin_notes}
+                </p>
+              )}
+
+              <ApplicationActions
+                applicationId={app.id}
+                currentStatus={app.status}
+                adminNotes={app.admin_notes}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/ClaimActions.tsx
+++ b/apps/web/src/components/admin/ClaimActions.tsx
@@ -13,16 +13,24 @@ interface Props {
 export function ClaimActions({ claimId, currentStatus }: Props) {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   async function updateStatus(status: string) {
     setBusy(true);
+    setError(null);
     try {
       const res = await fetch("/api/admin/claims", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ id: claimId, status }),
       });
-      if (res.ok) router.refresh();
+      if (!res.ok) {
+        const json = await res.json();
+        throw new Error(json.error ?? "Failed to update claim");
+      }
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
     } finally {
       setBusy(false);
     }
@@ -70,6 +78,7 @@ export function ClaimActions({ claimId, currentStatus }: Props) {
           Revert to Pending
         </Button>
       )}
+      {error && <p className="text-sm text-red-400">{error}</p>}
     </div>
   );
 }

--- a/apps/web/src/components/admin/ClaimActions.tsx
+++ b/apps/web/src/components/admin/ClaimActions.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Check, X } from "lucide-react";
+
+interface Props {
+  claimId: number;
+  currentStatus: string;
+}
+
+export function ClaimActions({ claimId, currentStatus }: Props) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  async function updateStatus(status: string) {
+    setBusy(true);
+    try {
+      const res = await fetch("/api/admin/claims", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: claimId, status }),
+      });
+      if (res.ok) router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-1.5 flex-wrap">
+      {currentStatus === "pending" && (
+        <>
+          <Button
+            size="sm"
+            disabled={busy}
+            onClick={() => updateStatus("reserved")}
+            className="bg-emerald-600/20 hover:bg-emerald-600/40 text-emerald-400 border border-emerald-500/30 text-xs gap-1 h-7 px-2"
+          >
+            <Check className="w-3 h-3" /> Approve
+          </Button>
+          <Button
+            size="sm"
+            disabled={busy}
+            onClick={() => updateStatus("cancelled")}
+            className="bg-red-600/20 hover:bg-red-600/40 text-red-400 border border-red-500/30 text-xs gap-1 h-7 px-2"
+          >
+            <X className="w-3 h-3" /> Reject
+          </Button>
+        </>
+      )}
+      {currentStatus === "reserved" && (
+        <Button
+          size="sm"
+          disabled={busy}
+          onClick={() => updateStatus("cancelled")}
+          className="bg-red-600/20 hover:bg-red-600/40 text-red-400 border border-red-500/30 text-xs gap-1 h-7 px-2"
+        >
+          <X className="w-3 h-3" /> Cancel
+        </Button>
+      )}
+      {currentStatus === "cancelled" && (
+        <Button
+          size="sm"
+          disabled={busy}
+          onClick={() => updateStatus("pending")}
+          className="btn-glass text-xs h-7 px-2"
+        >
+          Revert to Pending
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/ClaimsFilter.tsx
+++ b/apps/web/src/components/admin/ClaimsFilter.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Search, X } from "lucide-react";
+import { ClaimActions } from "@/components/admin/ClaimActions";
+
+type FreeDayClaim = {
+  id: number;
+  email: string;
+  name: string;
+  claimed_date: string;
+  status: string;
+  created_at: string;
+  about?: string | null;
+  why_join?: string | null;
+  invite_code?: string | null;
+};
+
+const statusTabs = ["all", "pending", "reserved", "activated", "expired", "cancelled"] as const;
+
+const statusStyle: Record<string, string> = {
+  pending: "border-amber-400/50 text-amber-400",
+  reserved: "border-blue-400/50 text-blue-400",
+  activated: "border-emerald-400/50 text-emerald-400",
+  expired: "border-muted text-muted",
+  cancelled: "border-red-400/50 text-red-400",
+};
+
+export function ClaimsFilter({ claims }: { claims: FreeDayClaim[] }) {
+  const [activeTab, setActiveTab] = useState<string>("all");
+  const [search, setSearch] = useState("");
+
+  const filtered = useMemo(() => {
+    let result = claims;
+    if (activeTab !== "all") {
+      result = result.filter((c) => c.status === activeTab);
+    }
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      result = result.filter((c) =>
+        c.name.toLowerCase().includes(q) ||
+        c.email.toLowerCase().includes(q)
+      );
+    }
+    return result;
+  }, [claims, activeTab, search]);
+
+  const counts = useMemo(() => {
+    const c: Record<string, number> = { all: claims.length };
+    for (const claim of claims) {
+      c[claim.status] = (c[claim.status] ?? 0) + 1;
+    }
+    return c;
+  }, [claims]);
+
+  return (
+    <div className="space-y-4">
+      {/* Filter tabs */}
+      <div className="flex flex-wrap gap-2">
+        {statusTabs.map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+              activeTab === tab
+                ? "bg-sage/20 text-sage border border-sage/30"
+                : "bg-white/5 text-muted border border-white/10 hover:bg-white/10"
+            }`}
+          >
+            {tab === "all" ? "All" : tab.charAt(0).toUpperCase() + tab.slice(1)}
+            {(counts[tab] ?? 0) > 0 && (
+              <span className="ml-1.5 opacity-70">{counts[tab]}</span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Search */}
+      <div className="relative max-w-sm">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted" />
+        <Input
+          placeholder="Search by name or email..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="glass-input pl-9 pr-8"
+        />
+        {search && (
+          <button
+            onClick={() => setSearch("")}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-muted hover:text-foreground"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Claims list */}
+      {filtered.length === 0 ? (
+        <div className="glass-panel p-8 text-center text-muted">
+          {search || activeTab !== "all" ? "No matching claims." : "No free day claims yet."}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {filtered.map((claim) => (
+            <div key={claim.id} className="glass-panel p-5 space-y-3">
+              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+                <div className="flex items-center gap-3 flex-wrap">
+                  <h3 className="font-semibold">{claim.name}</h3>
+                  <Badge variant="outline" className={`text-xs ${statusStyle[claim.status] ?? ""}`}>
+                    {claim.status}
+                  </Badge>
+                </div>
+                <div className="flex items-center gap-3 text-xs text-muted">
+                  <span>{claim.email}</span>
+                  <span>
+                    {new Date(claim.claimed_date + "T12:00:00").toLocaleDateString("en-US", {
+                      month: "short", day: "numeric", weekday: "short",
+                    })}
+                  </span>
+                  <span>
+                    Applied {new Date(claim.created_at).toLocaleDateString("en-US", {
+                      month: "short", day: "numeric",
+                    })}
+                  </span>
+                </div>
+              </div>
+
+              {(claim.about || claim.why_join) && (
+                <div className="grid sm:grid-cols-2 gap-4">
+                  {claim.about && (
+                    <div>
+                      <p className="text-xs text-muted mb-1 font-medium">What are you working on?</p>
+                      <p className="text-sm text-foreground/80">{claim.about}</p>
+                    </div>
+                  )}
+                  {claim.why_join && (
+                    <div>
+                      <p className="text-xs text-muted mb-1 font-medium">Why do you want to visit?</p>
+                      <p className="text-sm text-foreground/80">{claim.why_join}</p>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              <ClaimActions claimId={claim.id} currentStatus={claim.status} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Enhanced dashboard**: member counts by type, free day claim stats, recent activity panels (members, applications, codes)
- **New free day claims page** (`/admin/claims`): filter tabs, search, approve/reject actions
- **Member list filters**: by member type, by status (active/disabled), co-op badge
- **Application list filters**: status tabs with counts, search by name/email
- **Day pass management**: add AND subtract passes (was add-only)
- **Code history**: member edit page now shows last 20 door codes

## What changed

### Dashboard (`admin/page.tsx`)
- Member count card now shows breakdown: Cold Desk, Hot Desk, Hub Friend, Day Pass
- New "Free Days" stat card with pending + reserved counts
- Lock Sync card replaced (still accessible via nav)
- 3 recent activity panels: members, applications, codes

### Free Day Claims (`admin/claims/` — NEW)
- Server-fetched page + client filter component
- Filter tabs: All / Pending / Reserved / Activated / Expired / Cancelled
- Search by name or email
- Approve (→ reserved) / Reject (→ cancelled) / Revert actions
- API: `GET /api/admin/claims` + `PATCH /api/admin/claims`

### Members (`admin/members/page.tsx`)
- Type filter dropdown (Cold Desk / Hot Desk / Hub Friend / Day Pass / No Profile)
- Status filter dropdown (Active / Disabled)
- `[Co-op]` badge next to `[Admin]` badge

### Applications (`admin/applications/page.tsx`)
- Extracted to `ApplicationsFilter` client component
- Status tabs: All / Pending / Approved / Rejected with counts
- Search by name or email

### Day Passes (`AddPassesCard.tsx` + API)
- Add AND subtract buttons (was add-only)
- Client-side balance validation before subtract
- API now accepts negative counts → routes to `decrement_day_pass_balance` RPC

### Member Edit (`admin/members/[id]/page.tsx`)
- Code history table: last 20 door codes with status, slot, issued/expires dates

### Nav (`admin/layout.tsx`)
- Added "Free Days" link between Overview and Applications

## Verification
- `pnpm build` ✅ (38 routes, up from 36)
- `pnpm --filter web lint` ✅ (0 errors, 1 pre-existing warning)
- Self-reviewed: fixed silent error swallowing in ClaimActions

## Test plan
- [ ] Dashboard loads with correct type breakdown counts
- [ ] Free Days page: filter tabs work, search works, approve/reject actions update status
- [ ] Members page: type filter narrows correctly, status filter works, co-op badge shows
- [ ] Applications page: filter tabs work, search narrows correctly
- [ ] Day passes: subtract button works, prevents subtracting more than balance
- [ ] Member edit: code history table shows past codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)