### PR TITLE
fix(ci): build @regenhub/shared before web/bot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build shared package
+        run: pnpm --filter @regenhub/shared build
+
       - name: Lint
         run: pnpm --filter web lint
 


### PR DESCRIPTION
## Summary
Adds the missing `pnpm --filter @regenhub/shared build` step to the CI workflow. Without it, `pnpm --filter web build` (which is `next build` and triggers `tsc` resolution) fails with `Module not found: Can't resolve '@regenhub/shared'` because the workspace symlink resolves to a package whose `dist/` doesn't exist yet.

The Dockerfile already builds `packages/shared` first; CI now matches.

## Why this matters
CI has been red on `main` since #34 (~10 days). The Dockerfile path is correct, so production deploys never broke — but PR builds have been failing silently and PRs (#35, #36, #37, #39) merged with no CI signal. This restores the safety net.

## Test plan
- [x] Local: `pnpm --filter @regenhub/shared build && pnpm --filter web build` succeeds
- [ ] Once this PR merges, verify the next push to a feature branch produces a green CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)