### PR TITLE
feat: link interests to members + funnel continuity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,16 @@ DEPLOYMENT.md               # Full infra guide for agents + humans
 - `day_passes` — pool of N-use guest passes per member
 - `day_codes` — temporary door codes (PIN slots 125-249) issued against a pass
 - `access_logs` — every door access event
+- `interests` — public "stay in touch" signups from `/interest`. Linked to `members` via `member_id` (nullable FK). The funnel runs `interests → application → member → auth.users`; whichever events fire first, triggers backfill the linkage so admins can see who came from where.
+
+### Identity linkage
+Three identities can exist for one person: an `interests` row (email-only signup), a `members` row (full profile, may pre-exist via Telegram bot or admin add), and an `auth.users` row (created on first magic-link sign-in). They're stitched together by email via two trigger functions plus per-route fallbacks:
+- `link_member_on_auth` (migration 004 + extended in 020) fires on `auth.users` insert/update; links `members.supabase_user_id` and `interests.member_id` to whichever rows match the email.
+- `link_member_to_auth` (migration 013) fires on `members.email` change; pulls in the auth user if one already exists.
+- `/api/interest` (POST) looks up `members` by email at insert time, so the common case (member exists, then signs up to the interest list) is linked synchronously.
+- `/portal` (server component) auto-links `members.supabase_user_id` if the auth user signs in with an email matching an unlinked member.
+
+The result: regardless of event order, the linkage materializes the moment all three records can be reconciled.
 
 ## Common Tasks
 

--- a/apps/web/src/app/admin/interests/page.tsx
+++ b/apps/web/src/app/admin/interests/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import type { Interest } from "@/lib/supabase/types";
 import { INTEREST_OPTIONS } from "@/lib/supabase/types";
@@ -7,6 +8,8 @@ export const metadata = { title: "Interests — Admin" };
 const INTEREST_LABEL: Record<string, string> = Object.fromEntries(
   INTEREST_OPTIONS.map((o) => [o.value, o.label])
 );
+
+type Filter = "all" | "linked" | "unlinked";
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleString("en-US", {
@@ -19,26 +22,74 @@ function formatDate(iso: string): string {
   });
 }
 
-export default async function InterestsPage() {
+export default async function InterestsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ linked?: string }>;
+}) {
+  const params = await searchParams;
+  const filter: Filter =
+    params.linked === "true" ? "linked" : params.linked === "false" ? "unlinked" : "all";
+
   const supabase = await createClient();
 
-  const { data } = await supabase
+  let query = supabase
     .from("interests")
     .select("*")
     .order("created_at", { ascending: false });
 
+  if (filter === "linked") query = query.not("member_id", "is", null);
+  if (filter === "unlinked") query = query.is("member_id", null);
+
+  const { data } = await query;
   const interests = (data ?? []) as Interest[];
+
+  // Counts for the filter pills (independent of current filter)
+  const { data: counts } = await supabase
+    .from("interests")
+    .select("member_id");
+  const total = counts?.length ?? 0;
+  const linkedCount = counts?.filter((r) => r.member_id !== null).length ?? 0;
+  const unlinkedCount = total - linkedCount;
+
+  const filterLink = (f: Filter) => {
+    if (f === "all") return "/admin/interests";
+    if (f === "linked") return "/admin/interests?linked=true";
+    return "/admin/interests?linked=false";
+  };
 
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-forest">Interest List</h1>
-        <p className="text-muted text-sm mt-1">{interests.length} signups</p>
+        <p className="text-muted text-sm mt-1">{total} signups</p>
+      </div>
+
+      <div className="flex gap-2 text-sm">
+        {([
+          ["all", `All (${total})`],
+          ["linked", `Linked (${linkedCount})`],
+          ["unlinked", `Unlinked (${unlinkedCount})`],
+        ] as [Filter, string][]).map(([key, label]) => (
+          <Link
+            key={key}
+            href={filterLink(key)}
+            className={`glass-panel-subtle px-3 py-1.5 rounded-full transition-colors ${
+              filter === key ? "ring-2 ring-sage text-foreground" : "text-muted hover:text-foreground"
+            }`}
+          >
+            {label}
+          </Link>
+        ))}
       </div>
 
       {interests.length === 0 ? (
         <div className="glass-panel-subtle p-8 rounded-xl text-center text-muted">
-          No signups yet. Share <code className="text-sage">/interest</code> to start collecting.
+          {filter === "all"
+            ? <>No signups yet. Share <code className="text-sage">/interest</code> to start collecting.</>
+            : filter === "linked"
+              ? "No interests linked to a member yet."
+              : "No unlinked interests."}
         </div>
       ) : (
         <div className="glass-panel rounded-xl overflow-x-auto">
@@ -47,6 +98,7 @@ export default async function InterestsPage() {
               <tr>
                 <th className="px-4 py-3 font-medium">Email</th>
                 <th className="px-4 py-3 font-medium">Name</th>
+                <th className="px-4 py-3 font-medium">Member</th>
                 <th className="px-4 py-3 font-medium">Interests</th>
                 <th className="px-4 py-3 font-medium">Source</th>
                 <th className="px-4 py-3 font-medium">Signed up</th>
@@ -61,6 +113,18 @@ export default async function InterestsPage() {
                     </a>
                   </td>
                   <td className="px-4 py-3 text-muted">{row.name ?? "—"}</td>
+                  <td className="px-4 py-3">
+                    {row.member_id !== null ? (
+                      <Link
+                        href={`/admin/members/${row.member_id}`}
+                        className="inline-flex items-center gap-1 glass-panel-subtle px-2 py-0.5 text-xs rounded-full text-sage hover:ring-1 hover:ring-sage transition-colors"
+                      >
+                        ✓ Linked
+                      </Link>
+                    ) : (
+                      <span className="text-muted text-xs">—</span>
+                    )}
+                  </td>
                   <td className="px-4 py-3">
                     {row.interests.length === 0 ? (
                       <span className="text-muted">—</span>

--- a/apps/web/src/app/api/interest/route.ts
+++ b/apps/web/src/app/api/interest/route.ts
@@ -26,12 +26,25 @@ export async function POST(req: Request) {
     ? interests.filter((i): i is string => typeof i === "string" && VALID_INTERESTS.has(i))
     : [];
 
+  const normalizedEmail = email.trim().toLowerCase();
   const supabase = createServiceClient();
+
+  // If a member already exists for this email, link the interest at signup time.
+  // The signup-second-member-first case is also covered by the auth-side trigger
+  // in migration 020, but going direct here saves a round trip when the member
+  // exists today.
+  const { data: existingMember } = await supabase
+    .from("members")
+    .select("id")
+    .ilike("email", normalizedEmail)
+    .maybeSingle();
+
   const { error } = await supabase.from("interests").insert({
-    email: email.trim().toLowerCase(),
+    email: normalizedEmail,
     name: name?.trim() || null,
     interests: validInterests,
     source_path: source_path?.slice(0, 500) ?? null,
+    member_id: existingMember?.id ?? null,
   });
 
   if (error) {

--- a/apps/web/src/app/interest/success/page.tsx
+++ b/apps/web/src/app/interest/success/page.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
-import { CheckCircle, ArrowLeft } from "lucide-react";
+import { CheckCircle, ArrowLeft, Zap, Key, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import regenHubFull from "@/assets/regenhub-full.svg";
@@ -32,20 +32,48 @@ export default function InterestSuccessPage() {
               Thanks for reaching out. We&apos;ll be in touch when there&apos;s
               something worth sharing.
             </p>
-            <p className="text-sm text-muted mb-8">
-              In the meantime, your first day at RegenHub is on us — come hang out.
+            <p className="text-sm text-muted mb-6">
+              In the meantime — there&apos;s no need to wait.
             </p>
-            <div className="flex flex-col sm:flex-row gap-3 justify-center">
+
+            <div className="grid sm:grid-cols-2 gap-3 mb-6 text-left">
               <Link href="/freeday">
-                <Button className="btn-primary-glass">Try a Free Day</Button>
+                <Card className="glass-panel hover-lift cursor-pointer h-full">
+                  <CardContent className="p-4">
+                    <Zap className="w-6 h-6 text-gold mb-2" />
+                    <p className="font-medium text-sm mb-1">Try a Free Day</p>
+                    <p className="text-xs text-muted">
+                      Your first day&apos;s on us — see if RegenHub fits.
+                    </p>
+                    <p className="text-xs text-sage mt-2 inline-flex items-center gap-1">
+                      Get a code <ArrowRight className="w-3 h-3" />
+                    </p>
+                  </CardContent>
+                </Card>
               </Link>
-              <Link href="/">
-                <Button variant="ghost" className="btn-glass gap-2">
-                  <ArrowLeft className="w-4 h-4" />
-                  Back home
-                </Button>
-              </Link>
+
+              <a href="mailto:boulder.regenhub@gmail.com?subject=Interested in desk membership">
+                <Card className="glass-panel hover-lift cursor-pointer h-full">
+                  <CardContent className="p-4">
+                    <Key className="w-6 h-6 text-sage mb-2" />
+                    <p className="font-medium text-sm mb-1">See Membership</p>
+                    <p className="text-xs text-muted">
+                      Desks from $250/mo. Permanent code, 24/7 access.
+                    </p>
+                    <p className="text-xs text-sage mt-2 inline-flex items-center gap-1">
+                      Inquire <ArrowRight className="w-3 h-3" />
+                    </p>
+                  </CardContent>
+                </Card>
+              </a>
             </div>
+
+            <Link href="/">
+              <Button variant="ghost" className="btn-glass gap-2 text-xs">
+                <ArrowLeft className="w-3 h-3" />
+                Back home
+              </Button>
+            </Link>
           </CardContent>
         </Card>
       </div>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
-import RegenHubLanding from "@/components/landing/RegenHubLanding";
+import { createClient } from "@/lib/supabase/server";
+import RegenHubLanding, { type SignedInMember } from "@/components/landing/RegenHubLanding";
 
 export const metadata: Metadata = {
   title: "RegenHub Boulder — Regenerative Coworking & Innovation Hub",
@@ -21,6 +22,19 @@ export const metadata: Metadata = {
   },
 };
 
-export default function Home() {
-  return <RegenHubLanding />;
+export default async function Home() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  let signedInMember: SignedInMember = null;
+  if (user) {
+    const { data: member } = await supabase
+      .from("members")
+      .select("name")
+      .eq("supabase_user_id", user.id)
+      .maybeSingle();
+    if (member) signedInMember = { name: member.name };
+  }
+
+  return <RegenHubLanding signedInMember={signedInMember} />;
 }

--- a/apps/web/src/app/portal/page.tsx
+++ b/apps/web/src/app/portal/page.tsx
@@ -58,6 +58,19 @@ export default async function PortalPage() {
     freeDayClaim = data;
   }
 
+  // Look up the original interest signup (if any) for the funnel-continuity ack
+  let interestSignup: { created_at: string } | null = null;
+  if (member) {
+    const { data } = await supabase
+      .from("interests")
+      .select("created_at")
+      .eq("member_id", member.id)
+      .order("created_at", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+    interestSignup = data;
+  }
+
   if (!member) {
     if (application) {
       const statusColor = application.status === "approved"
@@ -120,11 +133,25 @@ export default async function PortalPage() {
   const accountAgeMs = Date.now() - new Date(member.created_at).getTime();
   const isNewMember = !member.pin_code || accountAgeMs < 7 * 24 * 60 * 60 * 1000;
 
+  const interestSignupLabel = interestSignup
+    ? new Date(interestSignup.created_at).toLocaleDateString("en-US", {
+        timeZone: "America/Denver",
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+      })
+    : null;
+
   return (
     <div className="space-y-8">
       <div>
         <h1 className="text-3xl font-bold text-forest">Welcome back, {member.name.split(" ")[0]}</h1>
         <p className="text-muted mt-1">{typeLabel} Member</p>
+        {interestSignupLabel && (
+          <p className="text-xs text-muted mt-2">
+            Thanks for joining our list on {interestSignupLabel}. Glad you stuck with us.
+          </p>
+        )}
       </div>
 
       <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/apps/web/src/components/landing/RegenHubLanding.tsx
+++ b/apps/web/src/components/landing/RegenHubLanding.tsx
@@ -6,12 +6,14 @@ import { Card, CardContent } from "@/components/ui/card";
 import { MemberDirectory } from "@/components/landing/MemberDirectory";
 import { ForestMascot } from "@/components/landing/ForestMascot";
 import HeroInterestForm from "@/components/landing/HeroInterestForm";
+
+export type SignedInMember = { name: string } | null;
 import forestBackground from "@/assets/forest-background.jpg";
 import regenHubLogo from "@/assets/regenhub-logo.svg";
 import regenHubText from "@/assets/regenhub-text.svg";
 import regenHubFull from "@/assets/regenhub-full.svg";
 
-export default function RegenHubLanding() {
+export default function RegenHubLanding({ signedInMember }: { signedInMember?: SignedInMember }) {
   return (
     <div className="min-h-screen relative overflow-x-hidden">
       {/* Forest background */}
@@ -65,7 +67,16 @@ export default function RegenHubLanding() {
                 </Button>
               </a>
             </div>
-            <HeroInterestForm />
+            {signedInMember ? (
+              <p className="mt-6 text-sm text-muted">
+                You&apos;re in, {signedInMember.name.split(" ")[0]}.{" "}
+                <Link href="/portal" className="text-sage hover:underline">
+                  Open your portal →
+                </Link>
+              </p>
+            ) : (
+              <HeroInterestForm />
+            )}
           </div>
         </div>
       </section>

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -143,6 +143,7 @@ export interface Database {
           source_path: string | null;
           interests: string[];
           resend_contact_id: string | null;
+          member_id: number | null;
           created_at: string;
         };
         Insert: {
@@ -151,6 +152,7 @@ export interface Database {
           source_path?: string | null;
           interests?: string[];
           resend_contact_id?: string | null;
+          member_id?: number | null;
         };
         Update: Partial<Database["public"]["Tables"]["interests"]["Insert"]>;
         Relationships: [];

--- a/supabase/migrations/020_interests_link_to_members.sql
+++ b/supabase/migrations/020_interests_link_to_members.sql
@@ -1,0 +1,60 @@
+-- Migration 020: link interests to members
+--
+-- The /interest form (migration 019) captures email-only signups that today
+-- live in their own silo. This migration connects those rows to the rest of
+-- the funnel: when a person who once submitted interest becomes a member,
+-- we know who they are.
+--
+-- Three layers ensure linkage works regardless of event order:
+--
+--   (a) Backfill at migration time — existing interests linked to existing
+--       members by case-insensitive email match.
+--   (b) Auth-side trigger (extending migration 004 — link_member_on_auth) —
+--       when an auth.users row appears, we link members.supabase_user_id and
+--       *also* fill in any matching interests.member_id.
+--   (c) API route (apps/web/src/app/api/interest/route.ts) — looks up
+--       members by email on POST and sets member_id directly when a match
+--       exists at signup time.
+--
+-- Edge case not covered here: interest submitted → member added (admin/bot)
+-- → member never signs in via magic link. The trigger fires on auth.users
+-- so until they sign in there's a brief window where the link is unset.
+-- Acceptable; the link materializes on first sign-in.
+
+ALTER TABLE interests
+  ADD COLUMN member_id BIGINT REFERENCES members(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_interests_member_id ON interests (member_id);
+
+-- (a) Backfill existing rows
+UPDATE interests i
+SET member_id = m.id
+FROM members m
+WHERE LOWER(i.email) = LOWER(m.email)
+  AND i.member_id IS NULL;
+
+-- (b) Extend the migration-004 auth trigger to also link interests
+CREATE OR REPLACE FUNCTION public.link_member_on_auth()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Original behavior: link any matching members row to this auth user
+  UPDATE members
+  SET supabase_user_id = NEW.id
+  WHERE email = NEW.email
+    AND supabase_user_id IS NULL;
+
+  -- New: link any matching interests row to the (now-resolvable) member
+  UPDATE interests
+  SET member_id = (
+    SELECT id FROM members WHERE email = NEW.email LIMIT 1
+  )
+  WHERE email = NEW.email
+    AND member_id IS NULL;
+
+  RETURN NEW;
+END;
+$$;

--- a/supabase/migrations/020_interests_link_to_members.sql
+++ b/supabase/migrations/020_interests_link_to_members.sql
@@ -58,3 +58,14 @@ BEGIN
   RETURN NEW;
 END;
 $$;
+
+-- (d) Let members read their own linked interest row.
+-- The migration-019 policy was admin-only; without this, the /portal
+-- "Thanks for joining our list on …" acknowledgment can't see the row
+-- (it queries via the user's RLS-bound client). The existing admins_all
+-- policy stays in place — RLS combines policies with OR, so admins still
+-- see everything and members see only their own row.
+CREATE POLICY "members_read_own" ON interests
+  FOR SELECT USING (
+    member_id = (SELECT id FROM members WHERE supabase_user_id = auth.uid())
+  );


### PR DESCRIPTION
Follow-up to #51. Connects `/interest` signups to the rest of the funnel.

## Schema — Migration 020 (NOT YET APPLIED — gated, ping for approval)

```sql
ALTER TABLE interests ADD COLUMN member_id BIGINT REFERENCES members(id) ON DELETE SET NULL;
CREATE INDEX idx_interests_member_id ON interests (member_id);

-- Backfill (case-insensitive email match):
UPDATE interests i SET member_id = m.id FROM members m
  WHERE LOWER(i.email) = LOWER(m.email) AND i.member_id IS NULL;

-- Extends link_member_on_auth (migration 004) to also link interests
-- when an auth.users row appears for an email with both rows.

-- Adds a members_read_own SELECT policy so /portal's interest
-- acknowledgment can read the member's own row through their RLS-bound client.
CREATE POLICY "members_read_own" ON interests
  FOR SELECT USING (
    member_id = (SELECT id FROM members WHERE supabase_user_id = auth.uid())
  );
```

The migration is **idempotent for the additive parts** (`ADD COLUMN` would fail if re-run, but that's the whole point of versioned migrations — only applied once). The trigger replacement preserves existing behavior and adds the interests linkage as a second statement. The new RLS policy is additive — migration-019's `admins_all` policy stays in place; RLS combines policies with OR, so admins still see everything and members see only their own row.

## App changes

- **`POST /api/interest`** looks up `members` by email at insert time, sets `member_id` when a match exists. Covers the signup-second-member-first flow synchronously, complementing the auth-trigger fallback.
- **`/admin/interests`** — new "Member" column with a "✓ Linked" badge that click-throughs to `/admin/members/<id>`, plus an All / Linked / Unlinked filter via `?linked=true|false` query param. Counts shown on each pill.
- **Homepage hero** — server-rendered now (was static); swaps `HeroInterestForm` for "You're in, <FirstName>. Open your portal →" when the visitor is a signed-in member. Auth-but-not-yet-member visitors still see the form.
- **`/interest/success`** — replaces the single CTA with two subtle option cards (Try a Free Day / See Membership) so the journey continues without nagging.
- **`/portal`** — adds a small subtle line under the welcome header: "Thanks for joining our list on \<date\>. Glad you stuck with us." when the member has a linked interest row. The new RLS policy makes this readable through the user's RLS-bound client.
- **`CLAUDE.md`** — new "Identity linkage" subsection under Database Schema documenting the three-rows-stitched-by-email pattern and the trigger/route fallbacks.

## Coverage matrix

| Event order | Linked when |
|---|---|
| interest exists → member created via admin/bot → never signs in | Brief gap — links on first sign-in via auth trigger |
| interest exists → member created → signs in via magic link | Auth trigger (link_member_on_auth, extended) |
| member exists → submits interest | `/api/interest` POST handler (synchronous) |
| Both pre-exist at migration time | Migration 020 backfill UPDATE |

## Worth a closer look at

- **Edge case I didn't close**: interest → member added → never signs in. The link materializes on first sign-in. Could be closed with another trigger on `members` (similar to migration 013's reverse-link pattern); team-lead opted to track but punt as uncommon.
- **Case-insensitive backfill** uses `LOWER()`. Members historically had emails stored mixed-case in some rows; the API path normalizes to lowercase on insert but historical data might not be uniform. Backfill is forgiving.
- **Home page (`/`) becomes dynamic** — auth check pushes it from `○` (static) to `ƒ` (server-rendered). Negligible perf impact, one Supabase auth call per render.

## CI

- `pnpm --filter @regenhub/shared build` ✅
- `pnpm --filter web lint` ✅ (1 pre-existing img warning, unrelated)
- `pnpm --filter web build` ✅

## Test plan (post-migration-apply)

- [ ] Migration 020 applied; `idx_interests_member_id` exists; `interests.member_id` column exists; `members_read_own` policy on `interests` shows in `pg_policies`.
- [ ] Existing `interests` rows with matching member emails have `member_id` populated.
- [ ] Signed-out homepage shows the form; signed-in member sees "You're in" line.
- [ ] `/admin/interests` filter pills work; "✓ Linked" badge clicks through.
- [ ] Submit interest as a signed-out new email → row appears with `member_id = NULL`.
- [ ] Submit interest with the email of an existing member → `member_id` set on insert.
- [ ] Sign in as a member who has a pre-existing interest row → row gets `member_id` via trigger; portal acknowledgment renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)