### PR TITLE
fix: atomic PIN slot allocation (#42)

### DIFF
--- a/apps/web/src/app/api/admin/members/route.ts
+++ b/apps/web/src/app/api/admin/members/route.ts
@@ -1,19 +1,9 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { requireAdmin } from "@/lib/admin";
+import { allocateSlotWithRetry } from "@/lib/slotAllocation";
+import type { Member } from "@/lib/supabase/types";
 import { setUserCode, generateRandomCode, MEMBER_SLOT_MIN, MEMBER_SLOT_MAX } from "@regenhub/shared";
-
-async function nextFreeSlot(supabase: Awaited<ReturnType<typeof createClient>>): Promise<number | null> {
-  const { data } = await supabase
-    .from("members")
-    .select("pin_code_slot")
-    .not("pin_code_slot", "is", null);
-  const used = new Set((data ?? []).map((r) => r.pin_code_slot as number));
-  for (let s = MEMBER_SLOT_MIN; s <= MEMBER_SLOT_MAX; s++) {
-    if (!used.has(s)) return s;
-  }
-  return null;
-}
 
 export async function POST(request: Request) {
   if (!await requireAdmin()) {
@@ -29,49 +19,72 @@ export async function POST(request: Request) {
   }
 
   const isDayPass = member_type === "day_pass";
+  const assignedPin = isDayPass ? null : (pin_code || generateRandomCode());
 
-  let slot: number | null = null;
-  let assignedPin: string | null = null;
+  const baseInsert = {
+    name,
+    email: email || null,
+    member_type,
+    is_coop_member: is_coop_member ?? false,
+    is_admin: is_admin ?? false,
+    day_passes_balance: Math.max(0, parseInt(initial_day_passes) || 0),
+    telegram_username: telegram_username || null,
+    pin_code: assignedPin,
+    supabase_user_id: supabase_user_id || null,
+    disabled: false,
+  };
 
-  if (!isDayPass) {
-    slot = await nextFreeSlot(supabase);
-    if (slot === null) {
-      return NextResponse.json({ error: "No free PIN slots available (all 100 member slots in use)" }, { status: 409 });
+  // Day-pass members don't get a PIN slot — simple INSERT.
+  if (isDayPass) {
+    const { data, error } = await supabase
+      .from("members")
+      .insert({ ...baseInsert, pin_code_slot: null })
+      .select()
+      .single();
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ member: data }, { status: 201 });
+  }
+
+  // Permanent members: atomic slot claim with retry on collision.
+  const allocation = await allocateSlotWithRetry<Member>({
+    min: MEMBER_SLOT_MIN,
+    max: MEMBER_SLOT_MAX,
+    getUsedSlots: async () => {
+      const { data } = await supabase
+        .from("members")
+        .select("pin_code_slot")
+        .not("pin_code_slot", "is", null);
+      return new Set((data ?? []).map((r) => r.pin_code_slot as number));
+    },
+    tryInsert: (slot) =>
+      supabase
+        .from("members")
+        .insert({ ...baseInsert, pin_code_slot: slot })
+        .select()
+        .single(),
+  });
+
+  if (!allocation.ok) {
+    if (allocation.exhausted) {
+      return NextResponse.json(
+        { error: "No free PIN slots available (all 100 member slots in use)" },
+        { status: 409 }
+      );
     }
-    assignedPin = pin_code || generateRandomCode();
+    return NextResponse.json({ error: allocation.error }, { status: 500 });
   }
 
-  const { data, error } = await supabase
-    .from("members")
-    .insert({
-      name,
-      email: email || null,
-      member_type,
-      is_coop_member: is_coop_member ?? false,
-      is_admin: is_admin ?? false,
-      day_passes_balance: Math.max(0, parseInt(initial_day_passes) || 0),
-      telegram_username: telegram_username || null,
-      pin_code_slot: slot,
-      pin_code: assignedPin,
-      supabase_user_id: supabase_user_id || null,
-      disabled: false,
-    })
-    .select()
-    .single();
+  const member = allocation.data;
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-
-  // Sync PIN to lock immediately (only for non-day_pass members)
-  if (!isDayPass && data.pin_code_slot && data.pin_code) {
+  // Sync PIN to lock immediately. Non-fatal: admin can run Lock Sync to retry.
+  if (member.pin_code_slot && member.pin_code) {
     try {
-      await setUserCode(data.pin_code_slot, data.pin_code);
+      await setUserCode(member.pin_code_slot, member.pin_code);
     } catch (err) {
-      console.error(`[LockSync] Failed to set code for new member ${data.name}:`, err);
-      // Non-fatal: admin can run Lock Sync to retry
+      console.error(`[LockSync] Failed to set code for new member ${member.name}:`, err);
     }
   }
 
-  return NextResponse.json({ member: data }, { status: 201 });
+  return NextResponse.json({ member }, { status: 201 });
 }

--- a/apps/web/src/app/api/freeday/activate/route.ts
+++ b/apps/web/src/app/api/freeday/activate/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { createServiceClient } from "@/lib/supabase/admin";
+import { allocateSlotWithRetry } from "@/lib/slotAllocation";
 import {
   setUserCode,
   formatLockStatus,
@@ -49,22 +50,6 @@ function calculateFreeDayExpiration(): Date {
     return new Date(exp.getTime() + 24 * 60 * 60 * 1000);
   }
   return exp;
-}
-
-/** Find the next available day code slot (101-200) */
-async function findAvailableSlot(
-  supabase: ReturnType<typeof createServiceClient>
-): Promise<number | null> {
-  const { data: usedSlots } = await supabase
-    .from("day_codes")
-    .select("pin_slot")
-    .eq("is_active", true);
-
-  const used = new Set(usedSlots?.map((r) => r.pin_slot) ?? []);
-  for (let slot = DAY_CODE_SLOT_MIN; slot <= DAY_CODE_SLOT_MAX; slot++) {
-    if (!used.has(slot)) return slot;
-  }
-  return null;
 }
 
 /** Post activation notification to Telegram */
@@ -182,55 +167,66 @@ export async function POST() {
     );
   }
 
-  // Find available slot
-  const slot = await findAvailableSlot(admin);
-  if (!slot) {
-    return NextResponse.json(
-      {
-        error:
-          "All temporary door code slots are in use right now. Please try again in a bit.",
-      },
-      { status: 503 }
-    );
-  }
-
   const code = generateRandomCode();
   const expiresAt = calculateFreeDayExpiration();
+
+  // Atomic slot claim: INSERT-with-retry against the partial unique index.
+  // If a concurrent request claims the chosen slot first, retry with the
+  // next free one.
+  const allocation = await allocateSlotWithRetry<{ id: number }>({
+    min: DAY_CODE_SLOT_MIN,
+    max: DAY_CODE_SLOT_MAX,
+    getUsedSlots: async () => {
+      const { data } = await admin
+        .from("day_codes")
+        .select("pin_slot")
+        .eq("is_active", true);
+      return new Set(data?.map((r) => r.pin_slot) ?? []);
+    },
+    tryInsert: (slot) =>
+      admin
+        .from("day_codes")
+        .insert({
+          day_pass_id: null,
+          member_id: null,
+          label: `Free Day: ${claim.name}`,
+          code,
+          pin_slot: slot,
+          issued_at: new Date().toISOString(),
+          expires_at: expiresAt.toISOString(),
+          is_active: true,
+        })
+        .select("id")
+        .single(),
+  });
+
+  if (!allocation.ok) {
+    if (!allocation.exhausted) console.error("[FreeDay] DB insert error:", allocation.error);
+    return NextResponse.json(
+      {
+        error: allocation.exhausted
+          ? "All temporary door code slots are in use right now. Please try again in a bit."
+          : "Code could not be saved",
+      },
+      { status: allocation.exhausted ? 503 : 500 }
+    );
+  }
 
   // Set code on the physical locks
   let lockStatus: string;
   try {
-    const lockResults = await setUserCode(slot, code);
+    const lockResults = await setUserCode(allocation.slot, code);
     lockStatus = formatLockStatus(lockResults);
   } catch (err) {
     console.error("[FreeDay] Lock error:", err);
+    // Roll back the day_code so its slot frees up for another attempt.
+    await admin
+      .from("day_codes")
+      .update({ is_active: false, revoked_at: new Date().toISOString() })
+      .eq("id", allocation.data.id);
     return NextResponse.json(
       { error: LOCK_FAILURE_MSG },
       { status: 502 }
-    );
-  }
-
-  // Insert day_code record
-  const { data: dayCode, error: insertError } = await admin
-    .from("day_codes")
-    .insert({
-      day_pass_id: null,
-      member_id: null,
-      label: `Free Day: ${claim.name}`,
-      code,
-      pin_slot: slot,
-      issued_at: new Date().toISOString(),
-      expires_at: expiresAt.toISOString(),
-      is_active: true,
-    })
-    .select("id")
-    .single();
-
-  if (insertError || !dayCode) {
-    console.error("[FreeDay] DB insert error:", insertError);
-    return NextResponse.json(
-      { error: "Code set on lock but database save failed" },
-      { status: 500 }
     );
   }
 
@@ -239,7 +235,7 @@ export async function POST() {
     .from("free_day_claims")
     .update({
       status: "activated",
-      day_code_id: dayCode.id,
+      day_code_id: allocation.data.id,
       activated_at: new Date().toISOString(),
     })
     .eq("id", claim.id);

--- a/apps/web/src/app/api/portal/request-daypass/route.ts
+++ b/apps/web/src/app/api/portal/request-daypass/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { allocateSlotWithRetry } from "@/lib/slotAllocation";
 import { setUserCode, formatLockStatus, generateRandomCode, DAY_CODE_SLOT_MIN, DAY_CODE_SLOT_MAX, LOCK_FAILURE_MSG } from "@regenhub/shared";
 
 const TIMEZONE = "America/Denver";
@@ -38,19 +39,6 @@ function calculateDayPassExpiry(): string {
     exp.setTime(exp.getTime() + 24 * 60 * 60 * 1000);
   }
   return exp.toISOString();
-}
-
-async function findAvailableSlot(supabase: Awaited<ReturnType<typeof createClient>>): Promise<number | null> {
-  const { data: usedSlots } = await supabase
-    .from("day_codes")
-    .select("pin_slot")
-    .eq("is_active", true);
-
-  const used = new Set(usedSlots?.map((r) => r.pin_slot) ?? []);
-  for (let slot = DAY_CODE_SLOT_MIN; slot <= DAY_CODE_SLOT_MAX; slot++) {
-    if (!used.has(slot)) return slot;
-  }
-  return null;
 }
 
 export async function POST(request: Request) {
@@ -105,44 +93,60 @@ export async function POST(request: Request) {
     );
   }
 
-  const slot = await findAvailableSlot(supabase);
-  if (!slot) {
-    // Refund — no slot available
-    await supabase.rpc("increment_day_pass_balance", { p_member_id: member.id, p_amount: 1 });
-    return NextResponse.json({ error: "No available door code slots" }, { status: 503 });
-  }
-
   const code = generateRandomCode();
+
+  // Atomic slot claim: INSERT, retry on unique-violation if a concurrent
+  // request beat us to this slot. Combined with migration 018's partial
+  // unique index, this prevents two day-codes from sharing a slot.
+  const allocation = await allocateSlotWithRetry<{ id: number; pin_slot: number }>({
+    min: DAY_CODE_SLOT_MIN,
+    max: DAY_CODE_SLOT_MAX,
+    getUsedSlots: async () => {
+      const { data } = await supabase
+        .from("day_codes")
+        .select("pin_slot")
+        .eq("is_active", true);
+      return new Set(data?.map((r) => r.pin_slot) ?? []);
+    },
+    tryInsert: (slot) =>
+      supabase
+        .from("day_codes")
+        .insert({
+          member_id: member.id,
+          label: label ?? null,
+          code,
+          pin_slot: slot,
+          issued_at: new Date().toISOString(),
+          expires_at: expiresAt,
+          is_active: true,
+        })
+        .select("id, pin_slot")
+        .single(),
+  });
+
+  if (!allocation.ok) {
+    // Refund — couldn't allocate a slot
+    await supabase.rpc("increment_day_pass_balance", { p_member_id: member.id, p_amount: 1 });
+    const status = allocation.exhausted ? 503 : 500;
+    const msg = allocation.exhausted ? "No available door code slots" : "Could not save day code";
+    if (!allocation.exhausted) console.error("[DB] Day code insert failed:", allocation.error);
+    return NextResponse.json({ error: msg }, { status });
+  }
 
   let lockStatus: string;
   try {
-    const lockResults = await setUserCode(slot, code);
+    const lockResults = await setUserCode(allocation.slot, code);
     lockStatus = formatLockStatus(lockResults);
   } catch (err) {
     console.error("[Lock] Failed to set day code:", err);
-    // Refund — couldn't program lock
+    // Roll back: deactivate the just-inserted day_code so its slot frees up,
+    // then refund the balance.
+    await supabase
+      .from("day_codes")
+      .update({ is_active: false, revoked_at: new Date().toISOString() })
+      .eq("id", allocation.data.id);
     await supabase.rpc("increment_day_pass_balance", { p_member_id: member.id, p_amount: 1 });
-    return NextResponse.json(
-      { error: LOCK_FAILURE_MSG },
-      { status: 502 }
-    );
-  }
-
-  const { error: insertError } = await supabase
-    .from("day_codes")
-    .insert({
-      member_id: member.id,
-      label: label ?? null,
-      code,
-      pin_slot: slot,
-      issued_at: new Date().toISOString(),
-      expires_at: expiresAt,
-      is_active: true,
-    });
-
-  if (insertError) {
-    console.error("[DB] Failed to insert day code:", insertError);
-    return NextResponse.json({ error: "Code set but DB save failed" }, { status: 500 });
+    return NextResponse.json({ error: LOCK_FAILURE_MSG }, { status: 502 });
   }
 
   return NextResponse.json({

--- a/apps/web/src/lib/slotAllocation.ts
+++ b/apps/web/src/lib/slotAllocation.ts
@@ -1,0 +1,70 @@
+/**
+ * Atomic PIN-slot allocation via INSERT-with-retry.
+ *
+ * The naive find-then-insert pattern races: two concurrent requests can both
+ * read the same "available" slot and both INSERT into it. With a partial
+ * unique index on the slot column (see migration 018), one INSERT wins and
+ * the other gets a Postgres `23505` unique-violation. This helper catches
+ * that, picks the next free slot, and retries.
+ *
+ * Without the migration, the `23505` path is unreachable and behavior
+ * silently degrades to current find-then-insert (still vulnerable). Apply
+ * the migration to make it airtight.
+ */
+
+const PG_UNIQUE_VIOLATION = "23505";
+
+type AllocateResult<T> =
+  | { ok: true; data: T; slot: number }
+  | { ok: false; error: string; exhausted?: boolean };
+
+interface AllocateOpts<T> {
+  min: number;
+  max: number;
+  /** Returns the set of slot numbers currently in use. Re-called on each retry. */
+  getUsedSlots: () => Promise<Set<number>>;
+  /**
+   * Attempts the INSERT with the chosen slot. Must surface a Postgres-style
+   * `{ code }` field on the error so the helper can detect collisions.
+   * `PromiseLike` rather than `Promise` so Supabase's PostgrestBuilder
+   * (thenable but not a real Promise) works without an extra `await`.
+   */
+  tryInsert: (slot: number) => PromiseLike<{
+    data: T | null;
+    error: { code?: string; message: string } | null;
+  }>;
+  maxRetries?: number;
+}
+
+export async function allocateSlotWithRetry<T extends object>(opts: AllocateOpts<T>): Promise<AllocateResult<T>> {
+  const maxRetries = opts.maxRetries ?? 5;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    const used = await opts.getUsedSlots();
+
+    let chosen: number | null = null;
+    for (let s = opts.min; s <= opts.max; s++) {
+      if (!used.has(s)) {
+        chosen = s;
+        break;
+      }
+    }
+    if (chosen === null) {
+      return { ok: false, error: "All slots in use", exhausted: true };
+    }
+
+    const result = await opts.tryInsert(chosen);
+    if (!result.error && result.data) {
+      return { ok: true, data: result.data, slot: chosen };
+    }
+
+    if (result.error?.code === PG_UNIQUE_VIOLATION) {
+      // Another request claimed this slot first — retry with a fresh used-set.
+      continue;
+    }
+
+    return { ok: false, error: result.error?.message ?? "Insert failed" };
+  }
+
+  return { ok: false, error: "Could not allocate slot after multiple retries" };
+}

--- a/supabase/migrations/018_atomic_slot_allocation.sql
+++ b/supabase/migrations/018_atomic_slot_allocation.sql
@@ -1,0 +1,29 @@
+-- Migration 018: Atomic PIN slot allocation
+--
+-- Adds partial unique indexes so two concurrent requests cannot both claim
+-- the same PIN slot. Combined with INSERT-with-retry in the API routes
+-- (apps/web/src/lib/slotAllocation.ts), this enforces correctness at the
+-- database level even under contention.
+--
+-- Idempotent: safe to re-run.
+--
+-- WARNING: Will fail if existing rows already violate the constraint.
+-- Before applying, check for duplicates:
+--
+--   SELECT pin_slot, COUNT(*) FROM day_codes
+--   WHERE is_active = true GROUP BY pin_slot HAVING COUNT(*) > 1;
+--
+--   SELECT pin_code_slot, COUNT(*) FROM members
+--   WHERE pin_code_slot IS NOT NULL GROUP BY pin_code_slot HAVING COUNT(*) > 1;
+--
+-- If either returns rows, deactivate or fix the duplicates first.
+
+-- One active day code per slot (slots 101-200 per migration 006).
+CREATE UNIQUE INDEX IF NOT EXISTS day_codes_active_slot_unique
+  ON day_codes (pin_slot)
+  WHERE is_active = true;
+
+-- One member per slot (slots 1-100 per migration 006).
+CREATE UNIQUE INDEX IF NOT EXISTS members_pin_code_slot_unique
+  ON members (pin_code_slot)
+  WHERE pin_code_slot IS NOT NULL;


### PR DESCRIPTION
Closes #42.

## Summary

Fixes the find-then-insert race in the three slot-allocating routes by switching to INSERT-with-retry on Postgres unique-violation (`23505`), backed by a partial unique index proposed in migration `018`.

- `apps/web/src/app/api/portal/request-daypass/route.ts`
- `apps/web/src/app/api/freeday/activate/route.ts`
- `apps/web/src/app/api/admin/members/route.ts`

Adds shared helper `apps/web/src/lib/slotAllocation.ts`. Reorders the day-code routes to **claim slot first, then program lock**, with rollback (deactivate the row + refund balance) on total lock failure — that way the slot frees up for the next attempt instead of leaving an orphaned row pointing at an unprogrammed lock.

## Proposed migration (NOT YET APPLIED — needs your review + duplicate check)

`supabase/migrations/018_atomic_slot_allocation.sql`:

```sql
CREATE UNIQUE INDEX IF NOT EXISTS day_codes_active_slot_unique
  ON day_codes (pin_slot)
  WHERE is_active = true;

CREATE UNIQUE INDEX IF NOT EXISTS members_pin_code_slot_unique
  ON members (pin_code_slot)
  WHERE pin_code_slot IS NOT NULL;
```

Before applying, please run these duplicate-checks against prod — the `CREATE INDEX` will fail if either returns rows:

```sql
SELECT pin_slot, COUNT(*) FROM day_codes
WHERE is_active = true GROUP BY pin_slot HAVING COUNT(*) > 1;

SELECT pin_code_slot, COUNT(*) FROM members
WHERE pin_code_slot IS NOT NULL GROUP BY pin_code_slot HAVING COUNT(*) > 1;
```

If duplicates exist, deactivate or fix them first, then apply the migration. The migration uses `IF NOT EXISTS` and is idempotent.

## Behavior without the migration

The application code is forward-compatible: without the partial unique indexes, the `23505` retry path is unreachable and behavior degrades silently to current find-then-insert (still vulnerable to the race, same as today). Applying the migration is what makes the fix airtight.

## Worth a closer look at

- **Lock-rollback semantics in `request-daypass`**: on total lock failure the route now `UPDATE day_codes SET is_active = false, revoked_at = now()` *and* refunds via `increment_day_pass_balance`. Previously the order was lock-first then insert; if the insert failed after the lock was set, the code returned 500 with a code physically programmed but no DB row. The new order avoids that orphan case.
- **Partial-lock-failure path is unchanged**: `setUserCode` still throws only when *all* locks fail. Partial failures return `LockResult[]` and the route proceeds normally with `formatLockStatus` describing which doors didn't accept the code.
- **No tests added.** The repo currently has zero tests; adding a vitest harness is its own task (recommended in the audit). Once a test rig exists, the natural test for this is `Promise.all` over N find-and-insert calls and asserting all N rows ended up with distinct slots.
- **Retry budget = 5.** Plenty of headroom for the current member load (~100 slots, single-digit concurrent activations realistically). If contention ever grows, jitter/backoff would be the next knob.

## Test plan

- [ ] CI green (lint + build)
- [ ] After merging migration: confirm member adds, daypass requests, and freeday activations all succeed end-to-end on the live system
- [ ] Spot-check `day_codes` for a week post-merge to confirm no duplicate-slot rows under `is_active = true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)