### PR TITLE
feat: simplify interest form to email-only

### DIFF
--- a/apps/web/src/app/interest/page.tsx
+++ b/apps/web/src/app/interest/page.tsx
@@ -22,8 +22,8 @@ export default function InterestPage() {
             Stay in Touch
           </h1>
           <p className="text-muted max-w-md mx-auto">
-            Not ready to commit but want to stay in the loop? Drop your email and
-            we&apos;ll reach out about whatever interests you most.
+            Drop your email and we&apos;ll keep you in the loop on what&apos;s
+            happening at RegenHub.
           </p>
         </div>
 

--- a/apps/web/src/components/landing/HeroInterestForm.tsx
+++ b/apps/web/src/components/landing/HeroInterestForm.tsx
@@ -5,10 +5,8 @@ import { useRouter } from "next/navigation";
 import { Loader2, Mail } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Card, CardContent } from "@/components/ui/card";
 
-export default function InterestForm() {
+export default function HeroInterestForm() {
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(false);
@@ -38,34 +36,24 @@ export default function InterestForm() {
   }
 
   return (
-    <Card className="glass-panel">
-      <CardContent className="p-8">
-        <form onSubmit={handleSubmit} className="space-y-6">
-          <div className="space-y-2">
-            <Label htmlFor="email">Email</Label>
-            <Input
-              id="email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              placeholder="you@example.com"
-              className="glass-input"
-            />
-          </div>
-
-          {error && <p className="text-sm text-red-400">{error}</p>}
-
-          <Button
-            type="submit"
-            disabled={loading}
-            className="btn-primary-glass w-full py-3 text-base font-semibold gap-2"
-          >
-            {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Mail className="w-4 h-4" />}
-            {loading ? "Saving…" : "Stay in Touch"}
-          </Button>
-        </form>
-      </CardContent>
-    </Card>
+    <form onSubmit={handleSubmit} className="mt-6 max-w-md mx-auto">
+      <p className="text-xs text-muted mb-2">Or just stay in the loop:</p>
+      <div className="flex flex-col sm:flex-row gap-2">
+        <Input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          placeholder="you@example.com"
+          aria-label="Email"
+          className="glass-input flex-1"
+        />
+        <Button type="submit" disabled={loading} className="btn-glass gap-2 sm:w-auto">
+          {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Mail className="w-4 h-4" />}
+          Stay in Touch
+        </Button>
+      </div>
+      {error && <p className="text-xs text-red-400 mt-2">{error}</p>}
+    </form>
   );
 }

--- a/apps/web/src/components/landing/RegenHubLanding.tsx
+++ b/apps/web/src/components/landing/RegenHubLanding.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { MemberDirectory } from "@/components/landing/MemberDirectory";
 import { ForestMascot } from "@/components/landing/ForestMascot";
+import HeroInterestForm from "@/components/landing/HeroInterestForm";
 import forestBackground from "@/assets/forest-background.jpg";
 import regenHubLogo from "@/assets/regenhub-logo.svg";
 import regenHubText from "@/assets/regenhub-text.svg";
@@ -64,12 +65,7 @@ export default function RegenHubLanding() {
                 </Button>
               </a>
             </div>
-            <p className="mt-6 text-sm text-muted">
-              Not ready yet?{" "}
-              <Link href="/interest" className="text-sage hover:underline">
-                Stay in touch →
-              </Link>
-            </p>
+            <HeroInterestForm />
           </div>
         </div>
       </section>


### PR DESCRIPTION
Follow-up to #51 / PR #52. Per Aaron's request: one input, one button.

## Summary

- **`RegenHubLanding.tsx`** — replaced the subtle "Not ready yet? Stay in touch →" link with `HeroInterestForm`, an inline email input + "Stay in Touch" button rendered just below the existing hero CTAs. Visual treatment stays subtle (the button uses `btn-glass`, not `btn-primary-glass`) so the primary "Try a Free Day" action keeps top-of-hierarchy.
- **`HeroInterestForm.tsx` (new)** — small client component, ~50 lines. Posts to `/api/interest`, redirects to `/interest/success` on success, surfaces errors inline.
- **`/interest/InterestForm.tsx`** — stripped down to email-only. Removed name field, interest checkboxes, and `INTEREST_OPTIONS`/`InterestKey` imports. Same submit flow.
- **`/interest/page.tsx`** — copy tweaked to match ("Drop your email and we'll keep you in the loop…").
- **`POST /api/interest`** — no change. Already accepts empty `interests` array and missing `name`; the server-side whitelist still defends against arbitrary direct posts.
- **Schema** — no migration. The `name` and `interests` columns stay; we just stop populating them from the public form. Existing rows in `/admin/interests` continue to render (the column shows "—" when empty).
- **Footer "Stay in Touch" entry** — kept; still links to `/interest`.

## Worth a closer look at

- **Two near-identical form components** (`HeroInterestForm` vs. standalone `InterestForm`). I kept them separate because the visual treatments differ — hero is inline (no Card wrapper, single row layout), standalone uses Card + vertical layout. Could be unified with a `compact` prop later if it grows; not worth the abstraction at two-call-sites.
- **Server-side whitelist still in place.** Even though the public forms no longer post `interests`, anyone posting directly to `/api/interest` with arbitrary `interests` strings will still be filtered by `INTEREST_OPTIONS`. Defense-in-depth, costs nothing.
- **Existing `name` and `interests` columns in `interests` table.** Forward-compat for V2 if Aaron wants segmentation back later. No data migration needed; new rows just have `name = NULL` and `interests = '{}'`.

## Separate flag — Coolify autodeploy webhook broken

Per team-lead: PR #52 didn't auto-deploy after merge — team-lead had to trigger the deploy manually via the Coolify API. The repo's GitHub webhook to Coolify (`/webhooks/deploy/<secret>`) appears to be misconfigured or pointed at a stale endpoint. Worth checking the webhook settings on the Coolify app (`ew848c4os44sw0wowwk0ksk8`) and the corresponding GitHub webhook to find the mismatch. Not addressed in this PR — surfacing for Aaron's awareness, separate from the form simplification.

## CI

- `pnpm --filter @regenhub/shared build` ✅
- `pnpm --filter web lint` ✅ (1 pre-existing img warning, unrelated)
- `pnpm --filter web build` ✅

## Test plan

- [ ] Hero form: enter an email, click Stay in Touch → redirects to `/interest/success`, row visible in `/admin/interests`
- [ ] Standalone `/interest` form: same flow
- [ ] Footer link still navigates to `/interest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)