### PR TITLE
feat: add /health endpoint to bot for Coolify migration

### DIFF
--- a/apps/bot/Dockerfile
+++ b/apps/bot/Dockerfile
@@ -42,4 +42,5 @@ COPY --from=builder /app/packages/shared/dist ./node_modules/@regenhub/shared/di
 COPY --from=builder /app/packages/shared/package.json ./node_modules/@regenhub/shared/package.json
 
 USER botuser
+EXPOSE 3000
 CMD ["node", "dist/index.js"]

--- a/apps/bot/src/health.ts
+++ b/apps/bot/src/health.ts
@@ -1,0 +1,19 @@
+import { createServer } from "node:http";
+
+const PORT = Number(process.env.HEALTH_PORT ?? 3000);
+
+export function startHealthServer() {
+  const server = createServer((req, res) => {
+    if (req.url === "/health" || req.url === "/") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, ts: new Date().toISOString() }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  server.listen(PORT, () => {
+    console.log(`[Health] Listening on :${PORT}`);
+  });
+  return server;
+}

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -1,7 +1,9 @@
 
 import { startBot } from "./bot.js";
 import { startScheduler } from "./scheduler.js";
+import { startHealthServer } from "./health.js";
 
 console.log("[RegenHub Bot] Starting...");
 startBot();
 startScheduler();
+startHealthServer();


### PR DESCRIPTION
## Summary
First step toward migrating the Telegram bot off bare-metal `docker run` and into Coolify-managed deployment (issue #38).

The bot uses Telegram long-polling — no HTTP server. Coolify's "web app" abstraction wires Traefik HTTPS routes to port 3000 and considers the service unhealthy if nothing listens. This adds a tiny built-in `http` server on port 3000 that responds 200 to `/health` and `/`, so Coolify can manage it like any other app.

## Changes
- `apps/bot/src/health.ts` — new file, ~17 LOC, no new deps (uses Node's built-in `http`)
- `apps/bot/src/index.ts` — call `startHealthServer()` alongside `startBot()` and `startScheduler()`
- `apps/bot/Dockerfile` — add `EXPOSE 3000`

Port is `HEALTH_PORT` env, defaults to 3000.

## Test plan
- [x] `pnpm --filter bot build` succeeds
- [ ] Once merged: rebuild bare-metal bot, confirm `/health` responds and Telegram polling still works
- [ ] After validation: configure Coolify env vars + trigger deploy on a test bot token (BotFather → throwaway bot) before swapping production token

## Why no `--port` runtime config / extra deps
Built-in `http` is fine for a 200-OK heartbeat. If we later want richer health (Telegram poll status, Supabase reachability) we can swap for fastify/express then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)