### PR TITLE
feat: stripe-powered memberships — desk + social tiers

### DIFF
--- a/apps/web/src/app/admin/members/[id]/page.tsx
+++ b/apps/web/src/app/admin/members/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { MemberForm } from "@/components/admin/MemberForm";
 import { AddPassesCard } from "@/components/admin/AddPassesCard";
 import { PaymentLinkCard } from "@/components/admin/PaymentLinkCard";
+import { SubscriptionCard } from "@/components/admin/SubscriptionCard";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Key } from "lucide-react";
@@ -13,7 +14,7 @@ export default async function EditMemberPage({ params }: { params: Promise<{ id:
   const { id } = await params;
   const supabase = await createClient();
 
-  const [{ data: member }, { data: codeHistory }] = await Promise.all([
+  const [{ data: member }, { data: codeHistory }, { data: subscriptions }, { data: purchases }] = await Promise.all([
     supabase
       .from("members")
       .select("*")
@@ -25,9 +26,24 @@ export default async function EditMemberPage({ params }: { params: Promise<{ id:
       .eq("member_id", Number(id))
       .order("created_at", { ascending: false })
       .limit(20),
+    supabase
+      .from("subscriptions")
+      .select("*")
+      .eq("member_id", Number(id))
+      .order("created_at", { ascending: false }),
+    supabase
+      .from("purchases")
+      .select("*")
+      .eq("member_id", Number(id))
+      .order("created_at", { ascending: false })
+      .limit(10),
   ]);
 
   if (!member) notFound();
+
+  const activeSubscription = subscriptions?.find((s) =>
+    ["active", "trialing", "past_due"].includes(s.status),
+  );
 
   return (
     <div className="space-y-8 max-w-2xl">
@@ -36,6 +52,12 @@ export default async function EditMemberPage({ params }: { params: Promise<{ id:
         <p className="text-muted mt-1">{member.name}</p>
       </div>
       <MemberForm member={member} />
+      <SubscriptionCard
+        memberId={member.id}
+        memberName={member.name}
+        activeSubscription={activeSubscription ?? null}
+        recentPurchases={purchases ?? []}
+      />
       <AddPassesCard memberId={member.id} initialBalance={member.day_passes_balance} />
       <PaymentLinkCard
         memberName={member.name}

--- a/apps/web/src/app/api/admin/applications/[id]/approve/route.test.ts
+++ b/apps/web/src/app/api/admin/applications/[id]/approve/route.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeSupabaseMock } from "../../../../../../../test/mockSupabase";
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ createServiceClient: vi.fn() }));
+vi.mock("@/lib/stripe", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/stripe")>("@/lib/stripe");
+  return {
+    ...actual,
+    isStripeConfigured: vi.fn(() => true),
+    createApprovalCheckoutSession: vi.fn(),
+  };
+});
+
+import { POST } from "./route";
+import { createClient } from "@/lib/supabase/server";
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/admin/applications/1/approve", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const ctx = { params: Promise.resolve({ id: "1" }) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/admin/applications/[id]/approve", () => {
+  it("returns 401 when no auth user", async () => {
+    vi.mocked(createClient).mockResolvedValue(
+      makeSupabaseMock({ auth: { user: null } }) as never,
+    );
+
+    const res = await POST(makeRequest({ plan_key: "cold_desk", monthly_cents: 50000 }), ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when caller is not an admin", async () => {
+    vi.mocked(createClient).mockResolvedValue(
+      makeSupabaseMock({
+        auth: { user: { id: "u-1", email: "a@b.co" } },
+        selects: { members: { data: { is_admin: false } } },
+      }) as never,
+    );
+
+    const res = await POST(makeRequest({ plan_key: "cold_desk", monthly_cents: 50000 }), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when plan_key is unknown", async () => {
+    vi.mocked(createClient).mockResolvedValue(
+      makeSupabaseMock({
+        auth: { user: { id: "u-1", email: "a@b.co" } },
+        selects: { members: { data: { is_admin: true } } },
+      }) as never,
+    );
+
+    const res = await POST(makeRequest({ plan_key: "bogus", monthly_cents: 50000 }), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when monthly_cents is missing or sub-dollar", async () => {
+    vi.mocked(createClient).mockResolvedValue(
+      makeSupabaseMock({
+        auth: { user: { id: "u-1", email: "a@b.co" } },
+        selects: { members: { data: { is_admin: true } } },
+      }) as never,
+    );
+
+    const res = await POST(makeRequest({ plan_key: "cold_desk", monthly_cents: 50 }), ctx);
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/src/app/api/admin/applications/[id]/approve/route.ts
+++ b/apps/web/src/app/api/admin/applications/[id]/approve/route.ts
@@ -1,0 +1,170 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/admin";
+import {
+  createApprovalCheckoutSession,
+  getPlan,
+  isStripeConfigured,
+} from "@/lib/stripe";
+import type { PlanKey, DiscountDuration } from "@/lib/supabase/types";
+
+interface ApproveBody {
+  plan_key: PlanKey;
+  monthly_cents: number;
+  discount_cents?: number;
+  discount_duration?: DiscountDuration;
+  discount_months?: number;
+  discount_note?: string;
+}
+
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { data: adminMember } = await supabase
+    .from("members")
+    .select("is_admin")
+    .eq("supabase_user_id", user.id)
+    .single();
+  if (!adminMember?.is_admin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (!isStripeConfigured()) {
+    return NextResponse.json(
+      { error: "Stripe is not configured on this environment" },
+      { status: 503 },
+    );
+  }
+
+  const { id: idParam } = await ctx.params;
+  const applicationId = parseInt(idParam, 10);
+  if (!applicationId) {
+    return NextResponse.json({ error: "Invalid application id" }, { status: 400 });
+  }
+
+  const body = (await req.json().catch(() => null)) as ApproveBody | null;
+  if (!body?.plan_key || !getPlan(body.plan_key)) {
+    return NextResponse.json({ error: "Missing or unknown plan_key" }, { status: 400 });
+  }
+  if (!body.monthly_cents || body.monthly_cents < 100) {
+    return NextResponse.json(
+      { error: "monthly_cents required and must be ≥ $1" },
+      { status: 400 },
+    );
+  }
+
+  const discountCents = body.discount_cents ?? 0;
+  const discountDuration: DiscountDuration | null = discountCents > 0
+    ? (body.discount_duration ?? "forever")
+    : null;
+  const discountMonths = discountDuration === "repeating" ? (body.discount_months ?? null) : null;
+  if (discountDuration === "repeating" && (!discountMonths || discountMonths < 1)) {
+    return NextResponse.json(
+      { error: "discount_months required when duration=repeating" },
+      { status: 400 },
+    );
+  }
+
+  const admin = createServiceClient();
+
+  const { data: application } = await admin
+    .from("applications")
+    .select("*")
+    .eq("id", applicationId)
+    .single();
+  if (!application) {
+    return NextResponse.json({ error: "Application not found" }, { status: 404 });
+  }
+
+  // Find or create the member row for this applicant.
+  let { data: member } = await admin
+    .from("members")
+    .select("id, name, email, stripe_customer_id, member_type")
+    .eq("email", application.email)
+    .maybeSingle();
+
+  if (!member) {
+    const { data: created, error: createErr } = await admin
+      .from("members")
+      .insert({
+        name: application.name,
+        email: application.email,
+        member_type: "day_pass",
+        supabase_user_id: application.supabase_user_id,
+      })
+      .select("id, name, email, stripe_customer_id, member_type")
+      .single();
+    if (createErr || !created) {
+      console.error("[ApproveApp] Failed to create member:", createErr);
+      return NextResponse.json({ error: "Failed to create member" }, { status: 500 });
+    }
+    member = created;
+  }
+
+  const baseUrl =
+    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ?? "https://regenhub.xyz";
+
+  let checkoutUrl: string;
+  let sessionId: string;
+  let customerId: string;
+  try {
+    const result = await createApprovalCheckoutSession({
+      application_id: application.id,
+      member,
+      planKey: body.plan_key,
+      monthlyCents: body.monthly_cents,
+      discountCents: discountCents > 0 ? discountCents : null,
+      discountDuration,
+      discountMonths,
+      discountNote: body.discount_note ?? null,
+      successUrl: `${baseUrl}/portal?welcome=1`,
+      cancelUrl: `${baseUrl}/portal?checkout=cancelled`,
+    });
+    checkoutUrl = result.session.url ?? "";
+    sessionId = result.session.id;
+    customerId = result.customer.id;
+    if (!checkoutUrl) throw new Error("Stripe returned no checkout URL");
+  } catch (err) {
+    console.error("[ApproveApp] Stripe error:", err);
+    const msg = err instanceof Error ? err.message : "Stripe request failed";
+    return NextResponse.json({ error: msg }, { status: 502 });
+  }
+
+  // Persist customer id on the member if newly created
+  if (!member.stripe_customer_id) {
+    await admin
+      .from("members")
+      .update({ stripe_customer_id: customerId })
+      .eq("id", member.id);
+  }
+
+  const { error: updateErr } = await admin
+    .from("applications")
+    .update({
+      status: "approved",
+      approved_plan_key: body.plan_key,
+      approved_monthly_cents: body.monthly_cents,
+      discount_cents: discountCents > 0 ? discountCents : null,
+      discount_duration: discountDuration,
+      discount_months: discountMonths,
+      discount_note: body.discount_note ?? null,
+      stripe_checkout_session_id: sessionId,
+      stripe_checkout_url: checkoutUrl,
+      checkout_sent_at: new Date().toISOString(),
+    })
+    .eq("id", application.id);
+
+  if (updateErr) {
+    console.error("[ApproveApp] Failed to update application:", updateErr);
+    return NextResponse.json({ error: "Failed to update application" }, { status: 500 });
+  }
+
+  return NextResponse.json({ checkout_url: checkoutUrl, session_id: sessionId });
+}

--- a/apps/web/src/app/api/admin/members/[id]/revoke/route.ts
+++ b/apps/web/src/app/api/admin/members/[id]/revoke/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/admin";
+import { getStripe, isStripeConfigured } from "@/lib/stripe";
+
+interface RevokeBody {
+  refund_last_purchase?: boolean;
+}
+
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { data: adminMember } = await supabase
+    .from("members")
+    .select("is_admin")
+    .eq("supabase_user_id", user.id)
+    .single();
+  if (!adminMember?.is_admin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id: idParam } = await ctx.params;
+  const memberId = parseInt(idParam, 10);
+  if (!memberId) {
+    return NextResponse.json({ error: "Invalid member id" }, { status: 400 });
+  }
+
+  const body = (await req.json().catch(() => null)) as RevokeBody | null;
+  const admin = createServiceClient();
+
+  const { data: member, error: memberErr } = await admin
+    .from("members")
+    .select("id, name")
+    .eq("id", memberId)
+    .single();
+  if (memberErr || !member) {
+    return NextResponse.json({ error: "Member not found" }, { status: 404 });
+  }
+
+  await admin.from("members").update({ disabled: true }).eq("id", memberId);
+
+  let refunded: { amount: number; refund_id: string } | null = null;
+  if (body?.refund_last_purchase && isStripeConfigured()) {
+    const { data: lastPurchase } = await admin
+      .from("purchases")
+      .select("id, stripe_payment_intent, amount_cents")
+      .eq("member_id", memberId)
+      .not("stripe_payment_intent", "is", null)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (lastPurchase?.stripe_payment_intent) {
+      try {
+        const refund = await getStripe().refunds.create({
+          payment_intent: lastPurchase.stripe_payment_intent,
+        });
+        refunded = { amount: lastPurchase.amount_cents, refund_id: refund.id };
+      } catch (err) {
+        console.error("[RevokeMember] Refund failed:", err);
+        // Don't fail the whole revoke if refund fails — member is still disabled.
+        return NextResponse.json({
+          revoked: true,
+          refund_error: err instanceof Error ? err.message : "Refund failed",
+        });
+      }
+    }
+  }
+
+  return NextResponse.json({ revoked: true, refunded });
+}

--- a/apps/web/src/app/api/apply/route.ts
+++ b/apps/web/src/app/api/apply/route.ts
@@ -5,6 +5,8 @@ import type { MembershipInterest } from "@/lib/supabase/types";
 const interestLabels: Record<string, string> = {
   daypass_single: "Day Pass",
   daypass_5pack: "5-Pack Day Passes",
+  social_events_1: "Social — Events + 1 day/mo",
+  social_events_5: "Social — Events + 5 days/mo",
   hot_desk: "Hot Desk",
   reserved_desk: "Reserved Desk",
   community: "Community",

--- a/apps/web/src/app/api/cron/past-due-sweep/route.test.ts
+++ b/apps/web/src/app/api/cron/past-due-sweep/route.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeSupabaseMock } from "../../../../../test/mockSupabase";
+
+vi.mock("@/lib/supabase/admin", () => ({ createServiceClient: vi.fn() }));
+
+import { POST } from "./route";
+import { createServiceClient } from "@/lib/supabase/admin";
+
+function makeRequest(auth?: string): Request {
+  return new Request("http://localhost/api/cron/past-due-sweep", {
+    method: "POST",
+    headers: auth ? { Authorization: auth } : {},
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/cron/past-due-sweep", () => {
+  it("returns 503 when CRON_SECRET is not configured", async () => {
+    const prev = process.env.CRON_SECRET;
+    delete process.env.CRON_SECRET;
+    const res = await POST(makeRequest("Bearer anything"));
+    expect(res.status).toBe(503);
+    if (prev) process.env.CRON_SECRET = prev;
+  });
+
+  it("returns 401 with bad bearer token", async () => {
+    process.env.CRON_SECRET = "secret-1";
+    const res = await POST(makeRequest("Bearer wrong"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 with no auth header", async () => {
+    process.env.CRON_SECRET = "secret-1";
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns swept=0 when no stale subscriptions found", async () => {
+    process.env.CRON_SECRET = "secret-1";
+    const sb = makeSupabaseMock({ selects: { subscriptions: { data: [] } } });
+    vi.mocked(createServiceClient).mockReturnValue(sb as never);
+
+    const res = await POST(makeRequest("Bearer secret-1"));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.swept).toBe(0);
+    expect(json.flipped).toBe(0);
+  });
+});

--- a/apps/web/src/app/api/cron/past-due-sweep/route.ts
+++ b/apps/web/src/app/api/cron/past-due-sweep/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/admin";
+
+const GRACE_DAYS = 7;
+
+async function notifyTelegram(text: string) {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  const chatId = process.env.TELEGRAM_GROUP_CHAT_ID;
+  if (!token || !chatId) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text,
+        parse_mode: "Markdown",
+        disable_web_page_preview: true,
+      }),
+    });
+  } catch (err) {
+    console.error("[PastDueCron] Telegram error:", err);
+  }
+}
+
+/**
+ * POST /api/cron/past-due-sweep
+ *
+ * Flips members back to day_pass after the 7-day grace period on a
+ * failed payment expires. Designed to be hit daily by Coolify cron.
+ *
+ * Auth: requires `Authorization: Bearer ${CRON_SECRET}`.
+ */
+export async function POST(req: Request) {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    return NextResponse.json(
+      { error: "CRON_SECRET is not set on this environment" },
+      { status: 503 },
+    );
+  }
+  const auth = req.headers.get("authorization");
+  if (auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const admin = createServiceClient();
+  const cutoff = new Date(Date.now() - GRACE_DAYS * 24 * 60 * 60 * 1000).toISOString();
+
+  // Find subscriptions in their grace window that are past the cutoff and
+  // haven't already been disabled.
+  const { data: stale, error } = await admin
+    .from("subscriptions")
+    .select("id, member_id, stripe_subscription_id, past_due_since, members(name)")
+    .lt("past_due_since", cutoff)
+    .is("access_disabled_at", null)
+    .not("past_due_since", "is", null);
+
+  if (error) {
+    console.error("[PastDueCron] Query error:", error);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+
+  const now = new Date().toISOString();
+  let flipped = 0;
+  for (const row of stale ?? []) {
+    await admin
+      .from("subscriptions")
+      .update({ access_disabled_at: now })
+      .eq("id", row.id);
+    await admin
+      .from("members")
+      .update({ member_type: "day_pass" })
+      .eq("id", row.member_id);
+    // @ts-expect-error nested join shape
+    const name = row.members?.name ?? "A member";
+    await notifyTelegram(
+      `🔒 *Access downgraded*\n\n${name}'s payment failed >7 days ago. Moved to day-pass status.`,
+    );
+    flipped++;
+  }
+
+  return NextResponse.json({ swept: (stale ?? []).length, flipped });
+}

--- a/apps/web/src/app/api/portal/billing-portal/route.ts
+++ b/apps/web/src/app/api/portal/billing-portal/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createCustomerPortalSession, isStripeConfigured } from "@/lib/stripe";
+
+export async function POST() {
+  if (!isStripeConfigured()) {
+    return NextResponse.json({ error: "Stripe is not configured" }, { status: 503 });
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { data: member } = await supabase
+    .from("members")
+    .select("id, name, email, stripe_customer_id")
+    .eq("supabase_user_id", user.id)
+    .single();
+
+  if (!member) {
+    return NextResponse.json({ error: "Member profile not found" }, { status: 404 });
+  }
+
+  const baseUrl =
+    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ?? "https://regenhub.xyz";
+  const returnUrl = process.env.STRIPE_CUSTOMER_PORTAL_RETURN_URL ?? `${baseUrl}/portal`;
+
+  try {
+    const session = await createCustomerPortalSession(member, returnUrl);
+    return NextResponse.json({ url: session.url });
+  } catch (err) {
+    console.error("[BillingPortal] Stripe error:", err);
+    const msg = err instanceof Error ? err.message : "Stripe request failed";
+    return NextResponse.json({ error: msg }, { status: 502 });
+  }
+}

--- a/apps/web/src/app/api/webhooks/stripe/route.ts
+++ b/apps/web/src/app/api/webhooks/stripe/route.ts
@@ -1,17 +1,45 @@
 import { NextResponse } from "next/server";
-import Stripe from "stripe";
+import type Stripe from "stripe";
+import { getStripe, getPlan, planLabel } from "@/lib/stripe";
 import { createServiceClient } from "@/lib/supabase/admin";
+import type { StripeSubscriptionStatus } from "@/lib/supabase/types";
 
-// Map Stripe price IDs → number of day passes to grant
+type ServiceClient = ReturnType<typeof createServiceClient>;
+
+// Map Stripe price IDs → number of day passes granted (one-time purchases)
 function passCountForPrice(priceId: string): number {
   if (priceId === process.env.STRIPE_PRICE_DAYPASS) return 1;
   if (priceId === process.env.STRIPE_PRICE_FIVEPACK) return 5;
   return 0;
 }
 
-// Must be raw body for Stripe signature verification
+function isActiveStatus(s: string | null | undefined): boolean {
+  return s === "active" || s === "trialing";
+}
+
+async function notifyTelegram(text: string, opts?: { silent?: boolean }) {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  const chatId = process.env.TELEGRAM_GROUP_CHAT_ID;
+  if (!token || !chatId) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text,
+        parse_mode: "Markdown",
+        disable_web_page_preview: true,
+        disable_notification: opts?.silent ?? false,
+      }),
+    });
+  } catch (err) {
+    console.error("[StripeWebhook] Telegram notify error:", err);
+  }
+}
+
 export async function POST(request: Request) {
-  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+  const stripe = getStripe();
   const body = await request.text();
   const sig = request.headers.get("stripe-signature");
 
@@ -27,55 +55,553 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
   }
 
-  if (event.type === "checkout.session.completed") {
-    const session = event.data.object as Stripe.Checkout.Session;
+  const admin = createServiceClient();
 
-    // client_reference_id = member ID, set via ?client_reference_id= on payment link URL
-    const memberId = session.client_reference_id;
-    if (!memberId) {
-      console.warn("[Stripe] checkout.session.completed with no client_reference_id — skipping");
-      return NextResponse.json({ received: true });
+  try {
+    switch (event.type) {
+      case "checkout.session.completed":
+        await handleCheckoutCompleted(admin, event.data.object as Stripe.Checkout.Session);
+        break;
+      case "customer.subscription.created":
+        await handleSubscriptionCreated(admin, event.data.object as Stripe.Subscription);
+        break;
+      case "customer.subscription.updated":
+        await handleSubscriptionUpdated(admin, event.data.object as Stripe.Subscription);
+        break;
+      case "customer.subscription.deleted":
+        await handleSubscriptionDeleted(admin, event.data.object as Stripe.Subscription);
+        break;
+      case "invoice.payment_succeeded":
+        await handleInvoicePaymentSucceeded(admin, event.data.object as Stripe.Invoice);
+        break;
+      case "invoice.payment_failed":
+        await handleInvoicePaymentFailed(admin, event.data.object as Stripe.Invoice);
+        break;
+      default:
+        // Unhandled event types — Stripe sends a lot we don't care about
+        break;
     }
-
-    // Fetch line items to determine which product was purchased
-    const lineItems = await stripe.checkout.sessions.listLineItems(session.id, { limit: 5 });
-    let passCount = 0;
-    for (const item of lineItems.data) {
-      if (item.price?.id) {
-        passCount += passCountForPrice(item.price.id) * (item.quantity ?? 1);
-      }
-    }
-
-    if (passCount === 0) {
-      console.warn("[Stripe] No matching price IDs in session", session.id);
-      return NextResponse.json({ received: true });
-    }
-
-    const supabase = createServiceClient();
-    const { data: member } = await supabase
-      .from("members")
-      .select("id, name")
-      .eq("id", parseInt(memberId))
-      .single();
-
-    if (!member) {
-      console.error("[Stripe] Member not found for id:", memberId);
-      return NextResponse.json({ received: true });
-    }
-
-    // Atomic increment — prevents lost updates from concurrent webhook calls
-    const { data: newBalance, error: rpcError } = await supabase.rpc(
-      "increment_day_pass_balance",
-      { p_member_id: member.id, p_amount: passCount }
-    );
-
-    if (rpcError) {
-      console.error("[Stripe] Failed to increment balance:", rpcError);
-      return NextResponse.json({ error: "Balance update failed" }, { status: 500 });
-    }
-
-    console.log(`[Stripe] +${passCount} passes for ${member.name} (id=${member.id}) → balance=${newBalance}`);
+  } catch (err) {
+    console.error(`[Stripe] Error handling ${event.type}:`, err);
+    return NextResponse.json({ error: "Processing failed" }, { status: 500 });
   }
 
   return NextResponse.json({ received: true });
+}
+
+// =====================================================
+// Handlers
+// =====================================================
+
+async function handleCheckoutCompleted(admin: ServiceClient, session: Stripe.Checkout.Session) {
+  if (session.mode === "subscription") {
+    // The actual grant happens on customer.subscription.created — more
+    // authoritative since we read the live subscription state.
+    return;
+  }
+
+  // mode === 'payment' → existing day pass / 5-pack flow
+  const stripe = getStripe();
+  const lineItems = await stripe.checkout.sessions.listLineItems(session.id, { limit: 5 });
+
+  let passCount = 0;
+  let kind: "day_pass" | "five_pack" | null = null;
+  for (const item of lineItems.data) {
+    const priceId = item.price?.id;
+    if (!priceId) continue;
+    const count = passCountForPrice(priceId) * (item.quantity ?? 1);
+    passCount += count;
+    if (count === 1 && !kind) kind = "day_pass";
+    if (count === 5) kind = "five_pack";
+  }
+
+  if (passCount === 0 || !kind) {
+    console.warn("[Stripe] No matching price IDs in session", session.id);
+    return;
+  }
+
+  // Resolve the member: prefer client_reference_id, fall back to email
+  const customerEmail =
+    session.customer_details?.email ??
+    session.customer_email ??
+    null;
+
+  let memberId: number | null = null;
+  let memberName: string | null = null;
+  let isFirstTime = false;
+
+  if (session.client_reference_id) {
+    const id = parseInt(session.client_reference_id, 10);
+    if (Number.isFinite(id)) {
+      const { data: m } = await admin
+        .from("members")
+        .select("id, name")
+        .eq("id", id)
+        .maybeSingle();
+      if (m) {
+        memberId = m.id;
+        memberName = m.name;
+      }
+    }
+  }
+
+  if (!memberId && customerEmail) {
+    const { data: m } = await admin
+      .from("members")
+      .select("id, name")
+      .eq("email", customerEmail)
+      .maybeSingle();
+    if (m) {
+      memberId = m.id;
+      memberName = m.name;
+    } else {
+      // First-time buyer: auto-create a day_pass member
+      const name = session.customer_details?.name?.trim() || customerEmail.split("@")[0];
+      const { data: created } = await admin
+        .from("members")
+        .insert({
+          name,
+          email: customerEmail,
+          member_type: "day_pass",
+        })
+        .select("id, name")
+        .single();
+      if (created) {
+        memberId = created.id;
+        memberName = created.name;
+        isFirstTime = true;
+      }
+    }
+  }
+
+  if (!memberId) {
+    console.error("[Stripe] Could not resolve member for session", session.id);
+    return;
+  }
+
+  // Increment balance atomically
+  const { data: newBalance, error: rpcError } = await admin.rpc(
+    "increment_day_pass_balance",
+    { p_member_id: memberId, p_amount: passCount },
+  );
+  if (rpcError) {
+    console.error("[Stripe] Failed to increment balance:", rpcError);
+    throw rpcError;
+  }
+
+  // Audit log — idempotent on stripe_checkout_session
+  const paymentIntent =
+    typeof session.payment_intent === "string"
+      ? session.payment_intent
+      : (session.payment_intent?.id ?? null);
+  await admin.from("purchases").upsert(
+    {
+      member_id: memberId,
+      stripe_checkout_session: session.id,
+      stripe_payment_intent: paymentIntent,
+      kind,
+      amount_cents: session.amount_total ?? 0,
+      passes_granted: passCount,
+      email: customerEmail,
+    },
+    { onConflict: "stripe_checkout_session" },
+  );
+
+  console.log(
+    `[Stripe] +${passCount} passes for ${memberName} (id=${memberId}) → balance=${newBalance}`,
+  );
+
+  if (isFirstTime) {
+    const reviewUrl = `https://regenhub.xyz/admin/members/${memberId}`;
+    await notifyTelegram(
+      [
+        `🆕 *First-time day-pass buyer*`,
+        ``,
+        `*${memberName}* · ${customerEmail}`,
+        `Bought: ${kind === "five_pack" ? "5-Pack" : "Day Pass"} ($${(session.amount_total ?? 0) / 100})`,
+        ``,
+        `[Review →](${reviewUrl})`,
+      ].join("\n"),
+    );
+  }
+}
+
+async function handleSubscriptionCreated(admin: ServiceClient, sub: Stripe.Subscription) {
+  await upsertSubscription(admin, sub, { isNew: true });
+}
+
+async function handleSubscriptionUpdated(admin: ServiceClient, sub: Stripe.Subscription) {
+  // Capture previous state to detect transitions
+  const { data: prev } = await admin
+    .from("subscriptions")
+    .select("status, cancel_at_period_end, past_due_since")
+    .eq("stripe_subscription_id", sub.id)
+    .maybeSingle();
+
+  await upsertSubscription(admin, sub, { isNew: false });
+
+  const newStatus = sub.status;
+
+  // Transitions worth telling humans about
+  if (prev) {
+    // Cancellation queued
+    if (!prev.cancel_at_period_end && sub.cancel_at_period_end) {
+      const { data: member } = await admin
+        .from("subscriptions")
+        .select("member_id, members(name)")
+        .eq("stripe_subscription_id", sub.id)
+        .single();
+      const periodEndUnix = sub.items.data[0]?.current_period_end;
+      const endDate = periodEndUnix
+        ? new Date(periodEndUnix * 1000).toLocaleDateString("en-US", {
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+          })
+        : "the end of the period";
+      // @ts-expect-error nested join shape
+      const name = member?.members?.name ?? "A member";
+      await notifyTelegram(
+        `📤 *Subscription cancellation queued*\n\n${name} cancelled, effective ${endDate}. Maybe reach out?`,
+      );
+    }
+
+    // Entered past_due
+    if (prev.status !== "past_due" && newStatus === "past_due") {
+      const { data: row } = await admin
+        .from("subscriptions")
+        .select("member_id, members(name, email)")
+        .eq("stripe_subscription_id", sub.id)
+        .single();
+      // @ts-expect-error nested join shape
+      const name = row?.members?.name ?? "A member";
+      // @ts-expect-error nested join shape
+      const email = row?.members?.email ?? "";
+      await notifyTelegram(
+        `⚠️ *Payment failed*\n\n${name} (${email}) — card needs attention. 7-day grace period started.`,
+      );
+    }
+
+    // Recovered from past_due
+    if (prev.status === "past_due" && isActiveStatus(newStatus)) {
+      const { data: row } = await admin
+        .from("subscriptions")
+        .select("members(name)")
+        .eq("stripe_subscription_id", sub.id)
+        .single();
+      // @ts-expect-error nested join shape
+      const name = row?.members?.name ?? "A member";
+      await notifyTelegram(`✅ ${name}'s payment recovered — back in good standing.`, {
+        silent: true,
+      });
+    }
+  }
+}
+
+async function handleSubscriptionDeleted(admin: ServiceClient, sub: Stripe.Subscription) {
+  // Mark canceled in local mirror
+  await admin
+    .from("subscriptions")
+    .update({
+      status: sub.status,
+      canceled_at: new Date().toISOString(),
+      cancel_at_period_end: sub.cancel_at_period_end,
+    })
+    .eq("stripe_subscription_id", sub.id);
+
+  // Flip member back to day_pass (they keep portal/day-pass access)
+  const { data: row } = await admin
+    .from("subscriptions")
+    .select("member_id, members(name)")
+    .eq("stripe_subscription_id", sub.id)
+    .single();
+  if (row?.member_id) {
+    await admin.from("members").update({ member_type: "day_pass" }).eq("id", row.member_id);
+    // @ts-expect-error nested join shape
+    const name = row.members?.name ?? "A member";
+    await notifyTelegram(`👋 ${name}'s subscription ended. Now on day-pass status.`);
+  }
+}
+
+function invoiceSubscriptionId(invoice: Stripe.Invoice): string | null {
+  const sub = invoice.parent?.subscription_details?.subscription;
+  if (typeof sub === "string") return sub;
+  if (sub && typeof sub === "object") return sub.id;
+  return null;
+}
+
+async function handleInvoicePaymentSucceeded(admin: ServiceClient, invoice: Stripe.Invoice) {
+  const subId = invoiceSubscriptionId(invoice);
+  if (!subId) return;
+
+  // Clear past_due state on the renewal
+  await admin
+    .from("subscriptions")
+    .update({ past_due_since: null })
+    .eq("stripe_subscription_id", subId);
+
+  // For plans with monthlyDayPasses, credit the member's balance.
+  // Idempotent via UNIQUE(stripe_invoice_id) on pass_grants.
+  await maybeGrantMonthlyPasses(admin, invoice, subId);
+}
+
+/**
+ * Credit monthly day passes if the subscription's plan defines `monthlyDayPasses`.
+ * Idempotency: relies on UNIQUE(stripe_invoice_id) — if the INSERT into pass_grants
+ * conflicts, the balance is NOT incremented.
+ */
+async function maybeGrantMonthlyPasses(
+  admin: ServiceClient,
+  invoice: Stripe.Invoice,
+  subId: string,
+) {
+  // Local subscription row (created by handleSubscriptionCreated) gives us
+  // plan_key + member_id + local sub.id for the grant audit trail.
+  const { data: localSub } = await admin
+    .from("subscriptions")
+    .select("id, member_id, plan_key")
+    .eq("stripe_subscription_id", subId)
+    .maybeSingle();
+
+  // Fallback: subscription metadata is mirrored onto the invoice
+  const planKey =
+    localSub?.plan_key ??
+    (invoice.parent?.subscription_details?.metadata?.plan_key as string | undefined);
+  if (!planKey) {
+    console.warn(`[Stripe] No plan_key found for invoice ${invoice.id} (sub ${subId})`);
+    return;
+  }
+
+  const plan = getPlan(planKey);
+  if (!plan || !plan.monthlyDayPasses || plan.monthlyDayPasses <= 0) return;
+
+  // Resolve member: prefer local subscription row, fall back to customer lookup
+  let memberId = localSub?.member_id ?? null;
+  if (!memberId) {
+    const customerId = typeof invoice.customer === "string" ? invoice.customer : invoice.customer?.id;
+    if (customerId) {
+      const { data: m } = await admin
+        .from("members")
+        .select("id")
+        .eq("stripe_customer_id", customerId)
+        .maybeSingle();
+      memberId = m?.id ?? null;
+    }
+  }
+  if (!memberId) {
+    console.warn(`[Stripe] No member resolved for invoice ${invoice.id}`);
+    return;
+  }
+
+  if (!invoice.id) {
+    console.warn("[Stripe] Invoice missing id, skipping grant");
+    return;
+  }
+
+  // Idempotent insert — UNIQUE on stripe_invoice_id prevents double-grant on redelivery
+  const { data: inserted, error: insertErr } = await admin
+    .from("pass_grants")
+    .insert({
+      member_id: memberId,
+      subscription_id: localSub?.id ?? null,
+      stripe_invoice_id: invoice.id,
+      plan_key: planKey,
+      passes_granted: plan.monthlyDayPasses,
+    })
+    .select("id")
+    .maybeSingle();
+
+  // PG unique violation code is 23505 — that's the "already granted" case
+  if (insertErr) {
+    if (insertErr.code === "23505") return;
+    console.error("[Stripe] pass_grants insert failed:", insertErr);
+    return;
+  }
+  if (!inserted) return;
+
+  const { data: newBalance, error: rpcError } = await admin.rpc(
+    "increment_day_pass_balance",
+    { p_member_id: memberId, p_amount: plan.monthlyDayPasses },
+  );
+  if (rpcError) {
+    console.error("[Stripe] Failed to grant monthly passes:", rpcError);
+    // Rollback the grant row so a retry can succeed
+    await admin.from("pass_grants").delete().eq("id", inserted.id);
+    return;
+  }
+
+  console.log(
+    `[Stripe] +${plan.monthlyDayPasses} monthly passes for member ${memberId} (plan=${planKey}, invoice=${invoice.id}) → balance=${newBalance}`,
+  );
+}
+
+async function handleInvoicePaymentFailed(admin: ServiceClient, invoice: Stripe.Invoice) {
+  const subId = invoiceSubscriptionId(invoice);
+  if (!subId) return;
+
+  // Only set past_due_since if not already set (preserve original failure time)
+  const { data: existing } = await admin
+    .from("subscriptions")
+    .select("past_due_since")
+    .eq("stripe_subscription_id", subId)
+    .maybeSingle();
+
+  if (!existing?.past_due_since) {
+    await admin
+      .from("subscriptions")
+      .update({ past_due_since: new Date().toISOString() })
+      .eq("stripe_subscription_id", subId);
+  }
+}
+
+// =====================================================
+// Sub upsert + side effects
+// =====================================================
+
+async function upsertSubscription(
+  admin: ServiceClient,
+  sub: Stripe.Subscription,
+  { isNew }: { isNew: boolean },
+) {
+  // Plan key comes from metadata set at checkout creation. No fallback — if
+  // metadata is missing, something's wrong with how the sub was created.
+  const planKey = sub.metadata?.plan_key;
+  if (!planKey) {
+    console.error(`[Stripe] No plan_key in metadata for subscription ${sub.id}`);
+    return;
+  }
+  const plan = getPlan(planKey);
+  if (!plan) {
+    console.error(`[Stripe] Unknown plan_key "${planKey}" for subscription ${sub.id}`);
+    return;
+  }
+
+  const item = sub.items.data[0];
+  const priceId = item?.price?.id ?? "";
+  // Stripe v20 reports the actual recurring amount on the SubscriptionItem's price
+  const monthlyCents = item?.price?.unit_amount ?? parseInt(sub.metadata?.monthly_cents ?? "0", 10);
+
+  // Resolve member by Stripe customer ID
+  const customerId = typeof sub.customer === "string" ? sub.customer : sub.customer.id;
+  let { data: member } = await admin
+    .from("members")
+    .select("id, name, day_passes_balance")
+    .eq("stripe_customer_id", customerId)
+    .maybeSingle();
+
+  // Fallback: lookup by metadata.member_id (set in createApprovalCheckoutSession)
+  if (!member && sub.metadata?.member_id) {
+    const memberId = parseInt(sub.metadata.member_id, 10);
+    if (Number.isFinite(memberId)) {
+      const { data: m } = await admin
+        .from("members")
+        .select("id, name, day_passes_balance")
+        .eq("id", memberId)
+        .maybeSingle();
+      if (m) {
+        member = m;
+        // Backfill customer ID
+        await admin
+          .from("members")
+          .update({ stripe_customer_id: customerId })
+          .eq("id", m.id);
+      }
+    }
+  }
+
+  if (!member) {
+    console.error(`[Stripe] No member found for subscription ${sub.id} (customer ${customerId})`);
+    return;
+  }
+
+  // Pull discount snapshot from the originating application (source of truth
+  // for what admin approved). Stripe v20 returns sub.discounts as bare IDs;
+  // we'd have to retrieve each one. The application has the same info.
+  let discountSnapshot: {
+    cents: number | null;
+    duration: "forever" | "repeating" | null;
+    months: number | null;
+    note: string | null;
+  } = { cents: null, duration: null, months: null, note: null };
+  const appIdStr = sub.metadata?.application_id;
+  if (appIdStr) {
+    const appId = parseInt(appIdStr, 10);
+    if (Number.isFinite(appId)) {
+      const { data: app } = await admin
+        .from("applications")
+        .select("discount_cents, discount_duration, discount_months, discount_note")
+        .eq("id", appId)
+        .maybeSingle();
+      if (app) {
+        discountSnapshot = {
+          cents: app.discount_cents,
+          duration: app.discount_duration,
+          months: app.discount_months,
+          note: app.discount_note,
+        };
+      }
+    }
+  }
+
+  const status = sub.status as StripeSubscriptionStatus;
+  // Stripe v20 moved current_period_end to the SubscriptionItem (per-item billing periods)
+  const periodEndUnix = sub.items.data[0]?.current_period_end;
+  const currentPeriodEnd = periodEndUnix ? new Date(periodEndUnix * 1000).toISOString() : null;
+
+  const row = {
+    member_id: member.id,
+    stripe_subscription_id: sub.id,
+    stripe_customer_id: customerId,
+    stripe_price_id: priceId,
+    plan_key: planKey,
+    monthly_cents: monthlyCents,
+    status,
+    current_period_end: currentPeriodEnd,
+    cancel_at_period_end: sub.cancel_at_period_end,
+    canceled_at: sub.canceled_at ? new Date(sub.canceled_at * 1000).toISOString() : null,
+    discount_cents: discountSnapshot.cents,
+    discount_duration: discountSnapshot.duration,
+    discount_months: discountSnapshot.months,
+    discount_note: discountSnapshot.note,
+  };
+
+  await admin.from("subscriptions").upsert(row, { onConflict: "stripe_subscription_id" });
+
+  // Side effects: only grant access when status flips to active/trialing
+  if (isActiveStatus(status)) {
+    // Only update member_type if the plan grants physical access
+    if (plan.grantsMemberType) {
+      await admin
+        .from("members")
+        .update({ member_type: plan.grantsMemberType, disabled: false })
+        .eq("id", member.id);
+    } else {
+      // Digital-only plan — just clear disabled flag
+      await admin.from("members").update({ disabled: false }).eq("id", member.id);
+    }
+
+    // Clear any stale past_due_since on grant
+    await admin
+      .from("subscriptions")
+      .update({ past_due_since: null, access_disabled_at: null })
+      .eq("stripe_subscription_id", sub.id);
+
+    // Mark application complete + announce (only first time)
+    if (isNew && sub.metadata?.application_id) {
+      const appId = parseInt(sub.metadata.application_id, 10);
+      if (Number.isFinite(appId)) {
+        await admin
+          .from("applications")
+          .update({ checkout_completed_at: new Date().toISOString() })
+          .eq("id", appId);
+      }
+      const passesNote =
+        member.day_passes_balance > 0
+          ? ` (${member.day_passes_balance} guest passes carried forward)`
+          : "";
+      await notifyTelegram(
+        `🎉 *New member!*\n\n*${member.name}* is now on ${planLabel(planKey)} ($${monthlyCents / 100}/mo)${passesNote}.`,
+      );
+    }
+  }
 }

--- a/apps/web/src/app/apply/ApplyForm.tsx
+++ b/apps/web/src/app/apply/ApplyForm.tsx
@@ -14,8 +14,10 @@ import regenHubFull from "@/assets/regenhub-full.svg";
 const ACCESS_OPTIONS = [
   { value: "daypass_5pack", label: "5-Pack Day Passes", desc: "Flexible drop-in access — buy a 5-pack and use them whenever you need a desk" },
   { value: "daypass_single", label: "Single Day Passes", desc: "Occasional drop-in access, purchased one at a time" },
-  { value: "hot_desk", label: "Hot Desk Membership", desc: "Regular monthly access — a dedicated place in the community with full membership benefits" },
-  { value: "reserved_desk", label: "Reserved Desk", desc: "Your own dedicated desk, always available, full cooperative membership" },
+  { value: "social_events_1", label: "Social — Events + 1 day/mo ($50/mo)", desc: "Member-only events + 1 day of coworking per month" },
+  { value: "social_events_5", label: "Social — Events + 5 days/mo ($100/mo)", desc: "Member-only events + 5 days of coworking per month" },
+  { value: "hot_desk", label: "Hot Desk Membership ($250/mo)", desc: "Regular monthly access — a dedicated place in the community with full membership benefits" },
+  { value: "reserved_desk", label: "Reserved Desk ($500/mo)", desc: "Your own dedicated desk, always available, full cooperative membership" },
 ] as const;
 
 type Props = {
@@ -31,7 +33,7 @@ export default function ApplyForm({ authenticatedEmail }: Props) {
     telegram: "",
     about: "",
     why_join: "",
-    membership_interest: "daypass_5pack" as "daypass_5pack" | "daypass_single" | "hot_desk" | "reserved_desk",
+    membership_interest: "daypass_5pack" as "daypass_5pack" | "daypass_single" | "hot_desk" | "reserved_desk" | "social_events_1" | "social_events_5",
   });
   const [loading, setLoading] = useState(false);
   const [submitted, setSubmitted] = useState(false);

--- a/apps/web/src/app/portal/page.tsx
+++ b/apps/web/src/app/portal/page.tsx
@@ -3,10 +3,11 @@ import { createClient } from "@/lib/supabase/server";
 import { createServiceClient } from "@/lib/supabase/admin";
 import { Card, CardContent } from "@/components/ui/card";
 import Link from "next/link";
-import { Key, Ticket, User, ClipboardList, CheckCircle, Clock, MessageCircle, Zap, Calendar, Mail } from "lucide-react";
+import { Key, Ticket, User, ClipboardList, CheckCircle, Clock, MessageCircle, Zap, Calendar, ArrowRight, AlertCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import HubEssentials from "@/components/portal/HubEssentials";
 import InviteCard from "@/components/portal/InviteCard";
+import { ManageSubscriptionButton } from "@/components/portal/ManageSubscriptionButton";
 
 export default async function PortalPage() {
   const supabase = await createClient();
@@ -69,6 +70,29 @@ export default async function PortalPage() {
       .limit(1)
       .maybeSingle();
     interestSignup = data;
+  }
+
+  // Look up active subscription (if any) for the manage-subscription CTA
+  let activeSubscription:
+    | {
+        plan_key: string;
+        monthly_cents: number;
+        status: string;
+        cancel_at_period_end: boolean;
+        current_period_end: string | null;
+        past_due_since: string | null;
+      }
+    | null = null;
+  if (member) {
+    const { data } = await supabase
+      .from("subscriptions")
+      .select("plan_key, monthly_cents, status, cancel_at_period_end, current_period_end, past_due_since")
+      .eq("member_id", member.id)
+      .in("status", ["active", "trialing", "past_due"])
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    activeSubscription = data;
   }
 
   if (!member) {
@@ -229,24 +253,80 @@ export default async function PortalPage() {
         {member.is_coop_member && <InviteCard />}
       </div>
 
-      {/* Membership upgrade prompt for day_pass members */}
-      {!isFullMember && (
+      {/* Subscription management — shown for ANY active sub (desk or social tiers) */}
+      {activeSubscription && (
+        <Card className="glass-panel border border-sage/20">
+          <CardContent className="p-6">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+              <div>
+                <h3 className="font-semibold mb-1">
+                  Membership
+                  {activeSubscription.plan_key && (
+                    <span className="text-muted font-normal ml-2 text-sm">
+                      ·{" "}
+                      {activeSubscription.plan_key === "cold_desk" ? "Cold Desk"
+                        : activeSubscription.plan_key === "hot_desk" ? "Hot Desk"
+                        : activeSubscription.plan_key === "social_events_1" ? "Social — Events + 1 day/mo"
+                        : activeSubscription.plan_key === "social_events_5" ? "Social — Events + 5 days/mo"
+                        : activeSubscription.plan_key}
+                      {" · "}${activeSubscription.monthly_cents / 100}/mo
+                    </span>
+                  )}
+                </h3>
+                {activeSubscription.cancel_at_period_end && activeSubscription.current_period_end && (
+                  <p className="text-sm text-amber-400 flex items-center gap-1.5">
+                    <AlertCircle className="w-4 h-4" />
+                    Cancelling on{" "}
+                    {new Date(activeSubscription.current_period_end).toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                    })}
+                  </p>
+                )}
+                {activeSubscription.status === "past_due" && (
+                  <p className="text-sm text-red-400 flex items-center gap-1.5">
+                    <AlertCircle className="w-4 h-4" />
+                    Payment failed — update your card to keep access
+                  </p>
+                )}
+                {!activeSubscription.cancel_at_period_end && activeSubscription.status !== "past_due" && (
+                  <p className="text-sm text-muted">
+                    Renews{" "}
+                    {activeSubscription.current_period_end
+                      ? new Date(activeSubscription.current_period_end).toLocaleDateString("en-US", {
+                          month: "short",
+                          day: "numeric",
+                        })
+                      : "monthly"}
+                  </p>
+                )}
+              </div>
+              <ManageSubscriptionButton />
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Upgrade prompt only for day_pass members WITHOUT an active sub
+          (free/intro users — paying social members shouldn't see "apply") */}
+      {!isFullMember && !activeSubscription && (
         <Card className="glass-panel border border-forest/20">
           <CardContent className="p-6">
             <div className="flex items-start gap-4">
               <Key className="w-7 h-7 text-sage shrink-0 mt-0.5" />
               <div>
-                <h3 className="font-semibold mb-1">Want your own desk?</h3>
+                <h3 className="font-semibold mb-1">Ready for a permanent desk?</h3>
                 <p className="text-sm text-muted mb-3">
-                  Desk members get a permanent door code, 24/7 access, and a path to co-op ownership.
-                  Desks are $250/month.
+                  Members get a permanent door code, 24/7 access, and a path to co-op ownership.
+                  Hot Desk is $250/month, Cold Desk (reserved) is $500/month.
                 </p>
-                <a href="mailto:boulder.regenhub@gmail.com?subject=Interested in desk membership">
+                <Link href="/freeday">
                   <Button className="btn-glass gap-2 text-sm">
-                    <Mail className="w-4 h-4" />
-                    Inquire about membership
+                    Apply for membership
+                    <ArrowRight className="w-4 h-4" />
                   </Button>
-                </a>
+                </Link>
               </div>
             </div>
           </CardContent>

--- a/apps/web/src/app/portal/passes/page.tsx
+++ b/apps/web/src/app/portal/passes/page.tsx
@@ -4,8 +4,9 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { RequestDayPassButton } from "@/components/portal/RequestDayPassButton";
 import { RevokeCodeButton } from "@/components/portal/RevokeCodeButton";
-import { Ticket, Clock, ShoppingCart, Key, Mail } from "lucide-react";
+import { Ticket, Clock, ShoppingCart, Key, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import Link from "next/link";
 
 export const metadata = { title: "Live Codes — RegenHub" };
 
@@ -200,14 +201,14 @@ export default async function PassesPage() {
                 <h3 className="font-semibold mb-1">Ready for your own desk?</h3>
                 <p className="text-sm text-muted mb-4">
                   Desk members get a permanent door code, 24/7 access, and a path to co-op ownership.
-                  Desks are $250/month.
+                  Hot Desk is $250/month, Cold Desk (reserved) is $500/month.
                 </p>
-                <a href="mailto:boulder.regenhub@gmail.com?subject=Interested in desk membership">
+                <Link href="/freeday">
                   <Button className="btn-glass gap-2 text-sm">
-                    <Mail className="w-4 h-4" />
-                    Inquire about membership
+                    Apply for membership
+                    <ArrowRight className="w-4 h-4" />
                   </Button>
-                </a>
+                </Link>
               </div>
             </div>
           </CardContent>

--- a/apps/web/src/components/admin/ApplicationActions.tsx
+++ b/apps/web/src/components/admin/ApplicationActions.tsx
@@ -3,113 +3,342 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import { Check, X, MessageSquare } from "lucide-react";
-import type { ApplicationStatus } from "@/lib/supabase/types";
+import { Check, X, MessageSquare, Copy, ExternalLink, Loader2, Tag } from "lucide-react";
+import type { Application, ApplicationStatus } from "@/lib/supabase/types";
 
-interface Props {
-  applicationId: number;
-  currentStatus: ApplicationStatus;
-  adminNotes: string | null;
-}
+// Plan catalog — keep in sync with apps/web/src/lib/stripe.ts PLANS.
+// Mirrored here so the admin UI doesn't have to import server-only code.
+const APPROVABLE_PLANS = [
+  { key: "cold_desk",       label: "Cold Desk",                       defaultDollars: 500 },
+  { key: "hot_desk",        label: "Hot Desk",                        defaultDollars: 250 },
+  { key: "social_events_5", label: "Social — Events + 5 days/mo",     defaultDollars: 100 },
+  { key: "social_events_1", label: "Social — Events + 1 day/mo",      defaultDollars: 50 },
+] as const;
 
-export function ApplicationActions({ applicationId, currentStatus, adminNotes }: Props) {
+type DurationChoice = "forever" | "repeating";
+
+export function ApplicationActions({ application }: { application: Application }) {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [showNotes, setShowNotes] = useState(false);
-  const [notes, setNotes] = useState(adminNotes ?? "");
+  const [notes, setNotes] = useState(application.admin_notes ?? "");
+  const [showApprove, setShowApprove] = useState(false);
+  const [planKey, setPlanKey] = useState<string>(APPROVABLE_PLANS[0].key);
+  const [monthlyDollars, setMonthlyDollars] = useState<string>(String(APPROVABLE_PLANS[0].defaultDollars));
+  const [discountNote, setDiscountNote] = useState("");
+  const [showPromo, setShowPromo] = useState(false);
+  const [promoDollars, setPromoDollars] = useState("");
+  const [promoDuration, setPromoDuration] = useState<DurationChoice>("repeating");
+  const [promoMonths, setPromoMonths] = useState("3");
+  const [copied, setCopied] = useState(false);
 
-  async function updateStatus(status: ApplicationStatus) {
-    setBusy(true);
-    try {
-      const res = await fetch("/api/admin/applications", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id: applicationId, status }),
-      });
-      if (res.ok) router.refresh();
-    } finally {
-      setBusy(false);
-    }
+  function selectPlan(key: string) {
+    setPlanKey(key);
+    const found = APPROVABLE_PLANS.find((p) => p.key === key);
+    if (found) setMonthlyDollars(String(found.defaultDollars));
   }
 
-  async function saveNotes() {
+  async function patch(body: Record<string, unknown>) {
     setBusy(true);
+    setError(null);
     try {
       const res = await fetch("/api/admin/applications", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id: applicationId, admin_notes: notes }),
+        body: JSON.stringify({ id: application.id, ...body }),
       });
       if (res.ok) {
-        setShowNotes(false);
         router.refresh();
+        return true;
       }
+      const data = await res.json().catch(() => null);
+      setError(data?.error ?? "Request failed");
+      return false;
     } finally {
       setBusy(false);
     }
   }
 
+  async function reject() { await patch({ status: "rejected" }); }
+  async function revertToPending() { await patch({ status: "pending" }); }
+  async function saveNotes() {
+    const ok = await patch({ admin_notes: notes });
+    if (ok) setShowNotes(false);
+  }
+
+  async function submitApprove() {
+    setBusy(true);
+    setError(null);
+    try {
+      const monthlyCents = Math.round((parseFloat(monthlyDollars || "0") || 0) * 100);
+      if (monthlyCents < 100) {
+        setError("Monthly amount must be at least $1");
+        return;
+      }
+      const promoCents = showPromo ? Math.round((parseFloat(promoDollars || "0") || 0) * 100) : 0;
+      const res = await fetch(`/api/admin/applications/${application.id}/approve`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          plan_key: planKey,
+          monthly_cents: monthlyCents,
+          discount_cents: promoCents > 0 ? promoCents : undefined,
+          discount_duration: promoCents > 0 ? promoDuration : undefined,
+          discount_months: promoCents > 0 && promoDuration === "repeating" ? parseInt(promoMonths, 10) : undefined,
+          discount_note: discountNote.trim() || undefined,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        setError(data?.error ?? "Failed to approve");
+        return;
+      }
+      setShowApprove(false);
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function copyLink() {
+    if (!application.stripe_checkout_url) return;
+    await navigator.clipboard.writeText(application.stripe_checkout_url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  const status: ApplicationStatus = application.status;
+  const checkoutUrl = application.stripe_checkout_url;
+  const checkoutCompleted = !!application.checkout_completed_at;
+
   return (
-    <div className="flex items-center gap-1.5 flex-wrap">
-      {currentStatus === "pending" && (
-        <>
+    <div className="space-y-2">
+      <div className="flex items-center gap-1.5 flex-wrap">
+        {status === "pending" && (
+          <>
+            <Button
+              size="sm"
+              disabled={busy}
+              onClick={() => setShowApprove(!showApprove)}
+              className="bg-emerald-600/20 hover:bg-emerald-600/40 text-emerald-400 border border-emerald-500/30 text-xs gap-1 h-7 px-2"
+            >
+              <Check className="w-3 h-3" /> Approve
+            </Button>
+            <Button
+              size="sm"
+              disabled={busy}
+              onClick={reject}
+              className="bg-red-600/20 hover:bg-red-600/40 text-red-400 border border-red-500/30 text-xs gap-1 h-7 px-2"
+            >
+              <X className="w-3 h-3" /> Reject
+            </Button>
+          </>
+        )}
+        {(status === "approved" || status === "rejected") && (
           <Button
             size="sm"
             disabled={busy}
-            onClick={() => updateStatus("approved")}
-            className="bg-emerald-600/20 hover:bg-emerald-600/40 text-emerald-400 border border-emerald-500/30 text-xs gap-1 h-7 px-2"
+            onClick={revertToPending}
+            className="btn-glass text-xs h-7 px-2"
           >
-            <Check className="w-3 h-3" /> Approve
+            Revert to Pending
           </Button>
-          <Button
-            size="sm"
-            disabled={busy}
-            onClick={() => updateStatus("rejected")}
-            className="bg-red-600/20 hover:bg-red-600/40 text-red-400 border border-red-500/30 text-xs gap-1 h-7 px-2"
-          >
-            <X className="w-3 h-3" /> Reject
-          </Button>
-        </>
-      )}
-      {currentStatus === "approved" && (
+        )}
+
         <Button
           size="sm"
-          disabled={busy}
-          onClick={() => updateStatus("pending")}
-          className="btn-glass text-xs h-7 px-2"
+          variant="ghost"
+          onClick={() => setShowNotes(!showNotes)}
+          className="text-muted hover:text-foreground text-xs h-7 px-2 gap-1"
         >
-          Revert to Pending
+          <MessageSquare className="w-3 h-3" />
+          {application.admin_notes ? "Edit Notes" : "Notes"}
         </Button>
-      )}
-      {currentStatus === "rejected" && (
-        <Button
-          size="sm"
-          disabled={busy}
-          onClick={() => updateStatus("pending")}
-          className="btn-glass text-xs h-7 px-2"
-        >
-          Revert to Pending
-        </Button>
+      </div>
+
+      {/* Approval modal — inline panel */}
+      {showApprove && status === "pending" && (
+        <div className="glass-panel p-4 space-y-3 border border-emerald-500/20">
+          <div>
+            <p className="text-xs text-muted mb-1.5 font-medium">Plan</p>
+            <div className="flex gap-2 flex-wrap">
+              {APPROVABLE_PLANS.map((p) => (
+                <button
+                  key={p.key}
+                  type="button"
+                  onClick={() => selectPlan(p.key)}
+                  className={`px-3 py-1.5 rounded text-xs border ${
+                    planKey === p.key
+                      ? "bg-sage/20 border-sage/50 text-sage"
+                      : "bg-white/5 border-white/10 text-muted hover:bg-white/10"
+                  }`}
+                >
+                  {p.label} · ${p.defaultDollars}/mo
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <p className="text-xs text-muted mb-1.5 font-medium">Monthly rate</p>
+            <div className="flex items-center gap-1">
+              <span className="text-sm text-muted">$</span>
+              <input
+                type="number"
+                min="1"
+                step="1"
+                value={monthlyDollars}
+                onChange={(e) => setMonthlyDollars(e.target.value)}
+                className="w-24 bg-white/5 border border-white/10 rounded px-2 py-1 text-sm focus:outline-none focus:border-sage/50"
+              />
+              <span className="text-sm text-muted">/ month</span>
+            </div>
+            <p className="text-xs text-muted mt-1">
+              Set whatever they should pay — discounts are baked into the rate.
+            </p>
+          </div>
+
+          <div>
+            <p className="text-xs text-muted mb-1.5 font-medium">Note (admin-only)</p>
+            <input
+              type="text"
+              value={discountNote}
+              onChange={(e) => setDiscountNote(e.target.value)}
+              placeholder="e.g. Founder rate, Friend of co-op"
+              className="w-full bg-white/5 border border-white/10 rounded px-2 py-1 text-sm focus:outline-none focus:border-sage/50"
+            />
+          </div>
+
+          <div>
+            <button
+              type="button"
+              onClick={() => setShowPromo(!showPromo)}
+              className="text-xs text-muted hover:text-foreground flex items-center gap-1"
+            >
+              <Tag className="w-3 h-3" />
+              {showPromo ? "Remove time-bounded promo" : "+ Add time-bounded promo (e.g. first month free)"}
+            </button>
+            {showPromo && (
+              <div className="mt-2 flex flex-wrap items-center gap-2">
+                <div className="flex items-center gap-1">
+                  <span className="text-xs text-muted">$</span>
+                  <input
+                    type="number"
+                    min="0"
+                    value={promoDollars}
+                    onChange={(e) => setPromoDollars(e.target.value)}
+                    placeholder="0"
+                    className="w-20 bg-white/5 border border-white/10 rounded px-2 py-1 text-sm focus:outline-none focus:border-sage/50"
+                  />
+                  <span className="text-xs text-muted">off</span>
+                </div>
+                <select
+                  value={promoDuration}
+                  onChange={(e) => setPromoDuration(e.target.value as DurationChoice)}
+                  className="bg-white/5 border border-white/10 rounded px-2 py-1 text-sm focus:outline-none focus:border-sage/50"
+                >
+                  <option value="repeating">for N months</option>
+                  <option value="forever">forever</option>
+                </select>
+                {promoDuration === "repeating" && (
+                  <div className="flex items-center gap-1">
+                    <input
+                      type="number"
+                      min="1"
+                      value={promoMonths}
+                      onChange={(e) => setPromoMonths(e.target.value)}
+                      className="w-14 bg-white/5 border border-white/10 rounded px-2 py-1 text-sm focus:outline-none focus:border-sage/50"
+                    />
+                    <span className="text-xs text-muted">mo</span>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              disabled={busy}
+              onClick={submitApprove}
+              className="bg-emerald-600/20 hover:bg-emerald-600/40 text-emerald-400 border border-emerald-500/30 text-xs gap-1 h-7"
+            >
+              {busy ? <Loader2 className="w-3 h-3 animate-spin" /> : <Check className="w-3 h-3" />}
+              Generate Checkout Link
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={busy}
+              onClick={() => setShowApprove(false)}
+              className="text-muted text-xs h-7"
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
       )}
 
-      <Button
-        size="sm"
-        variant="ghost"
-        onClick={() => setShowNotes(!showNotes)}
-        className="text-muted hover:text-foreground text-xs h-7 px-2 gap-1"
-      >
-        <MessageSquare className="w-3 h-3" />
-        {adminNotes ? "Edit Notes" : "Notes"}
-      </Button>
+      {/* Checkout link surface for approved apps */}
+      {status === "approved" && checkoutUrl && (
+        <div className="glass-panel p-3 border border-sage/20 space-y-2">
+          <div className="flex items-center justify-between gap-2 flex-wrap">
+            <div className="text-xs">
+              <span className="text-muted">Checkout link · </span>
+              <span className="text-sage font-medium">
+                {APPROVABLE_PLANS.find((p) => p.key === application.approved_plan_key)?.label
+                  ?? application.approved_plan_key
+                  ?? "—"}
+              </span>
+              {application.approved_monthly_cents != null && (
+                <span className="text-foreground ml-1">
+                  · ${application.approved_monthly_cents / 100}/mo
+                </span>
+              )}
+              {application.discount_cents != null && application.discount_cents > 0 && (
+                <span className="text-amber-400 ml-1">
+                  · ${application.discount_cents / 100} off
+                  {application.discount_duration === "repeating"
+                    ? ` × ${application.discount_months}mo`
+                    : " forever"}
+                </span>
+              )}
+              {application.discount_note && (
+                <span className="text-muted ml-1">· {application.discount_note}</span>
+              )}
+            </div>
+            {checkoutCompleted && (
+              <span className="text-xs text-emerald-400">✓ Completed</span>
+            )}
+          </div>
+          {!checkoutCompleted && (
+            <div className="flex gap-1.5">
+              <Button
+                size="sm"
+                onClick={copyLink}
+                className="btn-glass text-xs h-7 gap-1"
+              >
+                <Copy className="w-3 h-3" /> {copied ? "Copied!" : "Copy link"}
+              </Button>
+              <a href={checkoutUrl} target="_blank" rel="noopener noreferrer">
+                <Button size="sm" className="btn-glass text-xs h-7 gap-1">
+                  <ExternalLink className="w-3 h-3" /> Open
+                </Button>
+              </a>
+            </div>
+          )}
+        </div>
+      )}
 
       {showNotes && (
-        <div className="w-full mt-2 flex gap-2">
+        <div className="flex gap-2">
           <input
             type="text"
             value={notes}
             onChange={(e) => setNotes(e.target.value)}
             placeholder="Internal notes..."
-            className="flex-1 bg-white/5 border border-white/10 rounded px-2 py-1 text-sm text-foreground placeholder:text-muted focus:outline-none focus:border-sage/50"
+            className="flex-1 bg-white/5 border border-white/10 rounded px-2 py-1 text-sm placeholder:text-muted focus:outline-none focus:border-sage/50"
           />
           <Button
             size="sm"
@@ -121,6 +350,8 @@ export function ApplicationActions({ applicationId, currentStatus, adminNotes }:
           </Button>
         </div>
       )}
+
+      {error && <p className="text-xs text-red-400">{error}</p>}
     </div>
   );
 }

--- a/apps/web/src/components/admin/ApplicationsFilter.tsx
+++ b/apps/web/src/components/admin/ApplicationsFilter.tsx
@@ -10,6 +10,8 @@ import type { Application, ApplicationStatus } from "@/lib/supabase/types";
 const interestLabels: Record<string, string> = {
   daypass_single: "Day Pass",
   daypass_5pack: "5-Pack",
+  social_events_1: "Social · 1 day/mo",
+  social_events_5: "Social · 5 days/mo",
   hot_desk: "Hot Desk",
   reserved_desk: "Reserved Desk",
   community: "Community",
@@ -145,11 +147,7 @@ export function ApplicationsFilter({ applications }: { applications: Application
                 </p>
               )}
 
-              <ApplicationActions
-                applicationId={app.id}
-                currentStatus={app.status}
-                adminNotes={app.admin_notes}
-              />
+              <ApplicationActions application={app} />
             </div>
           ))}
         </div>

--- a/apps/web/src/components/admin/SubscriptionCard.tsx
+++ b/apps/web/src/components/admin/SubscriptionCard.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { CreditCard, Ban, Loader2 } from "lucide-react";
+import type { Subscription, Purchase } from "@/lib/supabase/types";
+
+interface Props {
+  memberId: number;
+  memberName: string;
+  activeSubscription: Subscription | null;
+  recentPurchases: Purchase[];
+}
+
+const statusStyle: Record<string, string> = {
+  active: "bg-emerald-500/20 text-emerald-400 border-emerald-500/30",
+  trialing: "bg-sky-500/20 text-sky-400 border-sky-500/30",
+  past_due: "bg-red-500/20 text-red-400 border-red-500/30",
+  canceled: "bg-white/10 text-muted border-white/20",
+};
+
+function fmtDate(iso: string | null) {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString("en-US", {
+    timeZone: "America/Denver",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function SubscriptionCard({ memberId, memberName, activeSubscription, recentPurchases }: Props) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showRevoke, setShowRevoke] = useState(false);
+  const [refundLast, setRefundLast] = useState(true);
+
+  async function revoke() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/members/${memberId}/revoke`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refund_last_purchase: refundLast }),
+      });
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        setError(data?.error ?? "Failed to revoke");
+        return;
+      }
+      setShowRevoke(false);
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card className="glass-panel">
+      <CardContent className="p-6 space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <CreditCard className="w-5 h-5 text-sage" />
+            <h3 className="font-semibold">Billing</h3>
+          </div>
+          <Button
+            size="sm"
+            onClick={() => setShowRevoke(!showRevoke)}
+            className="bg-red-600/20 hover:bg-red-600/40 text-red-400 border border-red-500/30 text-xs gap-1 h-7"
+          >
+            <Ban className="w-3 h-3" /> Revoke access
+          </Button>
+        </div>
+
+        {activeSubscription ? (
+          <div className="space-y-2 text-sm">
+            <div className="flex items-center gap-2 flex-wrap">
+              <Badge className={`text-xs ${statusStyle[activeSubscription.status] ?? "border-white/20"}`}>
+                {activeSubscription.status}
+              </Badge>
+              <span className="text-muted">·</span>
+              <span>
+                {activeSubscription.plan_key === "cold_desk" ? "Cold Desk"
+                  : activeSubscription.plan_key === "hot_desk" ? "Hot Desk"
+                  : activeSubscription.plan_key}
+              </span>
+              <span className="text-muted">·</span>
+              <span className="text-foreground">${activeSubscription.monthly_cents / 100}/mo</span>
+              {activeSubscription.cancel_at_period_end && (
+                <Badge className="text-xs bg-amber-500/20 text-amber-400 border-amber-500/30">
+                  cancels {fmtDate(activeSubscription.current_period_end)}
+                </Badge>
+              )}
+            </div>
+            {activeSubscription.discount_cents != null && activeSubscription.discount_cents > 0 && (
+              <p className="text-xs text-muted">
+                Time-bounded promo: ${activeSubscription.discount_cents / 100} off{" "}
+                {activeSubscription.discount_duration === "repeating"
+                  ? `× ${activeSubscription.discount_months}mo`
+                  : "forever"}
+                {activeSubscription.discount_note && ` · ${activeSubscription.discount_note}`}
+              </p>
+            )}
+            <p className="text-xs text-muted">
+              Next renewal: {fmtDate(activeSubscription.current_period_end)}
+            </p>
+            {activeSubscription.past_due_since && (
+              <p className="text-xs text-red-400">
+                Past due since {fmtDate(activeSubscription.past_due_since)}
+              </p>
+            )}
+          </div>
+        ) : (
+          <p className="text-sm text-muted">No active subscription.</p>
+        )}
+
+        {recentPurchases.length > 0 && (
+          <div className="pt-3 border-t border-white/10">
+            <p className="text-xs text-muted mb-2 font-medium">Recent purchases</p>
+            <ul className="text-xs space-y-1">
+              {recentPurchases.map((p) => (
+                <li key={p.id} className="flex justify-between gap-2">
+                  <span>
+                    {p.kind === "five_pack" ? "5-Pack" : "Day Pass"} · ${p.amount_cents / 100}
+                  </span>
+                  <span className="text-muted">{fmtDate(p.created_at)}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {showRevoke && (
+          <div className="glass-panel p-3 border border-red-500/20 space-y-2">
+            <p className="text-sm">
+              Revoke <span className="font-semibold">{memberName}</span>&apos;s access?
+              This sets <code>disabled = true</code> on the member record.
+              {activeSubscription && (
+                <span className="text-muted"> The active subscription will need to be cancelled separately in Stripe.</span>
+              )}
+            </p>
+            {recentPurchases.length > 0 && (
+              <label className="flex items-center gap-2 text-xs">
+                <input
+                  type="checkbox"
+                  checked={refundLast}
+                  onChange={(e) => setRefundLast(e.target.checked)}
+                />
+                Also refund their most recent purchase
+                ({recentPurchases[0].kind === "five_pack" ? "5-Pack" : "Day Pass"} · $
+                {recentPurchases[0].amount_cents / 100})
+              </label>
+            )}
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                disabled={busy}
+                onClick={revoke}
+                className="bg-red-600/20 hover:bg-red-600/40 text-red-400 border border-red-500/30 text-xs gap-1 h-7"
+              >
+                {busy ? <Loader2 className="w-3 h-3 animate-spin" /> : <Ban className="w-3 h-3" />}
+                Confirm revoke
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={busy}
+                onClick={() => setShowRevoke(false)}
+                className="text-muted text-xs h-7"
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {error && <p className="text-xs text-red-400">{error}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/portal/ManageSubscriptionButton.tsx
+++ b/apps/web/src/components/portal/ManageSubscriptionButton.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { CreditCard, Loader2 } from "lucide-react";
+
+export function ManageSubscriptionButton() {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function open() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/portal/billing-portal", { method: "POST" });
+      const data = await res.json().catch(() => null);
+      if (!res.ok || !data?.url) {
+        setError(data?.error ?? "Could not open billing portal");
+        return;
+      }
+      window.location.href = data.url as string;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <Button onClick={open} disabled={busy} className="btn-glass gap-2 text-sm">
+        {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <CreditCard className="w-4 h-4" />}
+        Manage subscription
+      </Button>
+      {error && <p className="text-xs text-red-400 mt-2">{error}</p>}
+    </>
+  );
+}

--- a/apps/web/src/lib/stripe.ts
+++ b/apps/web/src/lib/stripe.ts
@@ -1,0 +1,223 @@
+import Stripe from "stripe";
+import type { Member, PlanKey, MemberType, DiscountDuration } from "./supabase/types";
+
+let stripeClient: Stripe | null = null;
+
+export function getStripe(): Stripe {
+  if (!stripeClient) {
+    const key = process.env.STRIPE_SECRET_KEY;
+    if (!key) throw new Error("STRIPE_SECRET_KEY is not set");
+    stripeClient = new Stripe(key);
+  }
+  return stripeClient;
+}
+
+export function isStripeConfigured(): boolean {
+  const key = process.env.STRIPE_SECRET_KEY;
+  return !!key && key.startsWith("sk_");
+}
+
+/**
+ * Membership plan catalog.
+ *
+ * Each plan defines:
+ *   - label:                   human-readable name (UI + Stripe descriptor)
+ *   - defaultMonthlyCents:     default monthly rate (admin can override per-person)
+ *   - grantsMemberType:        what `members.member_type` becomes when this is active
+ *                              (null = digital-only, doesn't affect physical access)
+ *   - productIdEnvKey:         OPTIONAL — if set, all subs for this plan attach to this
+ *                              Stripe Product for dashboard grouping. If unset, Stripe
+ *                              auto-creates a product per subscription using `label`.
+ *   - monthlyDayPasses:        OPTIONAL — for future social tiers that grant N day passes
+ *                              per billing cycle (not yet wired into the renewal job)
+ *
+ * Adding a new plan = adding an entry here. No DB migration needed.
+ */
+export const PLANS = {
+  cold_desk: {
+    label: "Cold Desk",
+    defaultMonthlyCents: 50000,
+    grantsMemberType: "cold_desk" as MemberType,
+    productIdEnvKey: "STRIPE_PRODUCT_COLD_DESK",
+  },
+  hot_desk: {
+    label: "Hot Desk",
+    defaultMonthlyCents: 25000,
+    grantsMemberType: "hot_desk" as MemberType,
+    productIdEnvKey: "STRIPE_PRODUCT_HOT_DESK",
+  },
+  social_events_1: {
+    label: "Social — Events + 1 day/mo",
+    defaultMonthlyCents: 5000,
+    grantsMemberType: "day_pass" as MemberType,
+    productIdEnvKey: "STRIPE_PRODUCT_SOCIAL_EVENTS_1",
+    monthlyDayPasses: 1,
+  },
+  social_events_5: {
+    label: "Social — Events + 5 days/mo",
+    defaultMonthlyCents: 10000,
+    grantsMemberType: "day_pass" as MemberType,
+    productIdEnvKey: "STRIPE_PRODUCT_SOCIAL_EVENTS_5",
+    monthlyDayPasses: 5,
+  },
+  // Future: social_forums (~$20/mo, online-only, grantsMemberType: null)
+} as const satisfies Record<
+  string,
+  {
+    label: string;
+    defaultMonthlyCents: number;
+    grantsMemberType: MemberType | null;
+    productIdEnvKey?: string;
+    monthlyDayPasses?: number;
+  }
+>;
+
+export type KnownPlanKey = keyof typeof PLANS;
+
+export interface PlanDef {
+  label: string;
+  defaultMonthlyCents: number;
+  grantsMemberType: MemberType | null;
+  productIdEnvKey?: string;
+  monthlyDayPasses?: number;
+}
+
+export function getPlan(planKey: PlanKey): PlanDef | null {
+  return (PLANS as Record<string, PlanDef | undefined>)[planKey] ?? null;
+}
+
+export function planLabel(planKey: PlanKey): string {
+  return getPlan(planKey)?.label ?? planKey;
+}
+
+export function formatCents(cents: number): string {
+  return `$${(cents / 100).toFixed(0)}`;
+}
+
+/**
+ * Find or create the Stripe customer for a member.
+ * Caller is responsible for persisting `customer.id` back to members.stripe_customer_id.
+ */
+export async function getOrCreateCustomer(
+  member: Pick<Member, "id" | "name" | "email" | "stripe_customer_id">,
+): Promise<Stripe.Customer> {
+  const stripe = getStripe();
+
+  if (member.stripe_customer_id) {
+    const existing = await stripe.customers.retrieve(member.stripe_customer_id);
+    if (!existing.deleted) return existing as Stripe.Customer;
+    // If deleted in Stripe, fall through and create a new one.
+  }
+
+  return stripe.customers.create({
+    email: member.email ?? undefined,
+    name: member.name,
+    metadata: { member_id: String(member.id) },
+  });
+}
+
+export interface ApprovalCheckoutInput {
+  application_id: number;
+  member: Pick<Member, "id" | "name" | "email" | "stripe_customer_id">;
+  planKey: PlanKey;
+  monthlyCents: number;
+  // OPTIONAL time-bounded promo (rate adjustments should be baked into monthlyCents instead)
+  discountCents?: number | null;
+  discountDuration?: DiscountDuration | null;
+  discountMonths?: number | null;
+  discountNote?: string | null;
+  successUrl: string;
+  cancelUrl: string;
+}
+
+/**
+ * Create a Stripe Checkout Session for a recurring membership.
+ *
+ * Pricing is dynamic: we pass `price_data` inline rather than referencing
+ * a pre-defined Stripe Price. This means adding new plans (or charging
+ * per-person rates) requires no Stripe Dashboard setup beyond an
+ * optional Product for analytics grouping.
+ *
+ * For time-bounded promos (e.g. "first 3 months free"), pass discount* args
+ * and a one-off Coupon is created and attached.
+ */
+export async function createApprovalCheckoutSession(
+  input: ApprovalCheckoutInput,
+): Promise<{ session: Stripe.Checkout.Session; customer: Stripe.Customer; couponId?: string }> {
+  const stripe = getStripe();
+  const plan = getPlan(input.planKey);
+  if (!plan) throw new Error(`Unknown plan_key: ${input.planKey}`);
+
+  const customer = await getOrCreateCustomer(input.member);
+
+  let couponId: string | undefined;
+  if (input.discountCents && input.discountCents > 0) {
+    const duration = input.discountDuration ?? "forever";
+    const coupon = await stripe.coupons.create({
+      amount_off: input.discountCents,
+      currency: "usd",
+      duration,
+      ...(duration === "repeating" && input.discountMonths
+        ? { duration_in_months: input.discountMonths }
+        : {}),
+      name: input.discountNote ?? `Promo for ${input.member.name}`,
+      metadata: {
+        member_id: String(input.member.id),
+        application_id: String(input.application_id),
+      },
+    });
+    couponId = coupon.id;
+  }
+
+  // Resolve optional product ID for dashboard grouping
+  const productId = plan.productIdEnvKey ? process.env[plan.productIdEnvKey] : undefined;
+
+  const priceData: Stripe.Checkout.SessionCreateParams.LineItem.PriceData = {
+    currency: "usd",
+    unit_amount: input.monthlyCents,
+    recurring: { interval: "month" },
+    ...(productId
+      ? { product: productId }
+      : { product_data: { name: plan.label } }),
+  };
+
+  const session = await stripe.checkout.sessions.create({
+    mode: "subscription",
+    customer: customer.id,
+    client_reference_id: String(input.application_id),
+    line_items: [{ price_data: priceData, quantity: 1 }],
+    ...(couponId ? { discounts: [{ coupon: couponId }] } : {}),
+    metadata: {
+      application_id: String(input.application_id),
+      member_id: String(input.member.id),
+      plan_key: input.planKey,
+      monthly_cents: String(input.monthlyCents),
+    },
+    subscription_data: {
+      metadata: {
+        application_id: String(input.application_id),
+        member_id: String(input.member.id),
+        plan_key: input.planKey,
+        monthly_cents: String(input.monthlyCents),
+        ...(input.discountNote ? { discount_note: input.discountNote } : {}),
+      },
+    },
+    success_url: input.successUrl,
+    cancel_url: input.cancelUrl,
+    allow_promotion_codes: false,
+  });
+
+  return { session, customer, couponId };
+}
+
+export async function createCustomerPortalSession(
+  member: Pick<Member, "id" | "name" | "email" | "stripe_customer_id">,
+  returnUrl: string,
+): Promise<Stripe.BillingPortal.Session> {
+  const stripe = getStripe();
+  const customer = await getOrCreateCustomer(member);
+  return stripe.billingPortal.sessions.create({
+    customer: customer.id,
+    return_url: returnUrl,
+  });
+}

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -1,7 +1,30 @@
 export type MemberType = "cold_desk" | "hot_desk" | "hub_friend" | "day_pass";
 export type ApplicationStatus = "pending" | "approved" | "rejected";
-export type MembershipInterest = "daypass_single" | "daypass_5pack" | "hot_desk" | "reserved_desk";
+export type MembershipInterest =
+  | "daypass_single"
+  | "daypass_5pack"
+  | "hot_desk"
+  | "reserved_desk"
+  | "social_events_1"
+  | "social_events_5";
 export type AccessMethod = "nfc" | "pin" | "daycode";
+// Free text — concrete plan keys live in apps/web/src/lib/stripe.ts PLANS.
+// Typed as string here so adding new plans (social, events, etc.) doesn't
+// require touching the DB schema or this file.
+export type PlanKey = string;
+export type DiscountDuration = "forever" | "repeating";
+export type PurchaseKind = "day_pass" | "five_pack";
+
+// Mirrors Stripe.Subscription.Status verbatim
+export type StripeSubscriptionStatus =
+  | "active"
+  | "past_due"
+  | "canceled"
+  | "incomplete"
+  | "incomplete_expired"
+  | "trialing"
+  | "unpaid"
+  | "paused";
 
 export interface Database {
   public: {
@@ -17,6 +40,16 @@ export interface Database {
           membership_interest: MembershipInterest;
           status: ApplicationStatus;
           admin_notes: string | null;
+          approved_plan_key: PlanKey | null;
+          approved_monthly_cents: number | null;
+          discount_cents: number | null;
+          discount_duration: DiscountDuration | null;
+          discount_months: number | null;
+          discount_note: string | null;
+          stripe_checkout_session_id: string | null;
+          stripe_checkout_url: string | null;
+          checkout_sent_at: string | null;
+          checkout_completed_at: string | null;
           created_at: string;
           updated_at: string;
         };
@@ -29,6 +62,16 @@ export interface Database {
           membership_interest?: MembershipInterest;
           status?: ApplicationStatus;
           admin_notes?: string | null;
+          approved_plan_key?: PlanKey | null;
+          approved_monthly_cents?: number | null;
+          discount_cents?: number | null;
+          discount_duration?: DiscountDuration | null;
+          discount_months?: number | null;
+          discount_note?: string | null;
+          stripe_checkout_session_id?: string | null;
+          stripe_checkout_url?: string | null;
+          checkout_sent_at?: string | null;
+          checkout_completed_at?: string | null;
         };
         Update: Partial<Database["public"]["Tables"]["applications"]["Insert"]>;
         Relationships: [];
@@ -53,6 +96,7 @@ export interface Database {
           skills: string[] | null;
           profile_photo_url: string | null;
           show_in_directory: boolean;
+          stripe_customer_id: string | null;
           created_at: string;
           updated_at: string;
         };
@@ -74,6 +118,7 @@ export interface Database {
           bio?: string | null;
           skills?: string[] | null;
           profile_photo_url?: string | null;
+          stripe_customer_id?: string | null;
         };
         Update: Partial<Database["public"]["Tables"]["members"]["Insert"]>;
         Relationships: [];
@@ -157,6 +202,93 @@ export interface Database {
         Update: Partial<Database["public"]["Tables"]["interests"]["Insert"]>;
         Relationships: [];
       };
+      subscriptions: {
+        Row: {
+          id: number;
+          member_id: number;
+          stripe_subscription_id: string;
+          stripe_customer_id: string;
+          stripe_price_id: string;
+          plan_key: PlanKey;
+          monthly_cents: number;
+          status: StripeSubscriptionStatus;
+          current_period_end: string | null;
+          cancel_at_period_end: boolean;
+          canceled_at: string | null;
+          past_due_since: string | null;
+          access_disabled_at: string | null;
+          discount_cents: number | null;
+          discount_duration: DiscountDuration | null;
+          discount_months: number | null;
+          discount_note: string | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          member_id: number;
+          stripe_subscription_id: string;
+          stripe_customer_id: string;
+          stripe_price_id: string;
+          plan_key: PlanKey;
+          monthly_cents: number;
+          status: StripeSubscriptionStatus;
+          current_period_end?: string | null;
+          cancel_at_period_end?: boolean;
+          canceled_at?: string | null;
+          past_due_since?: string | null;
+          access_disabled_at?: string | null;
+          discount_cents?: number | null;
+          discount_duration?: DiscountDuration | null;
+          discount_months?: number | null;
+          discount_note?: string | null;
+        };
+        Update: Partial<Database["public"]["Tables"]["subscriptions"]["Insert"]>;
+        Relationships: [];
+      };
+      purchases: {
+        Row: {
+          id: number;
+          member_id: number | null;
+          stripe_checkout_session: string | null;
+          stripe_payment_intent: string | null;
+          kind: PurchaseKind;
+          amount_cents: number;
+          passes_granted: number;
+          email: string | null;
+          created_at: string;
+        };
+        Insert: {
+          member_id?: number | null;
+          stripe_checkout_session?: string | null;
+          stripe_payment_intent?: string | null;
+          kind: PurchaseKind;
+          amount_cents: number;
+          passes_granted: number;
+          email?: string | null;
+        };
+        Update: Partial<Database["public"]["Tables"]["purchases"]["Insert"]>;
+        Relationships: [];
+      };
+      pass_grants: {
+        Row: {
+          id: number;
+          member_id: number;
+          subscription_id: number | null;
+          stripe_invoice_id: string;
+          plan_key: PlanKey;
+          passes_granted: number;
+          created_at: string;
+        };
+        Insert: {
+          member_id: number;
+          subscription_id?: number | null;
+          stripe_invoice_id: string;
+          plan_key: PlanKey;
+          passes_granted: number;
+        };
+        Update: Partial<Database["public"]["Tables"]["pass_grants"]["Insert"]>;
+        Relationships: [];
+      };
     };
     Views: { [_ in never]: never };
     Functions: {
@@ -184,6 +316,9 @@ export type DayPass = Database["public"]["Tables"]["day_passes"]["Row"];
 export type DayCode = Database["public"]["Tables"]["day_codes"]["Row"];
 export type AccessLog = Database["public"]["Tables"]["access_logs"]["Row"];
 export type Interest = Database["public"]["Tables"]["interests"]["Row"];
+export type Subscription = Database["public"]["Tables"]["subscriptions"]["Row"];
+export type Purchase = Database["public"]["Tables"]["purchases"]["Row"];
+export type PassGrant = Database["public"]["Tables"]["pass_grants"]["Row"];
 
 export const INTEREST_OPTIONS = [
   { value: "membership", label: "Desk membership" },

--- a/supabase/migrations/021_stripe_memberships.sql
+++ b/supabase/migrations/021_stripe_memberships.sql
@@ -1,0 +1,160 @@
+-- Migration 021: Stripe-powered recurring memberships
+--
+-- Adds:
+--   - members.stripe_customer_id           (one Stripe customer per member)
+--   - subscriptions                        (local mirror of Stripe subscription state)
+--   - purchases                            (audit log of one-time buys: day_pass, five_pack)
+--   - applications.approved_plan_key + pricing/discount/checkout cols
+--
+-- Plans are identified by free-text `plan_key` (not enum) so adding new
+-- tiers (e.g. social, events-only) doesn't require a schema migration.
+-- Plan metadata lives in apps/web/src/lib/stripe.ts.
+--
+-- Stripe is the source of truth for subscription state; these local tables
+-- exist so the app can query cheaply (e.g. "who's past due") without
+-- round-tripping to Stripe.
+
+-- =====================================================
+-- 1. members.stripe_customer_id
+-- =====================================================
+alter table members add column stripe_customer_id text unique;
+create index on members (stripe_customer_id);
+
+-- =====================================================
+-- 2. subscriptions — mirrors Stripe.Subscription state
+-- =====================================================
+create table subscriptions (
+  id                       serial primary key,
+  member_id                integer not null references members(id) on delete cascade,
+  stripe_subscription_id   text not null unique,
+  stripe_customer_id       text not null,
+  stripe_price_id          text not null,
+  -- Free text — keys defined in apps/web/src/lib/stripe.ts PLANS constant
+  plan_key                 text not null,
+  -- Actual monthly amount charged (set dynamically per subscription, not from a fixed Price)
+  monthly_cents            integer not null,
+  -- mirrors Stripe status: active | past_due | canceled | incomplete | incomplete_expired | trialing | unpaid | paused
+  status                   text not null,
+  current_period_end       timestamptz,
+  cancel_at_period_end     boolean not null default false,
+  canceled_at              timestamptz,
+  -- set when invoice.payment_failed fires; cleared on payment_succeeded
+  past_due_since           timestamptz,
+  -- set by the past-due-sweep cron after the 7-day grace expires
+  access_disabled_at       timestamptz,
+  -- snapshot of any time-bounded promo Coupon (rate adjustments are baked
+  -- into monthly_cents; Coupons used only for "$X off for N months" deals)
+  discount_cents           integer,
+  discount_duration        text check (discount_duration in ('forever', 'repeating') or discount_duration is null),
+  discount_months          integer,
+  discount_note            text,
+  created_at               timestamptz not null default now(),
+  updated_at               timestamptz not null default now()
+);
+
+create index on subscriptions (member_id);
+create index on subscriptions (status);
+create index on subscriptions (plan_key);
+create index on subscriptions (past_due_since) where past_due_since is not null;
+
+create trigger subscriptions_updated_at before update on subscriptions
+  for each row execute function set_updated_at();
+
+-- =====================================================
+-- 3. purchases — audit log of one-time buys
+-- =====================================================
+create table purchases (
+  id                       serial primary key,
+  member_id                integer references members(id) on delete set null,
+  stripe_checkout_session  text unique,
+  stripe_payment_intent    text,
+  kind                     text not null check (kind in ('day_pass', 'five_pack')),
+  amount_cents             integer not null,
+  passes_granted           integer not null,
+  email                    text,
+  created_at               timestamptz not null default now()
+);
+
+create index on purchases (member_id);
+create index on purchases (email);
+
+-- =====================================================
+-- 3b. pass_grants — idempotent ledger of monthly day-pass grants
+-- =====================================================
+-- For social tiers (e.g. social_events_1, social_events_5) that grant N day
+-- passes per billing cycle. Each grant is keyed by the Stripe invoice ID
+-- to ensure idempotency — if Stripe redelivers invoice.payment_succeeded,
+-- the duplicate INSERT fails on the UNIQUE constraint and we skip the
+-- balance increment.
+create table pass_grants (
+  id                       serial primary key,
+  member_id                integer not null references members(id) on delete cascade,
+  subscription_id          integer references subscriptions(id) on delete set null,
+  stripe_invoice_id        text not null unique,
+  plan_key                 text not null,
+  passes_granted           integer not null,
+  created_at               timestamptz not null default now()
+);
+
+create index on pass_grants (member_id);
+create index on pass_grants (subscription_id);
+
+-- =====================================================
+-- 4. applications — admin-set plan + pricing + checkout state
+-- =====================================================
+alter table applications
+  add column approved_plan_key text,
+  add column approved_monthly_cents integer,
+  add column discount_cents integer,
+  add column discount_duration text check (discount_duration in ('forever', 'repeating') or discount_duration is null),
+  add column discount_months integer,
+  add column discount_note text,
+  add column stripe_checkout_session_id text,
+  add column stripe_checkout_url text,
+  add column checkout_sent_at timestamptz,
+  add column checkout_completed_at timestamptz;
+
+-- =====================================================
+-- 5. RLS
+-- =====================================================
+alter table subscriptions enable row level security;
+alter table purchases enable row level security;
+alter table pass_grants enable row level security;
+
+-- Members can read their own subscription rows
+create policy "members_read_own_subscriptions" on subscriptions
+  for select using (
+    member_id in (select id from members where supabase_user_id = auth.uid())
+  );
+
+-- Admins can do everything on subscriptions
+create policy "admins_all_subscriptions" on subscriptions
+  for all using (
+    exists (select 1 from members where supabase_user_id = auth.uid() and is_admin = true)
+  );
+
+-- Members can read their own purchases
+create policy "members_read_own_purchases" on purchases
+  for select using (
+    member_id in (select id from members where supabase_user_id = auth.uid())
+  );
+
+-- Admins can do everything on purchases
+create policy "admins_all_purchases" on purchases
+  for all using (
+    exists (select 1 from members where supabase_user_id = auth.uid() and is_admin = true)
+  );
+
+-- Members can read their own pass grants (so portal can show "1 pass granted on Mar 5")
+create policy "members_read_own_pass_grants" on pass_grants
+  for select using (
+    member_id in (select id from members where supabase_user_id = auth.uid())
+  );
+
+-- Admins can do everything on pass_grants
+create policy "admins_all_pass_grants" on pass_grants
+  for all using (
+    exists (select 1 from members where supabase_user_id = auth.uid() and is_admin = true)
+  );
+
+-- service_role bypasses RLS (used by webhook handler + admin routes)


### PR DESCRIPTION
## Summary

Recurring monthly subscriptions for RegenHub on top of the existing day-pass flow:

- **Desk tiers**: Cold Desk $500/mo, Hot Desk $250/mo (permanent door access)
- **Social tiers**: Events + 1 day/mo ($50), Events + 5 days/mo ($100) — auto-credits N day passes on each successful invoice

The plan catalog (`apps/web/src/lib/stripe.ts` → `PLANS`) is the single source of truth for tiers. Adding new plans = one entry there, no schema migration needed.

## How it works

- Admin approves an application → picks plan + monthly $ + optional time-bounded promo → generates a Stripe Checkout link (per-person rates baked into the price via dynamic `price_data`, no fixed Prices in Stripe)
- Webhook reflects subscription lifecycle into a local `subscriptions` table; grants door access; carries forward existing day-pass balance as guest credit
- Social tier renewals fire `invoice.payment_succeeded` → `pass_grants` insert (UNIQUE on invoice_id for idempotency) → balance increment
- Members self-serve cancel via Stripe Customer Portal; admin gets a Telegram nudge to have the conversation
- 7-day past-due grace cron flips access back to day-pass on missed payments

## What Aaron needs to do in Stripe

Before this is fully wired in prod:

1. **Webhook events**: in the existing Stripe webhook endpoint, subscribe to: `customer.subscription.created/updated/deleted`, `invoice.payment_succeeded`, `invoice.payment_failed` (currently only `checkout.session.completed` is subscribed)
2. **Customer Portal**: enable in Dashboard → Settings → Billing → Customer Portal (cancel-at-period-end, payment method updates; disable plan switching)
3. **(Optional) Products**: create one Stripe Product per plan (Cold Desk, Hot Desk, Social — Events + 1/5 day/mo) and set `STRIPE_PRODUCT_*` env vars in Coolify for dashboard grouping. Without these, Stripe auto-creates per-subscription products that clutter the dashboard.
4. **(Optional) `CRON_SECRET`** env var + Coolify cron hitting `POST /api/cron/past-due-sweep` daily

## Test plan

- [x] Build + lint + 18 smoke tests pass
- [x] Migration 021 dry-run + applied to prod DB
- [ ] Admin approves a test application → Checkout link works → subscription activates → member_type flips correctly
- [ ] Social tier renewal credits N passes (verify with Stripe CLI invoice event)
- [ ] Past-due → 7-day cron flips member_type back to day_pass
- [ ] Self-serve cancel via Customer Portal → admin Telegram ping fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)