### PR TITLE
feat: telegram field + support contact on apply form

### DIFF
--- a/apps/web/src/app/api/apply/route.ts
+++ b/apps/web/src/app/api/apply/route.ts
@@ -14,6 +14,7 @@ const interestLabels: Record<string, string> = {
 async function notifyTelegram(app: {
   name: string;
   email: string;
+  telegram?: string | null;
   about?: string | null;
   why_join?: string | null;
   membership_interest: string;
@@ -28,6 +29,7 @@ async function notifyTelegram(app: {
     `*${app.name}*  ·  ${app.email}`,
     `Interest: ${interestLabels[app.membership_interest] ?? app.membership_interest}`,
   ];
+  if (app.telegram) lines.push(`Telegram: @${app.telegram}`);
   if (app.about) lines.push(``, `_Working on:_ ${app.about}`);
   if (app.why_join) lines.push(``, `_Why join:_ ${app.why_join}`);
   lines.push(``, `[Review →](https://regenhub.xyz/admin/applications)`);
@@ -52,9 +54,10 @@ export async function POST(req: Request) {
   const body = await req.json().catch(() => null);
   if (!body) return NextResponse.json({ error: "Invalid request" }, { status: 400 });
 
-  const { name, email, about, why_join, membership_interest } = body as {
+  const { name, email, telegram, about, why_join, membership_interest } = body as {
     name?: string;
     email?: string;
+    telegram?: string;
     about?: string;
     why_join?: string;
     membership_interest?: MembershipInterest;
@@ -68,6 +71,9 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Invalid email address" }, { status: 400 });
   }
 
+  // Normalize telegram: strip leading @s, treat empty as null
+  const telegramHandle = telegram?.trim().replace(/^@+/, "") || null;
+
   const supabase = createServiceClient();
 
   // Upsert application by email (allows re-submission to update details)
@@ -77,6 +83,7 @@ export async function POST(req: Request) {
       {
         email: email.trim().toLowerCase(),
         name: name.trim(),
+        telegram: telegramHandle,
         about: about?.trim() || null,
         why_join: why_join?.trim() || null,
         membership_interest: membership_interest ?? "daypass_5pack",
@@ -95,6 +102,7 @@ export async function POST(req: Request) {
   notifyTelegram({
     name: name.trim(),
     email: email.trim().toLowerCase(),
+    telegram: telegramHandle,
     about: about?.trim() || null,
     why_join: why_join?.trim() || null,
     membership_interest: membership_interest ?? "daypass_5pack",

--- a/apps/web/src/app/api/portal/application/route.ts
+++ b/apps/web/src/app/api/portal/application/route.ts
@@ -24,8 +24,9 @@ export async function POST(req: Request) {
   const body = await req.json().catch(() => null);
   if (!body) return NextResponse.json({ error: "Invalid request" }, { status: 400 });
 
-  const { name, about, why_join, membership_interest } = body as {
+  const { name, telegram, about, why_join, membership_interest } = body as {
     name?: string;
+    telegram?: string;
     about?: string;
     why_join?: string;
     membership_interest?: MembershipInterest;
@@ -35,6 +36,8 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Name is required" }, { status: 400 });
   }
 
+  const telegramHandle = telegram?.trim().replace(/^@+/, "") || null;
+
   // Upsert by supabase_user_id — authenticated user updating their own application
   const { data, error } = await supabase
     .from("applications")
@@ -43,6 +46,7 @@ export async function POST(req: Request) {
         supabase_user_id: user.id,
         email: user.email!,
         name: name.trim(),
+        telegram: telegramHandle,
         about: about?.trim() || null,
         why_join: why_join?.trim() || null,
         membership_interest: membership_interest ?? "daypass_5pack",

--- a/apps/web/src/app/apply/ApplyForm.tsx
+++ b/apps/web/src/app/apply/ApplyForm.tsx
@@ -28,6 +28,7 @@ export default function ApplyForm({ authenticatedEmail }: Props) {
   const [form, setForm] = useState({
     name: "",
     email: authenticatedEmail ?? "",
+    telegram: "",
     about: "",
     why_join: "",
     membership_interest: "daypass_5pack" as "daypass_5pack" | "daypass_single" | "hot_desk" | "reserved_desk",
@@ -55,6 +56,7 @@ export default function ApplyForm({ authenticatedEmail }: Props) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             name: form.name,
+            telegram: form.telegram,
             about: form.about,
             why_join: form.why_join,
             membership_interest: form.membership_interest,
@@ -152,6 +154,20 @@ export default function ApplyForm({ authenticatedEmail }: Props) {
               </div>
 
               <div className="space-y-2">
+                <Label htmlFor="telegram">Telegram username (optional)</Label>
+                <Input
+                  id="telegram"
+                  value={form.telegram}
+                  onChange={set("telegram")}
+                  placeholder="@yourhandle"
+                  className="glass-input"
+                />
+                <p className="text-xs text-muted">
+                  We use Telegram for member coordination and access codes. Adding your handle helps us reach you faster.
+                </p>
+              </div>
+
+              <div className="space-y-2">
                 <Label htmlFor="membership_interest">What level of access are you interested in?</Label>
                 <select
                   id="membership_interest"
@@ -212,6 +228,24 @@ export default function ApplyForm({ authenticatedEmail }: Props) {
                 </p>
               )}
             </form>
+          </CardContent>
+        </Card>
+
+        <Card className="glass-panel">
+          <CardContent className="p-6 text-sm text-muted text-center">
+            <p className="text-foreground font-medium mb-1">Need support with anything?</p>
+            <p>
+              Reach out to <span className="text-foreground">Aaron Gabriel</span>, our member coordinator.
+              Email{" "}
+              <a href="mailto:ag@unforced.org" className="underline hover:text-sage transition-colors">
+                ag@unforced.org
+              </a>{" "}
+              or message{" "}
+              <a href="https://t.me/unforcedAG" target="_blank" rel="noopener noreferrer" className="underline hover:text-sage transition-colors">
+                @unforcedAG
+              </a>{" "}
+              on Telegram.
+            </p>
           </CardContent>
         </Card>
       </div>

--- a/supabase/migrations/017_application_telegram.sql
+++ b/supabase/migrations/017_application_telegram.sql
@@ -1,0 +1,4 @@
+-- Migration 017: Add optional telegram username to applications.
+-- Lets applicants share their Telegram handle so the member coordinator
+-- can reach out via Telegram in addition to email.
+ALTER TABLE applications ADD COLUMN telegram TEXT;


### PR DESCRIPTION
Two small additions to the membership application:

- Optional Telegram handle field (strips leading @, empty → null)
- Persisted on applications + included in the admin Telegram notification
- Both /api/apply (public) and /api/portal/application (authenticated) endpoints accept it
- Migration: `017_application_telegram.sql` adds the column
- New "Need support?" card below the form pointing to Aaron Gabriel (ag@unforced.org or @unforcedAG)

Build passes.