### PR TITLE
docs: env.example for web + local-dev README (#44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,18 @@ Member portal and Telegram bot for [RegenHub Boulder](https://regenhub.xyz) — 
 |-----|-------------|
 | `apps/web` | Next.js 15 member portal (sign in, view door code, request day passes) |
 | `apps/bot` | Telegram bot (door codes, day passes, admin tools, HA door control) |
-| `supabase/migrations` | Database schema |
+| `packages/shared` | Shared library — Home Assistant lock control, slot constants |
+| `supabase/migrations` | Database schema (apply in numerical order) |
 
-## Quick Start
+## Local development
+
+### Prerequisites
+
+- Node 22+
+- pnpm 10+
+- (Optional, for live Supabase) the [Supabase CLI](https://supabase.com/docs/guides/cli) — `brew install supabase/tap/supabase`
+
+### Set up
 
 ```bash
 git clone https://github.com/RegenHub-Boulder/regenhub.xyz.git
@@ -18,20 +27,53 @@ cd regenhub.xyz
 pnpm install
 ```
 
-Copy `.env.example` (TODO: add this) and fill in Supabase credentials, then:
+### Configure env
+
+Copy the example env files and fill in values:
 
 ```bash
-pnpm --filter web dev   # http://localhost:3000
-pnpm --filter bot build && node apps/bot/dist/index.js
+cp apps/web/.env.example apps/web/.env.local
+cp apps/bot/.env.example apps/bot/.env
 ```
+
+Each file documents what each variable is for. At minimum you need a Supabase instance (URL + anon key + service-role key) — either:
+
+- **Local Supabase** (recommended): `supabase start` from the repo root spins up a full stack on `http://localhost:54321`. The CLI prints the anon and service-role keys at the end. Apply the migrations with `supabase db reset` (runs every file in `supabase/migrations/` in order).
+- **Live regenhub Supabase**: get the keys from a maintainer. You'll be working against real data — be careful, especially with the service-role key.
+
+The Stripe, Telegram, and Home Assistant blocks in `.env.example` are optional for most flows — leave the placeholder values in place if you're not testing those features locally. Specifically:
+
+- Without Stripe vars set, the webhook route returns 400 — fine if you're not exercising checkout flow.
+- Without `TELEGRAM_*`, the freeday activate route still works, just doesn't post to the group.
+- Without `HA_*`, every lock-programming route fails with a 502. Stub them out to a fake URL/token if you want to bypass without setting up HA.
+
+`apps/web/.env.production` is committed — it holds the public build-time values for the deployed Coolify build. Don't put dev values there.
+
+### Run
+
+```bash
+# Web — http://localhost:3000
+pnpm --filter web dev
+
+# Bot — long-polls Telegram, expects valid TELEGRAM_BOT_TOKEN
+pnpm --filter bot build && node --env-file=apps/bot/.env apps/bot/dist/index.js
+
+# Type-check everything (CI-equivalent)
+pnpm --filter @regenhub/shared build
+pnpm --filter web lint
+pnpm --filter web build
+pnpm --filter bot build
+```
+
+The bot uses Telegram long-polling — only one process can poll a given bot token at a time. Use a separate dev bot (create one with @BotFather) so you don't fight the production poller.
 
 ## Deployment
 
 Self-hosted on RegenHub's local compute cluster via Coolify + Cloudflare Tunnels.
 
-**See [DEPLOYMENT.md](./DEPLOYMENT.md) for the full guide** — covers Coolify API, Traefik routing workarounds, Supabase setup, tunnel management, and the DNS flip checklist.
+**See [DEPLOYMENT.md](./DEPLOYMENT.md) for the full guide** — covers Coolify API, Traefik routing workarounds, Supabase setup, tunnel management, backup + recovery runbook, and the DNS flip checklist.
 
-Live at: `https://site.regenhub.build`
+Live at: `https://regenhub.xyz`
 
 ## Tech Stack
 

--- a/apps/bot/.env.example
+++ b/apps/bot/.env.example
@@ -1,15 +1,48 @@
-# Supabase service role (bypasses RLS — keep secret)
+# =============================================================================
+# apps/bot — local development env
+# =============================================================================
+# Copy to `apps/bot/.env` and fill in. The bot reads from process.env at
+# startup; the runner you choose (node, ts-node, pnpm script, docker run)
+# decides how the file is loaded — `--env-file=.env` works with Node 20.6+.
+#
+# In production these are stored in Coolify's DB for the bot app
+# (UUID t84sosw40088kokwco80kksw) — see DEPLOYMENT.md "Telegram Bot".
+# =============================================================================
+
+
+# -- Supabase (server-side, bypasses RLS) -------------------------------------
+# Service-role key — keep secret. Bot uses this to read members, manage
+# day_codes, and write access logs.
+
 SUPABASE_URL=http://localhost:54321
-SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+SUPABASE_SERVICE_ROLE_KEY=<your-supabase-service-role-key>
 
-# Telegram
-TELEGRAM_BOT_TOKEN=your-bot-token
 
-# Home Assistant
-HA_URL=http://homeassistant.local:8123/api
-HA_TOKEN=your-long-lived-ha-token
+# -- Telegram -----------------------------------------------------------------
+# Get from @BotFather → /mybots → your bot → API Token. Use a separate
+# bot for local dev so you don't fight the production poll loop (only one
+# poller per token at a time).
 
-# Door code slot configuration
-DAY_PASS_SLOT_MIN=125
-DAY_PASS_SLOT_MAX=249
+TELEGRAM_BOT_TOKEN=<bot-token-from-botfather>
+
+
+# -- Home Assistant -----------------------------------------------------------
+# See apps/web/.env.example for the same values — bot and web both program
+# the same physical locks via @regenhub/shared. Use a direct IP.
+
+HA_URL=http://192.168.1.141:8123/api
+HA_TOKEN=<long-lived-home-assistant-access-token>
+HA_LOCK_ENTITIES=lock.front_door_lock,lock.back_door_lock
+
+
+# -- Misc (all optional, sensible defaults) -----------------------------------
+# Timezone for day-code expiry math + cron schedules. Default America/Denver.
 TIMEZONE=America/Denver
+
+# Port for the /health endpoint that Coolify hits to consider the container
+# alive. Default 3000. Set to override if 3000 is busy locally.
+# HEALTH_PORT=3000
+
+# Base URL for portal links the bot includes in messages
+# (`/portal/my-code`, etc). Default https://regenhub.xyz.
+# SITE_URL=http://localhost:3000

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,85 @@
+# =============================================================================
+# apps/web — local development env
+# =============================================================================
+# Copy to `apps/web/.env.local` and fill in. Next.js loads `.env.local` for
+# `pnpm --filter web dev` automatically; do not commit `.env.local`.
+#
+# `apps/web/.env.production` (committed) holds the build-time public values
+# used during the Coolify Docker build — do not copy production values here.
+# =============================================================================
+
+
+# -- Supabase (build-time, public) --------------------------------------------
+# Both are baked into the client bundle. Anon key is public by design — RLS
+# enforces access control. For local dev, point at a local Supabase
+# (`supabase start` → http://localhost:54321) or at the live instance.
+
+NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-supabase-anon-key>
+
+# Used for auth redirect URLs (magic links, etc). Must match the origin the
+# browser is hitting — http://localhost:3000 for local dev.
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
+
+# -- Supabase (runtime, server-only) ------------------------------------------
+# Service-role key bypasses RLS. Server-side only — never expose to the
+# browser. Used by admin API routes, the Stripe webhook, and the freeday
+# activate route.
+
+SUPABASE_SERVICE_ROLE_KEY=<your-supabase-service-role-key>
+
+# Optional: alternate Supabase URL for server-side calls. In production this
+# is unused (the web container can reach the public Kong via the Cloudflare
+# tunnel hostname). Leave blank locally unless you have a separate
+# server-side endpoint.
+# SUPABASE_INTERNAL_URL=
+
+
+# -- Home Assistant (runtime) -------------------------------------------------
+# Used to program Z-Wave door lock PIN slots. Required for any flow that
+# touches the locks: /portal/regenerate-code, /api/portal/request-daypass,
+# /api/freeday/activate, admin add-member.
+#
+# Use a direct IP — `homeassistant.lan` does not resolve from inside Docker
+# bridge networks, and mDNS `homeassistant.local` is unreliable.
+# `HA_LOCK_ENTITIES` is a comma-separated list of Z-Wave lock entity IDs.
+
+HA_URL=http://192.168.1.141:8123/api
+HA_TOKEN=<long-lived-home-assistant-access-token>
+HA_LOCK_ENTITIES=lock.front_door_lock,lock.back_door_lock
+
+
+# -- Stripe (runtime) ---------------------------------------------------------
+# Used by /api/webhooks/stripe to credit day passes after checkout.
+# Webhook secret is the `whsec_...` value from `stripe listen` (local) or
+# the dashboard webhook config (prod). Price IDs map products → pass counts.
+
+STRIPE_SECRET_KEY=sk_test_<your-stripe-secret-key>
+STRIPE_WEBHOOK_SECRET=whsec_<your-stripe-webhook-secret>
+STRIPE_PRICE_DAYPASS=price_<single-day-pass-price-id>
+STRIPE_PRICE_FIVEPACK=price_<five-pack-price-id>
+
+
+# -- Stripe (build-time, public) ----------------------------------------------
+# Payment Link URLs surfaced in the portal. These are public links — safe to
+# commit if you want default values, but kept here so dev can use test-mode
+# links without affecting prod.
+
+NEXT_PUBLIC_STRIPE_DAYPASS_LINK=https://buy.stripe.com/test_<single-day-link>
+NEXT_PUBLIC_STRIPE_FIVEPACK_LINK=https://buy.stripe.com/test_<five-pack-link>
+
+
+# -- Telegram (runtime, optional) ---------------------------------------------
+# If set, /api/freeday/activate posts an "X just got their free day code"
+# notification to the Telegram group. Leave blank to disable notifications
+# locally; the activate route degrades gracefully.
+
+TELEGRAM_BOT_TOKEN=<bot-token-from-botfather>
+TELEGRAM_GROUP_CHAT_ID=<chat-id-of-your-test-group>
+
+
+# -- Misc ---------------------------------------------------------------------
+# Timezone used to compute day-code expiry (6 PM Mountain Time, weekday
+# guards, etc). Default is America/Denver if unset.
+TIMEZONE=America/Denver

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.production
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
Closes #44.

## Summary

- **`apps/web/.env.example` (new)** — full inventory of every `process.env.*` the web app reads (grepped from `apps/web/src` + `packages/shared/src`), grouped into Supabase / HA / Stripe / Telegram / Misc sections with one-line comments and placeholder values like `<your-supabase-anon-key>`. Documents which vars are build-time vs runtime.
- **`apps/web/.gitignore`** — adds `!.env.example` exception so the new file is tracked. Existing `!.env.production` exception preserved.
- **`apps/bot/.env.example` (updated)** — adds the previously-missing `HA_LOCK_ENTITIES`, comment-aligns with the web file, and clarifies which vars are required vs optional-with-defaults (`HEALTH_PORT`, `SITE_URL`, `TIMEZONE` all have sensible fallbacks in code, so they're commented-out by default).
- **`README.md`** — replaces the "TODO: add `.env.example`" Quick Start stub with a real **Local development** section: prerequisites (Node 22+, pnpm 10+, optional Supabase CLI), env-copy steps, two paths for Supabase (local via `supabase start` + `supabase db reset` or live keys from a maintainer), graceful-degradation notes for the optional service blocks, and run commands including the Telegram-poll caveat (only one poller per token).

## Worth a closer look at

- **Env var inventory was grepped, not assumed.** I ran `grep -rhoE "process\.env\.[A-Z_][A-Z0-9_]+"` over `apps/web/src`, `apps/bot/src`, and `packages/shared/src` and used the union. Every var that ends up read at runtime should be in one of the two `.env.example` files. If there's something the build pulls in via `next.config.*` that I missed, it'll show up at first dev-server start.
- **No real secrets committed.** Placeholders use `<bracketed-descriptor>` form. `apps/web/.env.production` (already committed) is unchanged — that file holds the public anon key for the production Coolify build, which is intentional.
- **Live-Supabase path is mentioned but not encouraged.** README says "you'll be working against real data — be careful." Anyone with the service-role key can mutate prod. Local Supabase is the recommended path for normal dev.
- **Bot dev caveat is real.** Telegram long-polls a single connection per token; running a local bot against the prod token would steal the poller from prod. README mentions creating a separate dev bot via @BotFather.

## Test plan

- [ ] Fresh-clone smoke: `git clone … && pnpm install && cp apps/web/.env.example apps/web/.env.local && pnpm --filter web dev` should bring up a server (will 500 on Supabase calls until a real URL is filled in, but the routing/build path should work)
- [ ] `pnpm --filter web build` still passes with the unchanged `.env.production` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)