### PR TITLE
regenOS integration: events calendar + one-login (both env-gated, default off)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ Thumbs.db
 
 # Archive (old Vite app)
 _archive/
+supabase/.branches/
+supabase/.temp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,10 @@ The `.dockerignore` has an exception (`!**/.env.production`) so the file is avai
 | `SUPABASE_URL` | Bot (runtime) | |
 | `SUPABASE_SERVICE_ROLE_KEY` | Bot (runtime) | Bypasses RLS |
 | `TELEGRAM_BOT_TOKEN` | Bot (runtime) | |
+| `REGENOS_BASE_URL` | Web (runtime) | regenOS AppView base URL, no trailing slash. Unset = events fall back to the Luma embed and one-login stays off. |
+| `REGENOS_COLLECTIVE_DID` | Web (runtime) | The RegenHub collective's `did:plc:…`. Required alongside the base URL for the events swap. |
+| `REGENOS_WEB_URL` | Web (runtime) | Public regenOS web origin, used to build `/events/<did>/<rkey>` + `calendar.ics` links. Unset = events render unlinked. |
+| `REGENOS_LOGIN_ENABLED` | Web (runtime) | **Default off.** `true`/`1`/`yes` turns on the regenOS login lane + the `/xrpc` proxy. |
 
 ## Project Structure
 ```
@@ -141,6 +145,51 @@ update members set member_type = 'cold_desk' where telegram_username = '@usernam
 Both web and bot are Coolify-managed and need `HA_URL`, `HA_TOKEN`, and `HA_LOCK_ENTITIES` at runtime.
 Set `HA_LOCK_ENTITIES=lock.front_door_lock,lock.back_door_lock` (comma-separated) to
 target multiple Z-Wave locks. Update env via Coolify UI for the relevant app and redeploy.
+
+## regenOS integration (events + one-login)
+
+[regenOS](https://github.com/irlfund/regenOS) is the atproto commons backend. RegenHub uses it for
+two independently-switchable things. Both degrade to today's behaviour when unconfigured.
+
+**Events (on whenever `REGENOS_BASE_URL` + `REGENOS_COLLECTIVE_DID` are set).** The landing page's
+"Upcoming Events" section renders the collective's public calendar instead of the Luma iframe.
+
+- `lib/regenos/events.ts` — `GET /xrpc/social.scenius.getEvents?scene=<did>&limit=200`, **anonymous**
+  (the AppView handler takes no viewer input, so member and non-member callers get byte-identical
+  responses and permissioned events are structurally absent). Returns `[]` on any failure, never throws.
+  The AppView orders by *indexing* time, not start time — we filter + sort on `startsAt` here.
+- `lib/events.ts` — the seam `lib/luma.ts:10-11` promised. One `UpcomingEvent` shape, two sources,
+  chosen by config: regenOS first, Luma second.
+- `components/landing/UpcomingEvents.tsx` — async server component. **Zero events for any reason
+  (quiet calendar, AppView down, timeout) falls back to the Luma embed.** The site never breaks
+  because regenOS is down.
+- Deliberately NOT changed: the newsletter still reads Luma directly (`lib/newsletter.ts:142`). Its
+  copy is Luma-branded end to end; switching it is a product decision, not a plumbing one.
+
+**One-login (`REGENOS_LOGIN_ENABLED`, default OFF).** regenOS becomes the front door; Supabase stays
+the session + RLS substrate.
+
+- `app/xrpc/[...nsid]/route.ts` — same-origin proxy to the AppView (ported from regenOS's own
+  liminal-web). Needed because the AppView's `__Host-rs_session` cookie forbids a `Domain` attribute
+  and can only land on the origin that emitted it. **Allowlisted to the login NSIDs only**; 404s when
+  the flag is off.
+- `POST /api/auth/regenos/session` — the handoff. Reads the regenOS session cookie → `getSession`
+  (DID) + `getMyContactPref` (the **verified** login-anchor email) → matches `members` by email →
+  writes `members.did` → mints a Supabase session via `generateLink` + `verifyOtp` (the admin API,
+  no second email). **No member match is not an error**: that's a *participant* — a real session with
+  public features only, sent to `/membership`.
+- The verified email is trustworthy because regenOS seeds it server-side from `email_identities` and
+  `saveContactPref` refuses any email that isn't the account's login anchor. We require
+  `verified === true` and ignore every other channel.
+- `members.did` (migration `042`) is **server-written only** and deliberately absent from the profile
+  self-edit whitelist (`api/portal/profile/route.ts:63-65`).
+- The Supabase one-time-link form stays on `/auth/login` as the fallback lane for the whole
+  transition — a regenOS outage must never lock a member out of their own door.
+
+**Known gap (upstream, Phase 0):** the AppView's `verify_base_url` / `app_base_url` are global and
+single-valued, so in production a magic link started from regenhub.xyz would email a
+`scenius.social` URL and set the cookie *there*. Locally you point them at regenhub. Fixing it for
+real is the multi-app-origin PR against regenOS.
 
 ## MCP Server
 The RegenHub MCP is served **in-app** by the web app at `https://regenhub.xyz/mcp` (Streamable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,13 +179,31 @@ two independently-switchable things. Both degrade to today's behaviour when unco
   copy is Luma-branded end to end; switching it is a product decision, not a plumbing one.
 
 **One-login (`REGENOS_LOGIN_ENABLED`, default OFF).** regenOS becomes the front door; Supabase stays
-the session + RLS substrate.
+the session + RLS substrate. Two doors, same finish:
+
+- **Real atproto OAuth** (`lib/regenos/oauth.ts`) — the actual mechanism ("regenOS acting like Google
+  OAuth"), matching how regenOS's own frontends (scenius-web, liminal-web) log in. All PAR/PKCE/DPoP/
+  token-exchange machinery lives in the AppView (`atrium-oauth`); this app is thin:
+  `/oauth-client-metadata.json` (the atproto client-ID metadata doc — its own URL IS the `client_id`,
+  confidential `private_key_jwt` once `REGENOS_OAUTH_JWKS_URI` is set, public `none` otherwise),
+  `<OAuthSignInButton>` (an identifier form → POST `beginOAuth` via `/xrpc` → 302 to the PDS consent
+  screen), and `/oauth/callback` (`<OAuthCallback>` → GET `oauthCallback` via `/xrpc`,
+  `credentials:'include'` + `redirect:'manual'`, mirroring regenOS's own `callback.ts`) which lands
+  `__Host-rs_session` on this origin then calls the SAME `POST /api/auth/regenos/session` handoff
+  below. Needs a matching `OAUTH_CLIENTS` entry on regenOS's side (Lucian's repo/deploy, not this
+  one) — `{clientId, redirectUri}` = this app's served metadata doc URL + `/oauth/callback`.
+- **Email bridge** (`RegenosLoginPanel.tsx`'s magic-link form) — proves identity by email possession
+  instead of real OAuth; kept as a second door, not superseded. Its
+  `beginSignup`/`checkEmail`/`chooseHandle` stages are unchanged by the OAuth addition.
+
+Both doors land the AppView's session cookie on this origin then call the one shared handoff:
 
 - `app/xrpc/[...nsid]/route.ts` — same-origin proxy to the AppView (ported from regenOS's own
   liminal-web). Needed because the AppView's `__Host-rs_session` cookie forbids a `Domain` attribute
-  and can only land on the origin that emitted it. **Allowlisted to the login NSIDs plus the three
-  event writes** (`createEvent`/`updateEvent`/`deleteEvent`) — nothing else; 404s when the flag is off.
-- `POST /api/auth/regenos/session` — the handoff. Reads the regenOS session cookie → `getSession`
+  and can only land on the origin that emitted it. **Allowlisted to the login NSIDs (incl.
+  `beginOAuth`/`oauthCallback`) plus the three event writes** (`createEvent`/`updateEvent`/
+  `deleteEvent`) — nothing else; 404s when the flag is off.
+- `POST /api/auth/regenos/session` — the handoff, shared by both doors. Reads the regenOS session cookie → `getSession`
   (DID) + `getMyContactPref` (the **verified** login-anchor email) → matches `members` by email →
   writes `members.did` → mints a Supabase session via `generateLink` + `verifyOtp` (the admin API,
   no second email). **No member match is not an error**: that's a *participant* — a real session with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,8 +171,8 @@ the session + RLS substrate.
 
 - `app/xrpc/[...nsid]/route.ts` — same-origin proxy to the AppView (ported from regenOS's own
   liminal-web). Needed because the AppView's `__Host-rs_session` cookie forbids a `Domain` attribute
-  and can only land on the origin that emitted it. **Allowlisted to the login NSIDs only**; 404s when
-  the flag is off.
+  and can only land on the origin that emitted it. **Allowlisted to the login NSIDs plus the three
+  event writes** (`createEvent`/`updateEvent`/`deleteEvent`) — nothing else; 404s when the flag is off.
 - `POST /api/auth/regenos/session` — the handoff. Reads the regenOS session cookie → `getSession`
   (DID) + `getMyContactPref` (the **verified** login-anchor email) → matches `members` by email →
   writes `members.did` → mints a Supabase session via `generateLink` + `verifyOtp` (the admin API,
@@ -183,6 +183,17 @@ the session + RLS substrate.
   `verified === true` and ignore every other channel.
 - `members.did` (migration `042`) is **server-written only** and deliberately absent from the profile
   self-edit whitelist (`api/portal/profile/route.ts:63-65`).
+- `/portal/events` — **Manage Events**, the stewards' in-portal calendar (no link-out to scenius).
+  Server component: Supabase session, then `fetchRegenosIdentity` + `fetchRegenosSceneStanding`
+  (`getSceneMembers`, whose `steward` flag is computed for the *caller* through the trust resolver;
+  we OR it with a direct Builder+ roster row to mirror the AppView's own `owner_or_builder` write
+  gate). Not a steward ⇒ an honest explainer, never the form. Mutations are same-origin `/xrpc`
+  POSTs from `components/portal/ManageEvents.tsx`; the wire shapes live in `lib/regenos/eventForm.ts`.
+  **Events are written with `publicFace: "exact"`** — the default `rough` face gates street/place-name
+  into the `event.detail` record we can't read back, so an edit would silently erase the address.
+  `updateEvent` re-runs the whole create fan-out, so an edit resends every field it wants to keep.
+  After each write the client pings `POST /api/portal/events/revalidate` (`revalidatePath('/')`) so
+  the landing page's 5-minute events cache doesn't hide the change.
 - The Supabase one-time-link form stays on `/auth/login` as the fallback lane for the whole
   transition — a regenOS outage must never lock a member out of their own door.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ The `.dockerignore` has an exception (`!**/.env.production`) so the file is avai
 | `TELEGRAM_BOT_TOKEN` | Bot (runtime) | |
 | `REGENOS_BASE_URL` | Web (runtime) | regenOS AppView base URL, no trailing slash. Unset = events fall back to the Luma embed and one-login stays off. |
 | `REGENOS_COLLECTIVE_DID` | Web (runtime) | The RegenHub collective's `did:plc:…`. Required alongside the base URL for the events swap. |
-| `REGENOS_WEB_URL` | Web (runtime) | Public regenOS web origin, used to build `/events/<did>/<rkey>` + `calendar.ics` links. Unset = events render unlinked. |
+| `REGENOS_WEB_URL` | Web (runtime) | Public regenOS web origin. **Only** used for the subscribable `calendar.ics` feed URL — event *pages* are in-site (`/events/<did>/<rkey>`) and never depend on this. Unset = no "Subscribe to the calendar" line. |
 | `REGENOS_LOGIN_ENABLED` | Web (runtime) | **Default off.** `true`/`1`/`yes` turns on the regenOS login lane + the `/xrpc` proxy. |
 
 ## Project Structure
@@ -163,6 +163,18 @@ two independently-switchable things. Both degrade to today's behaviour when unco
 - `components/landing/UpcomingEvents.tsx` — async server component. **Zero events for any reason
   (quiet calendar, AppView down, timeout) falls back to the Luma embed.** The site never breaks
   because regenOS is down.
+- **`/events` + `/events/<did>/<rkey>` — the whole event experience is in-site.** Per Aaron, an
+  event link never leaves regenhub.xyz: no lu.ma, no scenius.social. `/events` is the public
+  calendar at a 120-day horizon (same Luma fallback contract as the landing section); the detail
+  page reads ONE event via anonymous `GET /xrpc/social.scenius.getEvent?uri=at://<did>/community.lexicon.calendar.event/<rkey>`
+  and `notFound()`s on anything that isn't a public event (unknown rkey, private event, AppView
+  down) — one honest 404, never a leak that a private event exists. No public RSVP; the CTA sends
+  people to `/auth/login` + `/portal`. Card/date rendering is shared with the landing section in
+  `components/events/EventList.tsx`; a site-relative URL renders as a `next/link`, an absolute one
+  (the Luma fallback) keeps the new-tab treatment.
+- `lib/regenos/events.ts` `eventUrl()` returns the **site-relative** `/events/<did>/<rkey>` and is
+  env-independent. `regenosCalendarIcsUrl()` still points at REGENOS_WEB_URL on purpose — an ICS
+  feed is a calendar-app subscription URL, not a page a person navigates to.
 - Deliberately NOT changed: the newsletter still reads Luma directly (`lib/newsletter.ts:142`). Its
   copy is Luma-branded end to end; switching it is a product decision, not a plumbing one.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The Stripe, Telegram, and Home Assistant blocks in `.env.example` are optional f
 - Without Stripe vars set, the webhook route returns 400 — fine if you're not exercising checkout flow.
 - Without `TELEGRAM_*`, the freeday activate route still works, just doesn't post to the group.
 - Without `HA_*`, every lock-programming route fails with a 502. Stub them out to a fake URL/token if you want to bypass without setting up HA.
+- Without `REGENOS_*`, the landing page shows the Luma events embed exactly as it always has and the regenOS login lane stays hidden. See "Running against a local regenOS" below.
 
 `apps/web/.env.production` is committed — it holds the public build-time values for the deployed Coolify build. Don't put dev values there.
 
@@ -66,6 +67,39 @@ pnpm --filter bot build
 ```
 
 The bot uses Telegram long-polling — only one process can poll a given bot token at a time. Use a separate dev bot (create one with @BotFather) so you don't fight the production poller.
+
+### Running against a local regenOS
+
+[regenOS](https://github.com/irlfund/regenOS) backs the public events calendar and (behind a flag)
+the login lane. Both are off unless you configure them — see the `regenOS` block in
+`apps/web/.env.example` and the "regenOS integration" section of `CLAUDE.md`.
+
+In the regenOS checkout:
+
+```bash
+docker compose up -d db                      # Postgres on :5432
+brew install onnxruntime                     # REQUIRED on macOS or the AppView hangs at boot
+
+DATABASE_URL='postgres://postgres:postgres@localhost:5432/regenos' \
+REGENOS_OPERATOR_K256_HEX="$(openssl rand -hex 32)" \
+REGENOS_DEK_B64="$(openssl rand -base64 32)" \
+BIND_ADDR=127.0.0.1:8080 AUTH_MODE=beta HANDLE_DOMAIN=test ALLOWED_ORIGIN= \
+PDS_MODE=inmemory ORT_DYLIB_PATH=/opt/homebrew/lib/libonnxruntime.dylib \
+cargo run --bin regenos-appview              # migrations run on boot
+
+node scripts/seed-dev.mjs                    # a collective + events, via the beta signup door
+```
+
+Then point this app at it:
+
+```bash
+REGENOS_BASE_URL=http://localhost:8080
+REGENOS_COLLECTIVE_DID=did:plc:...           # printed by seed-dev.mjs
+REGENOS_LOGIN_ENABLED=true                   # optional — the login lane
+```
+
+`AUTH_MODE=beta` mints a session on `beginSignup` with no email round-trip, which is what makes the
+login lane testable locally. Production regenOS runs `AUTH_MODE=email`.
 
 ## Deployment
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -83,3 +83,32 @@ TELEGRAM_GROUP_CHAT_ID=<chat-id-of-your-test-group>
 # Timezone used to compute day-code expiry (6 PM Mountain Time, weekday
 # guards, etc). Default is America/Denver if unset.
 TIMEZONE=America/Denver
+
+
+# -- regenOS (runtime, optional) ----------------------------------------------
+# regenOS is the atproto commons backend (github.com/irlfund/regenOS). RegenHub
+# uses it for two things, independently switchable:
+#
+#   EVENTS — set REGENOS_BASE_URL + REGENOS_COLLECTIVE_DID and the landing
+#   page's "Upcoming Events" section renders the collective's public calendar
+#   (`social.scenius.getEvents`) instead of the Luma embed. Unset either one,
+#   or let the AppView go down, and it falls straight back to the Luma embed —
+#   the page never breaks.
+#
+#   ONE-LOGIN — additionally set REGENOS_LOGIN_ENABLED=true and /auth/login
+#   grows a "sign in with your membership email" lane over the regenOS magic
+#   link, plus the same-origin /xrpc proxy it needs. DEFAULT OFF. With it off,
+#   the Supabase one-time-link door is the only door and is untouched.
+
+# AppView base URL, no trailing slash. Local dev: http://localhost:8080
+REGENOS_BASE_URL=
+
+# The RegenHub collective's (scene's) DID — did:plc:...
+REGENOS_COLLECTIVE_DID=
+
+# Public regenOS web app origin, used to build event page + calendar.ics links.
+# Unset = events render without links.
+REGENOS_WEB_URL=
+
+# The one-login feature flag. "true" | "1" | "yes" to enable. Default OFF.
+REGENOS_LOGIN_ENABLED=false

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -96,9 +96,13 @@ TIMEZONE=America/Denver
 #   the page never breaks.
 #
 #   ONE-LOGIN — additionally set REGENOS_LOGIN_ENABLED=true and /auth/login
-#   grows a "sign in with your membership email" lane over the regenOS magic
-#   link, plus the same-origin /xrpc proxy it needs. DEFAULT OFF. With it off,
-#   the Supabase one-time-link door is the only door and is untouched.
+#   grows two regenOS sign-in doors over the same-origin /xrpc proxy: the
+#   magic-link email bridge, and real atproto OAuth (regenOS acting like
+#   Google OAuth — /oauth-client-metadata.json + /oauth/callback,
+#   lib/regenos/oauth.ts). Both land the same __Host-rs_session cookie and
+#   finish through the same POST /api/auth/regenos/session handoff.
+#   DEFAULT OFF. With it off, the Supabase one-time-link door is the only
+#   door and is untouched.
 
 # AppView base URL, no trailing slash. Local dev: http://localhost:8080
 REGENOS_BASE_URL=
@@ -112,3 +116,11 @@ REGENOS_WEB_URL=
 
 # The one-login feature flag. "true" | "1" | "yes" to enable. Default OFF.
 REGENOS_LOGIN_ENABLED=false
+
+# The AppView's published OAuth JWKS URL (e.g. https://scenius.social/oauth/jwks.json).
+# Set this ONLY once Lucian's OAUTH_CLIENTS entry for regenhub.xyz on regenOS
+# is configured as a CONFIDENTIAL client (matching jwksUri) — until then leave
+# it unset and /oauth-client-metadata.json serves a public client
+# (token_endpoint_auth_method: "none"). The two sides must agree, or the PDS
+# sees a mismatched client and refuses the flow.
+REGENOS_OAUTH_JWKS_URI=

--- a/apps/web/src/app/api/auth/regenos/session/route.test.ts
+++ b/apps/web/src/app/api/auth/regenos/session/route.test.ts
@@ -41,6 +41,8 @@ type AdminMockOpts = {
   updateError?: { code?: string; message: string } | null;
   /** Make the first generateLink fail, so the route takes the provisioning path. */
   generateLinkFailsUntilCreate?: boolean;
+  /** What GoTrue says it minted — `signup` when it auto-created the user. */
+  verificationType?: "magiclink" | "signup";
 };
 
 /**
@@ -85,7 +87,15 @@ function makeAdminMock(opts: AdminMockOpts = {}) {
     if (opts.generateLinkFailsUntilCreate && !created) {
       return { data: null, error: { message: "User not found" } };
     }
-    return { data: { properties: { hashed_token: HASHED_TOKEN } }, error: null };
+    return {
+      data: {
+        properties: {
+          hashed_token: HASHED_TOKEN,
+          verification_type: opts.verificationType ?? "magiclink",
+        },
+      },
+      error: null,
+    };
   });
   const createUser = vi.fn(async () => {
     created = true;
@@ -242,6 +252,29 @@ describe("POST /api/auth/regenos/session", () => {
     expect(admin.__createUser).toHaveBeenCalledWith({ email: EMAIL, email_confirm: true });
     expect(admin.__generateLink).toHaveBeenCalledTimes(2);
     expect(server.__verifyOtp).toHaveBeenCalled();
+  });
+
+  it("redeems with the verification_type GoTrue minted, not a hardcoded magiclink", async () => {
+    // Current GoTrue doesn't 404 generate_link for a missing user — it
+    // auto-creates one and mints a `signup` token. Redeeming that as
+    // "magiclink" fails, which used to break every new member's first
+    // sign-in. The route must pass through what GoTrue actually minted.
+    const admin = makeAdminMock({
+      member: { id: 42, email: EMAIL, did: null, disabled: false },
+      verificationType: "signup",
+    });
+    const server = makeServerMock();
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+    vi.mocked(createClient).mockResolvedValue(server as never);
+
+    const res = await POST(req());
+
+    expect(res.status).toBe(200);
+    expect(admin.__createUser).not.toHaveBeenCalled();
+    expect(server.__verifyOtp).toHaveBeenCalledWith({
+      type: "signup",
+      token_hash: HASHED_TOKEN,
+    });
   });
 
   it("500s when the session mint fails", async () => {

--- a/apps/web/src/app/api/auth/regenos/session/route.test.ts
+++ b/apps/web/src/app/api/auth/regenos/session/route.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeSupabaseMock } from "../../../../../../test/mockSupabase";
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createServiceClient: vi.fn(),
+}));
+
+vi.mock("@/lib/regenos/config", () => ({
+  isRegenosLoginEnabled: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/regenos/auth", () => ({
+  fetchRegenosIdentity: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/admin";
+import { isRegenosLoginEnabled } from "@/lib/regenos/config";
+import { fetchRegenosIdentity } from "@/lib/regenos/auth";
+
+const DID = "did:plc:regenhubmember";
+const EMAIL = "member@example.com";
+const HASHED_TOKEN = "hashed-token-abc";
+
+/** A request carrying the regenOS session cookie the route reads off the browser. */
+function req() {
+  return new Request("http://localhost:3000/api/auth/regenos/session", {
+    method: "POST",
+    headers: { cookie: "__Host-rs_session=opaque" },
+  });
+}
+
+type AdminMockOpts = {
+  member?: Record<string, unknown> | null;
+  /** Error the members UPDATE should return (e.g. a 23505 unique violation). */
+  updateError?: { code?: string; message: string } | null;
+  /** Make the first generateLink fail, so the route takes the provisioning path. */
+  generateLinkFailsUntilCreate?: boolean;
+};
+
+/**
+ * The service-role client, plus the admin auth surface this route uses
+ * (`auth.admin.generateLink` / `auth.admin.createUser`) which the shared
+ * mockSupabase helper doesn't model. Also records every `.update()` payload so
+ * a test can assert the DID write actually happened.
+ */
+function makeAdminMock(opts: AdminMockOpts = {}) {
+  const updates: { table: string; payload: unknown }[] = [];
+
+  const base = makeSupabaseMock({
+    selects: { members: { data: opts.member ?? null } },
+    mutations: { error: opts.updateError ?? null },
+  });
+
+  // The shared helper's `.update(...)` loses the mutation response as soon as
+  // you chain `.eq(...)` (its `eq` falls back to the SELECT builder), and this
+  // route's whole 23505 path lives on `await …update(…).eq(…)`. Widen it here,
+  // as mockSupabase.ts's own docstring invites.
+  const updateResult = { data: null, error: opts.updateError ?? null };
+  const innerFrom = base.from;
+  const from = vi.fn((table: string) => {
+    const builder = innerFrom(table) as Record<string, unknown>;
+    builder.update = vi.fn((payload: unknown) => {
+      updates.push({ table, payload });
+      const chain: Record<string, unknown> = {
+        eq: vi.fn(() => chain),
+        is: vi.fn(() => chain),
+        select: vi.fn(() => chain),
+        single: vi.fn(async () => updateResult),
+        then: (onfulfilled?: (v: typeof updateResult) => unknown) =>
+          Promise.resolve(updateResult).then(onfulfilled),
+      };
+      return chain;
+    });
+    return builder;
+  });
+
+  let created = false;
+  const generateLink = vi.fn(async () => {
+    if (opts.generateLinkFailsUntilCreate && !created) {
+      return { data: null, error: { message: "User not found" } };
+    }
+    return { data: { properties: { hashed_token: HASHED_TOKEN } }, error: null };
+  });
+  const createUser = vi.fn(async () => {
+    created = true;
+    return { data: { user: { id: "auth-1" } }, error: null };
+  });
+
+  return {
+    ...base,
+    from,
+    auth: { ...base.auth, admin: { generateLink, createUser } },
+    __updates: updates,
+    __generateLink: generateLink,
+    __createUser: createUser,
+  };
+}
+
+/** The cookie-bound server client — only `auth.verifyOtp` matters here. */
+function makeServerMock(verifyError: { message: string } | null = null) {
+  const base = makeSupabaseMock();
+  const verifyOtp = vi.fn(async () => ({ data: {}, error: verifyError }));
+  return { ...base, auth: { ...base.auth, verifyOtp }, __verifyOtp: verifyOtp };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(isRegenosLoginEnabled).mockReturnValue(true);
+  vi.mocked(fetchRegenosIdentity).mockResolvedValue({ did: DID, handle: "member.test", email: EMAIL });
+});
+
+describe("POST /api/auth/regenos/session", () => {
+  it("404s when the feature flag is off", async () => {
+    vi.mocked(isRegenosLoginEnabled).mockReturnValue(false);
+
+    const res = await POST(req());
+
+    expect(res.status).toBe(404);
+    expect(fetchRegenosIdentity).not.toHaveBeenCalled();
+  });
+
+  it("401s when there is no regenOS session", async () => {
+    vi.mocked(fetchRegenosIdentity).mockResolvedValue(null);
+    vi.mocked(createServiceClient).mockReturnValue(makeAdminMock() as never);
+
+    const res = await POST(req());
+    const json = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(json.error).toMatch(/No regenOS session/);
+  });
+
+  it("403s when the regenOS account has no verified email", async () => {
+    vi.mocked(fetchRegenosIdentity).mockResolvedValue({ did: DID, handle: null, email: null });
+    vi.mocked(createServiceClient).mockReturnValue(makeAdminMock() as never);
+
+    const res = await POST(req());
+    const json = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(json.error).toMatch(/no verified email/);
+  });
+
+  it("links the DID and mints a Supabase session for a matched member", async () => {
+    const admin = makeAdminMock({ member: { id: 42, email: EMAIL, did: null, disabled: false } });
+    const server = makeServerMock();
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+    vi.mocked(createClient).mockResolvedValue(server as never);
+
+    const res = await POST(req());
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toMatchObject({ ok: true, member: true, did: DID, redirect: "/portal" });
+
+    // The DID landed on the member row — server-side, not via the profile whitelist.
+    expect(admin.__updates).toEqual([{ table: "members", payload: { did: DID } }]);
+
+    // And the session was minted without sending a second email.
+    expect(admin.__generateLink).toHaveBeenCalledWith({ type: "magiclink", email: EMAIL });
+    expect(admin.__createUser).not.toHaveBeenCalled();
+    expect(server.__verifyOtp).toHaveBeenCalledWith({ type: "magiclink", token_hash: HASHED_TOKEN });
+  });
+
+  it("does not rewrite a DID that is already linked to the same identity", async () => {
+    const admin = makeAdminMock({ member: { id: 42, email: EMAIL, did: DID, disabled: false } });
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+    vi.mocked(createClient).mockResolvedValue(makeServerMock() as never);
+
+    const res = await POST(req());
+
+    expect(res.status).toBe(200);
+    expect(admin.__updates).toEqual([]);
+  });
+
+  it("409s when the member is already linked to a different regenOS identity", async () => {
+    const admin = makeAdminMock({
+      member: { id: 42, email: EMAIL, did: "did:plc:someoneelse", disabled: false },
+    });
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+    vi.mocked(createClient).mockResolvedValue(makeServerMock() as never);
+
+    const res = await POST(req());
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.error).toMatch(/already linked to a different regenOS identity/);
+    expect(admin.__updates).toEqual([]);
+    expect(admin.__generateLink).not.toHaveBeenCalled();
+  });
+
+  it("409s when the unique index catches a DID already held by another member", async () => {
+    const admin = makeAdminMock({
+      member: { id: 42, email: EMAIL, did: null, disabled: false },
+      updateError: { code: "23505", message: "duplicate key value violates unique constraint" },
+    });
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+    vi.mocked(createClient).mockResolvedValue(makeServerMock() as never);
+
+    const res = await POST(req());
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.error).toMatch(/already linked to another member/);
+    expect(admin.__generateLink).not.toHaveBeenCalled();
+  });
+
+  it("mints a participant session when no member matches the verified email", async () => {
+    const admin = makeAdminMock({ member: null });
+    const server = makeServerMock();
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+    vi.mocked(createClient).mockResolvedValue(server as never);
+
+    const res = await POST(req());
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toMatchObject({ ok: true, member: false, redirect: "/membership" });
+    // No member row is created — a participant gets public features only.
+    expect(admin.__updates).toEqual([]);
+    expect(server.__verifyOtp).toHaveBeenCalled();
+  });
+
+  it("provisions the auth.users row when one doesn't exist yet", async () => {
+    const admin = makeAdminMock({
+      member: { id: 42, email: EMAIL, did: null, disabled: false },
+      generateLinkFailsUntilCreate: true,
+    });
+    const server = makeServerMock();
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+    vi.mocked(createClient).mockResolvedValue(server as never);
+
+    const res = await POST(req());
+
+    expect(res.status).toBe(200);
+    expect(admin.__createUser).toHaveBeenCalledWith({ email: EMAIL, email_confirm: true });
+    expect(admin.__generateLink).toHaveBeenCalledTimes(2);
+    expect(server.__verifyOtp).toHaveBeenCalled();
+  });
+
+  it("500s when the session mint fails", async () => {
+    const admin = makeAdminMock({ member: { id: 42, email: EMAIL, did: null, disabled: false } });
+    const server = makeServerMock({ message: "token expired" });
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+    vi.mocked(createClient).mockResolvedValue(server as never);
+
+    const res = await POST(req());
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toMatch(/Couldn't start your session/);
+  });
+});

--- a/apps/web/src/app/api/auth/regenos/session/route.ts
+++ b/apps/web/src/app/api/auth/regenos/session/route.ts
@@ -1,0 +1,167 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/admin";
+import { isRegenosLoginEnabled } from "@/lib/regenos/config";
+import { fetchRegenosIdentity } from "@/lib/regenos/auth";
+
+/**
+ * POST /api/auth/regenos/session — the one-login handoff.
+ *
+ * The caller already holds a live regenOS session cookie on this origin (set
+ * by the /xrpc proxy). This route turns that into a RegenHub session:
+ *
+ *   1. ask regenOS who the caller is (DID + the VERIFIED login-anchor email —
+ *      see lib/regenos/auth.ts for why that email is trustworthy);
+ *   2. match that email to a `members` row — the SAME email join the four
+ *      existing stitching mechanisms already use (triggers 004/013/020 and the
+ *      portal's runtime repair, CLAUDE.md "Identity linkage");
+ *   3. write `members.did` — server-side only. This is deliberately NOT the
+ *      profile whitelist (api/portal/profile/route.ts:63-65 says not to add
+ *      columns unless they're safe for self-edit; a custodial DID isn't);
+ *   4. mint a real Supabase session so every RLS policy, every
+ *      `auth.getUser()` call site and the whole portal keep working untouched.
+ *
+ * NO MEMBER MATCH IS NOT AN ERROR. Anyone may hold a regenOS account; a
+ * session with no `members` row is a *participant* — a valid signed-in person
+ * with access to public features only. We mint their session, write no member
+ * row, and send them to /membership. That is Aaron's participants tier, and
+ * handling it explicitly is the point.
+ *
+ * ── On minting the Supabase session ──────────────────────────────────────────
+ * The repo's precedent for server-side identity provisioning is
+ * `admin.auth.signInWithOtp({ shouldCreateUser: true })` (api/freeday/route.ts:248,
+ * api/webhooks/stripe/route.ts:743, lib/passFulfillment.ts:205). We can't use it
+ * verbatim: it EMAILS a magic link, and a second email is exactly what one-login
+ * exists to remove. So we do the same thing without the email —
+ * `generateLink` (admin API, sends nothing, returns the hashed token) redeemed
+ * immediately by `verifyOtp`, which writes the `sb-regenhub` cookies through
+ * the server client's cookie adapter. Provisioning via `createUser` with
+ * `email_confirm: true` is honest here: regenOS just proved the address.
+ *
+ * Flag off ⇒ 404. The Supabase OTP door is untouched either way.
+ */
+export async function POST(request: Request) {
+  if (!isRegenosLoginEnabled()) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const cookieHeader = request.headers.get("cookie") ?? "";
+  const identity = await fetchRegenosIdentity(cookieHeader);
+  if (!identity) {
+    return NextResponse.json(
+      { error: "No regenOS session. Sign in with regenOS first." },
+      { status: 401 },
+    );
+  }
+
+  if (!identity.email) {
+    // A BYOD / passkey regenOS account has no email anchor at all. There is
+    // nothing to match on and nothing to prove, so we refuse rather than guess.
+    return NextResponse.json(
+      {
+        error:
+          "That regenOS account has no verified email, so we can't match it to a RegenHub membership.",
+      },
+      { status: 403 },
+    );
+  }
+
+  const email = identity.email;
+  const admin = createServiceClient();
+
+  // ── 2. match the membership by verified email ──────────────────────────────
+  const { data: member, error: memberError } = await admin
+    .from("members")
+    .select("id, email, did, disabled")
+    .eq("email", email)
+    .maybeSingle();
+
+  if (memberError) {
+    console.error("[regenOS] member lookup failed:", memberError);
+    return NextResponse.json({ error: "Couldn't look up your membership." }, { status: 500 });
+  }
+
+  // ── 3. write members.did ───────────────────────────────────────────────────
+  if (member) {
+    if (member.did && member.did !== identity.did) {
+      // One member row, two regenOS identities. regenOS's own email→DID map is
+      // a bijection, so this only happens if the member's email was changed
+      // after a previous link. A human has to decide which one is real.
+      console.warn(
+        `[regenOS] member ${member.id} already linked to ${member.did}, refusing to relink to ${identity.did}`,
+      );
+      return NextResponse.json(
+        {
+          error:
+            "This membership is already linked to a different regenOS identity. Email us and we'll sort it out.",
+        },
+        { status: 409 },
+      );
+    }
+
+    if (!member.did) {
+      const { error: linkError } = await admin
+        .from("members")
+        .update({ did: identity.did })
+        .eq("id", member.id);
+
+      if (linkError) {
+        // 23505 = the unique index caught another member already holding this
+        // DID. Same friendly-409 posture as the telegram handle
+        // (api/portal/profile/route.ts:78-86).
+        if ((linkError as { code?: string }).code === "23505") {
+          return NextResponse.json(
+            {
+              error:
+                "That regenOS identity is already linked to another member. Email us and we'll sort it out.",
+            },
+            { status: 409 },
+          );
+        }
+        console.error("[regenOS] did link failed:", linkError);
+        return NextResponse.json({ error: "Couldn't link your regenOS identity." }, { status: 500 });
+      }
+    }
+  }
+
+  // ── 4. mint the Supabase session ───────────────────────────────────────────
+  let link = await admin.auth.admin.generateLink({ type: "magiclink", email });
+
+  if (link.error) {
+    // No auth.users row yet — provision one. Trigger 004 links it to the
+    // member row by email on insert, so supabase_user_id lands for free.
+    const { error: createError } = await admin.auth.admin.createUser({
+      email,
+      email_confirm: true,
+    });
+    if (createError) {
+      console.error("[regenOS] auth user provisioning failed:", createError);
+      return NextResponse.json({ error: "Couldn't create your sign-in." }, { status: 500 });
+    }
+    link = await admin.auth.admin.generateLink({ type: "magiclink", email });
+  }
+
+  const tokenHash = link.data?.properties?.hashed_token;
+  if (link.error || !tokenHash) {
+    console.error("[regenOS] generateLink failed:", link.error);
+    return NextResponse.json({ error: "Couldn't create your sign-in." }, { status: 500 });
+  }
+
+  const supabase = await createClient();
+  const { error: verifyError } = await supabase.auth.verifyOtp({
+    type: "magiclink",
+    token_hash: tokenHash,
+  });
+  if (verifyError) {
+    console.error("[regenOS] verifyOtp failed:", verifyError);
+    return NextResponse.json({ error: "Couldn't start your session." }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    /** false = participant: a real session, public features only. */
+    member: !!member,
+    did: identity.did,
+    redirect: member ? "/portal" : "/membership",
+  });
+}

--- a/apps/web/src/app/api/auth/regenos/session/route.ts
+++ b/apps/web/src/app/api/auth/regenos/session/route.ts
@@ -125,11 +125,17 @@ export async function POST(request: Request) {
   }
 
   // ── 4. mint the Supabase session ───────────────────────────────────────────
+  // When no auth.users row exists yet, current GoTrue does NOT error here — it
+  // auto-creates an unconfirmed user and mints a `signup`-type token (older
+  // GoTrue 404s instead, which the branch below handles). Either way trigger
+  // 004 links the new auth user to the member row by email on insert, so
+  // supabase_user_id lands for free. The redeem must use the
+  // `verification_type` GoTrue says it minted: redeeming a signup token as
+  // "magiclink" fails with "Email link is invalid or has expired", which used
+  // to break exactly the first sign-in of every newly provisioned member.
   let link = await admin.auth.admin.generateLink({ type: "magiclink", email });
 
   if (link.error) {
-    // No auth.users row yet — provision one. Trigger 004 links it to the
-    // member row by email on insert, so supabase_user_id lands for free.
     const { error: createError } = await admin.auth.admin.createUser({
       email,
       email_confirm: true,
@@ -142,14 +148,15 @@ export async function POST(request: Request) {
   }
 
   const tokenHash = link.data?.properties?.hashed_token;
-  if (link.error || !tokenHash) {
+  const verificationType = link.data?.properties?.verification_type;
+  if (link.error || !tokenHash || !verificationType) {
     console.error("[regenOS] generateLink failed:", link.error);
     return NextResponse.json({ error: "Couldn't create your sign-in." }, { status: 500 });
   }
 
   const supabase = await createClient();
   const { error: verifyError } = await supabase.auth.verifyOtp({
-    type: "magiclink",
+    type: verificationType as "magiclink" | "signup",
     token_hash: tokenHash,
   });
   if (verifyError) {

--- a/apps/web/src/app/api/portal/events/revalidate/route.ts
+++ b/apps/web/src/app/api/portal/events/revalidate/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { isRegenosLoginEnabled } from "@/lib/regenos/config";
+
+/**
+ * POST /api/portal/events/revalidate
+ *
+ * The landing page's events call is cached for five minutes
+ * (lib/regenos/events.ts `next: { revalidate: 300 }`), which is right for a
+ * public page and wrong for the steward who just changed the calendar and
+ * wants to see it. This drops that cache for `/` on demand.
+ *
+ * A signed-in member is enough authorization: the worst a caller can do is make
+ * the landing page refetch a public calendar it would have refetched anyway.
+ */
+export async function POST() {
+  if (!isRegenosLoginEnabled()) {
+    return NextResponse.json({ error: "NotFound" }, { status: 404 });
+  }
+
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  revalidatePath("/");
+  return NextResponse.json({ revalidated: true });
+}

--- a/apps/web/src/app/auth/login/page.tsx
+++ b/apps/web/src/app/auth/login/page.tsx
@@ -38,20 +38,25 @@ export default async function LoginPage({ searchParams }: PageProps) {
             </p>
           </div>
 
-          {regenosEnabled && (
+          {regenosEnabled ? (
             <>
               <RegenosLoginPanel next={safeNext} />
-              {/* The classic lane stays available for the whole transition —
-                  a regenOS outage must never lock a member out of their door. */}
-              <div className="flex items-center gap-3 my-6">
-                <div className="h-px flex-1 bg-white/15" />
-                <span className="text-xs text-muted uppercase tracking-wider">or</span>
-                <div className="h-px flex-1 bg-white/15" />
-              </div>
+              {/* regenOS is THE login. The classic lane stays reachable for the
+                  whole transition — a regenOS outage must never lock a member
+                  out of their door — but it no longer shares the stage. It
+                  auto-opens when a failed-link banner needs showing. */}
+              <details className="mt-6" open={!!banner}>
+                <summary className="text-xs text-muted text-center cursor-pointer list-none hover:text-forest transition-colors">
+                  Having trouble signing in?
+                </summary>
+                <div className="mt-4">
+                  <LoginForm initialBanner={banner} next={safeNext} />
+                </div>
+              </details>
             </>
+          ) : (
+            <LoginForm initialBanner={banner} next={safeNext} />
           )}
-
-          <LoginForm initialBanner={banner} next={safeNext} />
         </div>
       </div>
     </div>

--- a/apps/web/src/app/auth/login/page.tsx
+++ b/apps/web/src/app/auth/login/page.tsx
@@ -1,4 +1,6 @@
 import { LoginForm } from "@/components/auth/LoginForm";
+import { RegenosLoginPanel } from "@/components/auth/RegenosLoginPanel";
+import { isRegenosLoginEnabled } from "@/lib/regenos/config";
 
 export const metadata = { title: "Sign In — RegenHub" };
 
@@ -19,6 +21,10 @@ export default async function LoginPage({ searchParams }: PageProps) {
   // Only honor next params that look like internal paths to avoid open redirects.
   const safeNext = params.next && /^\/[a-zA-Z0-9_\-/?=&]*$/.test(params.next) ? params.next : undefined;
 
+  // Phase 2 one-login, default OFF. When off this page is byte-identical to
+  // what it has always been: the Supabase one-time-link form and nothing else.
+  const regenosEnabled = isRegenosLoginEnabled();
+
   return (
     <div className="min-h-screen flex items-center justify-center px-6">
       <div className="w-full max-w-md">
@@ -26,9 +32,25 @@ export default async function LoginPage({ searchParams }: PageProps) {
           <div className="text-center mb-8">
             <h1 className="text-2xl font-bold text-forest mb-2">Member Portal</h1>
             <p className="text-muted text-sm">
-              Enter your email — we&apos;ll send a one-time sign-in link. Check your inbox (and spam folder, just in case).
+              {regenosEnabled
+                ? "Sign in with your membership email. Check your inbox (and spam folder, just in case)."
+                : "Enter your email — we'll send a one-time sign-in link. Check your inbox (and spam folder, just in case)."}
             </p>
           </div>
+
+          {regenosEnabled && (
+            <>
+              <RegenosLoginPanel next={safeNext} />
+              {/* The classic lane stays available for the whole transition —
+                  a regenOS outage must never lock a member out of their door. */}
+              <div className="flex items-center gap-3 my-6">
+                <div className="h-px flex-1 bg-white/15" />
+                <span className="text-xs text-muted uppercase tracking-wider">or</span>
+                <div className="h-px flex-1 bg-white/15" />
+              </div>
+            </>
+          )}
+
           <LoginForm initialBanner={banner} next={safeNext} />
         </div>
       </div>

--- a/apps/web/src/app/events/[did]/[rkey]/page.tsx
+++ b/apps/web/src/app/events/[did]/[rkey]/page.tsx
@@ -1,0 +1,130 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowLeft, CalendarDays, KeyRound, MapPin } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { fetchPublicRegenosEvent, type RegenosEventLocation } from "@/lib/regenos/events";
+import { formatEventRange } from "@/components/events/EventList";
+
+/**
+ * One public event, on regenhub.xyz.
+ *
+ * The last link-out. `lib/regenos/events.ts` used to point event cards at
+ * REGENOS_WEB_URL (scenius.social); it now points here, and this server
+ * component reads the same event through the AppView's public
+ * `social.scenius.getEvent` — anonymously, so only a genuinely public event
+ * can render. Anything else (unknown rkey, a private event, regenOS down,
+ * regenOS unconfigured) is `notFound()`: one honest 404, never a leak that a
+ * private event exists and never a broken page.
+ *
+ * **No public RSVP.** Seats are a members-and-invitees thing that needs a
+ * regenOS identity, so the CTA sends people to the door (`/auth/login`) and the
+ * portal rather than pretending to take an RSVP here.
+ */
+
+interface PageProps {
+  params: Promise<{ did: string; rkey: string }>;
+}
+
+/** `/events/did%3Aplc%3Axyz/abc` → `{ did: "did:plc:xyz", rkey: "abc" }`. */
+async function readParams(params: PageProps["params"]) {
+  const { did, rkey } = await params;
+  return { did: decodeURIComponent(did), rkey: decodeURIComponent(rkey) };
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { did, rkey } = await readParams(params);
+  const event = await fetchPublicRegenosEvent(did, rkey);
+  if (!event) return { title: "Event — RegenHub" };
+  return {
+    title: `${event.name} — RegenHub`,
+    description: event.description?.slice(0, 200) ?? "An upcoming event at RegenHub Boulder.",
+  };
+}
+
+/** "RegenHub · 1515 Walnut St, Boulder, CO 80302" from whatever fields the record actually carries. */
+function formatLocation(location: RegenosEventLocation): string {
+  const cityLine = [location.locality, location.region].filter(Boolean).join(", ");
+  const street = [location.street, cityLine, location.postalCode].filter(Boolean).join(", ");
+  return [location.name, street].filter(Boolean).join(" · ");
+}
+
+export default async function EventDetailPage({ params }: PageProps) {
+  const { did, rkey } = await readParams(params);
+  const event = await fetchPublicRegenosEvent(did, rkey);
+  if (!event) notFound();
+
+  const when = formatEventRange(event.startAt, event.endAt);
+  const location = event.location ? formatLocation(event.location) : "";
+
+  return (
+    <div className="min-h-screen px-6 py-12">
+      <div className="max-w-3xl mx-auto space-y-8">
+        <p className="text-sm">
+          <Link
+            href="/events"
+            className="inline-flex items-center gap-1.5 text-muted hover:text-sage transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            All events
+          </Link>
+        </p>
+
+        <article className="glass-panel-strong p-8 md:p-10 space-y-6">
+          <header className="space-y-3">
+            <h1 className="text-3xl md:text-4xl font-bold text-forest leading-tight">
+              {event.name}
+            </h1>
+            {when && (
+              <p className="flex items-start gap-2 text-muted">
+                <CalendarDays className="w-5 h-5 text-sage shrink-0 mt-0.5" />
+                <span>{when}</span>
+              </p>
+            )}
+            {location && (
+              <p className="flex items-start gap-2 text-muted">
+                <MapPin className="w-5 h-5 text-sage shrink-0 mt-0.5" />
+                <span>{location}</span>
+              </p>
+            )}
+            {event.hostName && (
+              <p className="text-sm text-muted">Hosted by {event.hostName}</p>
+            )}
+          </header>
+
+          {event.description && (
+            <div className="border-t border-white/10 pt-6">
+              {/* Full text, deliberately unclamped — the landing card is the summary, this is the event. */}
+              <p className="whitespace-pre-line leading-relaxed">{event.description}</p>
+            </div>
+          )}
+        </article>
+
+        <div className="glass-panel p-6 md:p-8 text-center space-y-3">
+          <h2 className="text-xl font-semibold">Members sign in to RSVP</h2>
+          <p className="text-muted text-sm max-w-lg mx-auto leading-relaxed">
+            Public events are open to everyone — just show up. Members sign in to RSVP, host, and
+            manage the collective&apos;s calendar.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center pt-1">
+            <Link href="/auth/login">
+              <Button className="btn-primary-glass gap-2 px-6">
+                <KeyRound className="w-4 h-4" />
+                Sign in
+              </Button>
+            </Link>
+            <Link href="/portal">
+              <Button className="btn-glass px-6">Member Portal</Button>
+            </Link>
+          </div>
+          <p className="text-sm text-muted pt-1">
+            Not a member yet?{" "}
+            <Link href="/freeday" className="text-sage hover:underline">
+              Try a free day →
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/events/page.tsx
+++ b/apps/web/src/app/events/page.tsx
@@ -1,0 +1,85 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { CalendarDays } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { fetchUpcomingEvents } from "@/lib/events";
+import { isRegenosEventsConfigured } from "@/lib/regenos/config";
+import { regenosCalendarIcsUrl } from "@/lib/regenos/events";
+import { CalendarSubscribeNote, EventList, LumaEmbed } from "@/components/events/EventList";
+
+/**
+ * The collective's public calendar, in full — regenhub.xyz's own events page.
+ *
+ * Per Aaron: regenhub.xyz IS the experience. "View Events" used to leave for
+ * lu.ma and an event card used to leave for scenius.social; both now land here,
+ * and a card from here opens `/events/<did>/<rkey>` on this same site.
+ *
+ * Same fallback contract as the landing section (components/landing/UpcomingEvents.tsx):
+ * regenOS unconfigured, quiet, or unreachable ⇒ the Luma embed. This page must
+ * never be an error page.
+ */
+
+export const metadata: Metadata = {
+  title: "Events — RegenHub",
+  description:
+    "Upcoming public events at RegenHub Boulder — community building, learning, and collaboration in the cooperative workspace.",
+};
+
+/** A longer look-ahead than the landing page's 60 days — this is the whole calendar. */
+const HORIZON_DAYS = 120;
+
+export default async function EventsPage() {
+  const configured = isRegenosEventsConfigured();
+  const { source, events } = configured
+    ? await fetchUpcomingEvents(HORIZON_DAYS)
+    : { source: "none" as const, events: [] };
+  const icsUrl = source === "regenos" ? regenosCalendarIcsUrl() : null;
+
+  return (
+    <div className="min-h-screen px-6 py-12">
+      <div className="max-w-4xl mx-auto space-y-10">
+        <div className="text-center space-y-3">
+          <h1 className="text-3xl md:text-4xl font-bold text-forest flex items-center justify-center gap-3">
+            <CalendarDays className="w-8 h-8 text-sage" />
+            Upcoming Events
+          </h1>
+          <p className="text-xl text-muted max-w-2xl mx-auto">
+            Join us for community building, learning, and collaboration. Public events are open to
+            everyone — you don&apos;t have to be a member to come.
+          </p>
+        </div>
+
+        <div className="glass-panel-subtle p-6 md:p-10 space-y-5">
+          {events.length > 0 ? (
+            <>
+              <EventList events={events} />
+              {icsUrl && <CalendarSubscribeNote icsUrl={icsUrl} />}
+            </>
+          ) : (
+            <LumaEmbed />
+          )}
+        </div>
+
+        <div className="glass-panel p-6 text-center space-y-3">
+          <p className="text-muted">
+            Members RSVP, host, and manage the calendar from the portal.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Link href="/portal">
+              <Button className="btn-primary-glass px-6">Member Portal</Button>
+            </Link>
+            <Link href="/freeday">
+              <Button className="btn-glass px-6">Try a Free Day</Button>
+            </Link>
+          </div>
+        </div>
+
+        <p className="text-center text-sm text-muted">
+          <Link href="/" className="underline hover:text-sage transition-colors">
+            Back to regenhub.xyz
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/oauth-client-metadata.json/route.test.ts
+++ b/apps/web/src/app/oauth-client-metadata.json/route.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/regenos/config", () => ({
+  isRegenosLoginEnabled: vi.fn(() => true),
+}));
+
+import { GET } from "./route";
+import { isRegenosLoginEnabled } from "@/lib/regenos/config";
+
+beforeEach(() => {
+  vi.mocked(isRegenosLoginEnabled).mockReturnValue(true);
+  process.env.NEXT_PUBLIC_SITE_URL = "https://regenhub.xyz";
+  delete process.env.REGENOS_OAUTH_JWKS_URI;
+});
+
+describe("GET /oauth-client-metadata.json", () => {
+  it("serves the atproto client-metadata document, client_id equal to its own URL", async () => {
+    const res = GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/application\/json/);
+
+    const doc = await res.json();
+    expect(doc.client_id).toBe("https://regenhub.xyz/oauth-client-metadata.json");
+    expect(doc.redirect_uris).toEqual(["https://regenhub.xyz/oauth/callback"]);
+    expect(doc.scope).toBe("atproto transition:generic");
+    expect(doc.grant_types).toEqual(["authorization_code", "refresh_token"]);
+    expect(doc.response_types).toEqual(["code"]);
+    expect(doc.token_endpoint_auth_method).toBe("none");
+    expect(doc.jwks_uri).toBeUndefined();
+  });
+
+  it("404s when the login flag is off", () => {
+    vi.mocked(isRegenosLoginEnabled).mockReturnValue(false);
+    const res = GET();
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/web/src/app/oauth-client-metadata.json/route.ts
+++ b/apps/web/src/app/oauth-client-metadata.json/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { isRegenosLoginEnabled } from "@/lib/regenos/config";
+import { buildClientMetadataDoc } from "@/lib/regenos/oauth";
+
+/**
+ * GET /oauth-client-metadata.json — regenhub.xyz's static atproto OAuth
+ * client-metadata document.
+ *
+ * This document's URL IS regenhub.xyz's OAuth `client_id`, per the atproto
+ * "client ID metadata document" convention. It declares this app's exact
+ * `redirect_uri` (its clean `/oauth/callback`, NOT the `/xrpc` proxy path),
+ * `scope`, and — once `REGENOS_OAUTH_JWKS_URI` is configured — the shared
+ * AppView JWKS that makes this a confidential `private_key_jwt` client,
+ * exactly like regenOS's own scenius-web/liminal-web
+ * (`OAUTH_CLIENTS` on regenOS's side must register the SAME client_id +
+ * redirect_uri, per `crates/regenos-appview/src/auth/oauth_client.rs`).
+ *
+ * Path and shape follow regenOS's own `oauth-client-metadata.json` route
+ * (`apps/scenius-web/src/app/oauth-client-metadata.json/route.ts`) —
+ * re-authored here, not imported, because `packages/ui` is a private
+ * workspace package regenhub.xyz's repo can't reach.
+ *
+ * GATED ON THE FLAG, same posture as the `/xrpc` proxy: with
+ * REGENOS_LOGIN_ENABLED off this 404s, so no OAuth surface is reachable
+ * before the flag flips. No secrets in the document either way.
+ */
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export function GET(): NextResponse {
+  if (!isRegenosLoginEnabled()) {
+    return NextResponse.json({ error: "NotFound" }, { status: 404 });
+  }
+  return NextResponse.json(buildClientMetadataDoc(), {
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}

--- a/apps/web/src/app/oauth/callback/page.tsx
+++ b/apps/web/src/app/oauth/callback/page.tsx
@@ -1,0 +1,49 @@
+import { Suspense } from "react";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { OAuthCallback } from "@/components/auth/OAuthCallback";
+import { isRegenosLoginEnabled } from "@/lib/regenos/config";
+
+/**
+ * `/oauth/callback` — regenhub.xyz's clean atproto OAuth redirect target
+ * (the EXACT-match registered `redirect_uri`, not the `/xrpc` proxy path).
+ *
+ * The PDS lands the browser here after consent with `code`/`state`/`iss`.
+ * The client <OAuthCallback> hands those to the AppView via the same-origin
+ * `/xrpc` proxy, which lands `__Host-rs_session` on this origin, then runs
+ * the SAME downstream logic the magic-link lane uses
+ * (`POST /api/auth/regenos/session`) before navigating on.
+ *
+ * Server wrapper (so the flag gate + metadata are server-side) over the
+ * client island, which needs a Suspense boundary because it reads
+ * `useSearchParams`. Pattern follows regenOS's own `apps/scenius-web/src/
+ * app/oauth/callback/page.tsx`.
+ *
+ * Gated the same way every other regenOS-login surface in this app is: with
+ * REGENOS_LOGIN_ENABLED off, this route 404s rather than rendering a dead
+ * end (the PDS would never redirect here in the first place, since
+ * `/oauth-client-metadata.json` — the thing that gets this app registered
+ * as an OAuth client at all — is 404ing too).
+ */
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Signing in — RegenHub",
+  robots: { index: false, follow: false },
+};
+
+export default function OAuthCallbackPage() {
+  if (!isRegenosLoginEnabled()) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-6">
+      <div className="w-full max-w-md">
+        <Suspense fallback={null}>
+          <OAuthCallback />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/portal/events/page.tsx
+++ b/apps/web/src/app/portal/events/page.tsx
@@ -1,0 +1,128 @@
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { cookies } from "next/headers";
+import { createClient } from "@/lib/supabase/server";
+import { Button } from "@/components/ui/button";
+import { CalendarDays, KeyRound, ShieldQuestion } from "lucide-react";
+import { isRegenosEventsConfigured, isRegenosLoginEnabled, regenosCollectiveDid } from "@/lib/regenos/config";
+import { fetchRegenosIdentity, fetchRegenosSceneStanding } from "@/lib/regenos/auth";
+import { fetchCollectiveEventsForManagement } from "@/lib/regenos/events";
+import { ManageEvents, type ManageableEvent } from "@/components/portal/ManageEvents";
+
+export const metadata = { title: "Manage Events — RegenHub" };
+
+/** Every read here is per-caller and per-cookie; nothing about this page is cacheable. */
+export const dynamic = "force-dynamic";
+
+function Explainer({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="glass-panel p-8 max-w-lg">
+      <h2 className="text-xl font-semibold mb-3">{title}</h2>
+      <div className="text-muted text-sm space-y-3 leading-relaxed">{children}</div>
+    </div>
+  );
+}
+
+export default async function ManageEventsPage() {
+  // The whole lane rides the login flag: no regenOS session, no way to authenticate a write.
+  if (!isRegenosLoginEnabled()) notFound();
+
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login");
+
+  const header = (
+    <div>
+      <h1 className="text-3xl font-bold text-forest flex items-center gap-3">
+        <CalendarDays className="w-7 h-7 text-sage" />
+        Manage Events
+      </h1>
+      <p className="text-muted mt-1">RegenHub&apos;s calendar on the commons, edited here.</p>
+    </div>
+  );
+
+  const collectiveDid = regenosCollectiveDid();
+  if (!isRegenosEventsConfigured() || !collectiveDid) {
+    return (
+      <div className="space-y-8">
+        {header}
+        <Explainer title="Events aren't wired up yet">
+          <p>
+            The collective&apos;s calendar lives in regenOS, and this deployment doesn&apos;t have a
+            collective configured yet. An admin needs to set <code>REGENOS_COLLECTIVE_DID</code>.
+          </p>
+        </Explainer>
+      </div>
+    );
+  }
+
+  // The regenOS session cookie was set on THIS origin by the /xrpc proxy, so we
+  // can replay the caller's own cookies to the AppView and ask who they are.
+  const cookieHeader = (await cookies()).toString();
+  const identity = await fetchRegenosIdentity(cookieHeader);
+
+  if (!identity) {
+    return (
+      <div className="space-y-8">
+        {header}
+        <Explainer title="Sign in with regenOS to manage events">
+          <p>
+            You&apos;re signed in to RegenHub, but events live on the commons and need your regenOS
+            identity — that&apos;s what proves to the calendar that you&apos;re a steward here.
+          </p>
+          <p>Sign in through the regenOS lane and come back.</p>
+          <Link href="/auth/login" className="inline-block pt-1">
+            <Button className="btn-primary-glass gap-2 px-6">
+              <KeyRound className="w-4 h-4" />
+              Sign in with regenOS
+            </Button>
+          </Link>
+        </Explainer>
+      </div>
+    );
+  }
+
+  const standing = await fetchRegenosSceneStanding(cookieHeader, collectiveDid, identity.did);
+
+  if (!standing.canManageEvents) {
+    return (
+      <div className="space-y-8">
+        {header}
+        <Explainer title="Only stewards edit the calendar">
+          <p>
+            You&apos;re signed in as{" "}
+            <strong className="text-foreground">{identity.handle ?? identity.did}</strong>, but the
+            collective lists you as{" "}
+            <strong className="text-foreground">{standing.role ?? "not a member"}</strong>. Creating
+            and editing RegenHub events needs Builder or higher.
+          </p>
+          <p className="flex items-start gap-2">
+            <ShieldQuestion className="w-4 h-4 mt-0.5 shrink-0 text-sage" />
+            <span>
+              If that&apos;s wrong, ask a steward to update your role in the collective — the calendar
+              reads it live, so it takes effect as soon as they do.
+            </span>
+          </p>
+        </Explainer>
+      </div>
+    );
+  }
+
+  const events = await fetchCollectiveEventsForManagement(cookieHeader);
+  const manageable: ManageableEvent[] = events.map((e) => ({
+    uri: e.uri,
+    rkey: e.rkey,
+    name: e.name,
+    startAt: e.startAt,
+    visibility: e.visibility,
+    value: e.value,
+    url: e.url,
+  }));
+
+  return (
+    <div className="space-y-8">
+      {header}
+      <ManageEvents authority={collectiveDid} events={manageable} />
+    </div>
+  );
+}

--- a/apps/web/src/app/portal/layout.tsx
+++ b/apps/web/src/app/portal/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import Link from "next/link";
 import { MobileNav, type NavLink } from "@/components/nav/MobileNav";
+import { isRegenosLoginEnabled } from "@/lib/regenos/config";
 
 export const metadata = { title: "Member Portal — RegenHub" };
 
@@ -17,11 +18,17 @@ export default async function PortalLayout({ children }: { children: React.React
     .eq("supabase_user_id", user.id)
     .single();
 
+  // Steward-ness is a regenOS read, and doing it here would put an AppView
+  // round-trip on every portal page. The link is flag-gated; the page itself
+  // explains honestly when the person isn't a steward.
+  const eventsEnabled = isRegenosLoginEnabled();
+
   const links: NavLink[] = [
     { href: "/portal", label: "Dashboard" },
     { href: "/portal/my-code", label: "My Code" },
     { href: "/portal/passes", label: "Live Codes" },
     { href: "/portal/profile", label: "Profile" },
+    ...(eventsEnabled ? [{ href: "/portal/events", label: "Events" }] : []),
     ...(member?.is_admin ? [{ href: "/admin", label: "Admin", accent: true }] : []),
   ];
 
@@ -46,6 +53,9 @@ export default async function PortalLayout({ children }: { children: React.React
               <Link href="/portal/my-code" className="text-muted hover:text-foreground transition-colors">My Code</Link>
               <Link href="/portal/passes" className="text-muted hover:text-foreground transition-colors">Live Codes</Link>
               <Link href="/portal/profile" className="text-muted hover:text-foreground transition-colors">Profile</Link>
+              {eventsEnabled && (
+                <Link href="/portal/events" className="text-muted hover:text-foreground transition-colors">Events</Link>
+              )}
               {member?.is_admin && (
                 <Link href="/admin" className="text-gold hover:text-gold/80 transition-colors">Admin</Link>
               )}

--- a/apps/web/src/app/portal/page.tsx
+++ b/apps/web/src/app/portal/page.tsx
@@ -3,7 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { createServiceClient } from "@/lib/supabase/admin";
 import { Card, CardContent } from "@/components/ui/card";
 import Link from "next/link";
-import { Key, Ticket, User, ClipboardList, CheckCircle, Clock, MessageCircle, Zap, Calendar, ArrowRight, AlertCircle } from "lucide-react";
+import { Key, Ticket, User, ClipboardList, CheckCircle, Clock, MessageCircle, Zap, Calendar, CalendarDays, ArrowRight, AlertCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import HubEssentials from "@/components/portal/HubEssentials";
 import InviteCard from "@/components/portal/InviteCard";
@@ -15,6 +15,7 @@ import { DayPassRedemptionHero } from "@/components/portal/DayPassRedemptionHero
 import { MembershipStatusCard } from "@/components/portal/MembershipStatusCard";
 import { InstallPrompt } from "@/components/pwa/InstallPrompt";
 import { planLabel, getPlan } from "@/lib/plans";
+import { isRegenosLoginEnabled } from "@/lib/regenos/config";
 
 export default async function PortalPage() {
   const supabase = await createClient();
@@ -410,6 +411,19 @@ export default async function PortalPage() {
             </CardContent>
           </Card>
         </Link>
+
+        {/* Flag-gated only — steward-ness is a regenOS read the page itself does. */}
+        {isRegenosLoginEnabled() && (
+          <Link href="/portal/events">
+            <Card className="glass-panel hover-lift cursor-pointer">
+              <CardContent className="p-6">
+                <CalendarDays className="w-8 h-8 text-sage mb-3" />
+                <h3 className="font-semibold mb-1">Manage Events</h3>
+                <p className="text-sm text-muted">Create and edit the collective&apos;s calendar</p>
+              </CardContent>
+            </Card>
+          </Link>
+        )}
 
         {member.is_coop_member && <InviteCard />}
       </div>

--- a/apps/web/src/app/xrpc/[...nsid]/route.test.ts
+++ b/apps/web/src/app/xrpc/[...nsid]/route.test.ts
@@ -59,6 +59,38 @@ describe("xrpc proxy allowlist", () => {
     expect(upstream).toHaveBeenCalledOnce();
   });
 
+  it("forwards beginOAuth (POST)", async () => {
+    const res = await POST(req("social.scenius.beginOAuth"), ctx("social.scenius.beginOAuth"));
+    expect(res.status).toBe(200);
+    expect(upstream).toHaveBeenCalledOnce();
+    expect(upstream.mock.calls[0][0]).toBe("https://appview.test/xrpc/social.scenius.beginOAuth");
+  });
+
+  it("forwards oauthCallback (GET) and relays its Set-Cookie", async () => {
+    upstream.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "set-cookie": "__Host-rs_session=opaque; Path=/; Secure; HttpOnly",
+        },
+      }),
+    );
+    const res = await GET(
+      req("social.scenius.oauthCallback", "GET"),
+      ctx("social.scenius.oauthCallback"),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("set-cookie")).toMatch(/^__Host-rs_session=opaque/);
+  });
+
+  it("404s beginOAuth/oauthCallback when the login flag is off", async () => {
+    vi.mocked(isRegenosLoginEnabled).mockReturnValue(false);
+    const res = await POST(req("social.scenius.beginOAuth"), ctx("social.scenius.beginOAuth"));
+    expect(res.status).toBe(404);
+    expect(upstream).not.toHaveBeenCalled();
+  });
+
   it.each([
     // Neighbours of the allowed writes — near-misses are the ones that matter.
     "social.scenius.setMembership",

--- a/apps/web/src/app/xrpc/[...nsid]/route.test.ts
+++ b/apps/web/src/app/xrpc/[...nsid]/route.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/regenos/config", () => ({
+  isRegenosLoginEnabled: vi.fn(() => true),
+  regenosBaseUrl: vi.fn(() => "https://appview.test"),
+  REGENOS_TIMEOUT_MS: 8_000,
+}));
+
+import { NextRequest } from "next/server";
+import { GET, POST } from "./route";
+import { isRegenosLoginEnabled } from "@/lib/regenos/config";
+
+/** The proxy's own contract, exercised through the handler: gate first, then forward. */
+function ctx(nsid: string) {
+  return { params: Promise.resolve({ nsid: [nsid] }) };
+}
+
+function req(nsid: string, method: "GET" | "POST" = "POST") {
+  return new NextRequest(`https://regenhub.xyz/xrpc/${nsid}`, {
+    method,
+    headers: { cookie: "__Host-rs_session=opaque", "content-type": "application/json" },
+    ...(method === "POST" ? { body: JSON.stringify({ rkey: "ev-1" }) } : {}),
+  });
+}
+
+const upstream = vi.fn();
+
+beforeEach(() => {
+  upstream.mockReset();
+  upstream.mockResolvedValue(
+    new Response(JSON.stringify({ eventUri: "at://did:plc:hub/community.lexicon.calendar.event/ev-1" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+  vi.stubGlobal("fetch", upstream);
+  vi.mocked(isRegenosLoginEnabled).mockReturnValue(true);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("xrpc proxy allowlist", () => {
+  it.each([
+    "social.scenius.createEvent",
+    "social.scenius.updateEvent",
+    "social.scenius.deleteEvent",
+  ])("forwards the event write %s", async (nsid) => {
+    const res = await POST(req(nsid), ctx(nsid));
+    expect(res.status).toBe(200);
+    expect(upstream).toHaveBeenCalledOnce();
+    expect(upstream.mock.calls[0][0]).toBe(`https://appview.test/xrpc/${nsid}`);
+  });
+
+  it("still forwards the login NSIDs", async () => {
+    const res = await GET(req("social.scenius.getSession", "GET"), ctx("social.scenius.getSession"));
+    expect(res.status).toBe(200);
+    expect(upstream).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    // Neighbours of the allowed writes — near-misses are the ones that matter.
+    "social.scenius.setMembership",
+    "social.scenius.adoptEvent",
+    "social.scenius.rsvp",
+    "social.scenius.inviteToEvent",
+    "social.scenius.createScene",
+  ])("404s the unlisted %s without touching the AppView", async (nsid) => {
+    const res = await POST(req(nsid), ctx(nsid));
+    expect(res.status).toBe(404);
+    expect(upstream).not.toHaveBeenCalled();
+  });
+
+  it("404s an allowed event write when the login flag is off", async () => {
+    vi.mocked(isRegenosLoginEnabled).mockReturnValue(false);
+    const res = await POST(req("social.scenius.createEvent"), ctx("social.scenius.createEvent"));
+    expect(res.status).toBe(404);
+    expect(upstream).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/xrpc/[...nsid]/route.ts
+++ b/apps/web/src/app/xrpc/[...nsid]/route.ts
@@ -32,6 +32,13 @@ export const runtime = "nodejs";
  * nothing else.
  * - beginSignup / setSignupProfile / createCustodialAccount — the signup wizard
  * - verifySignup / verifyEmail — the magic-link redemptions
+ * - beginOAuth / oauthCallback — the real atproto OAuth login lane
+ *   (`lib/regenos/oauth.ts`, `components/auth/OAuthSignInButton.tsx` +
+ *   `OAuthCallback.tsx`): begin resolves the PDS authorize URL, callback
+ *   exchanges the PDS's code/state/iss for the same `__Host-rs_session`
+ *   cookie the magic-link lane lands. Same trust posture as the rest of this
+ *   list — the AppView does the real verification, this proxy only carries
+ *   the cookie onto regenhub.xyz's origin.
  * - getSession / getMyContactPref — whoami, read by the browser for UI state
  * - createEvent / updateEvent / deleteEvent — /portal/events, the stewards'
  *   in-portal calendar. These are the only WRITES on the list; each one is
@@ -44,6 +51,8 @@ const ALLOWED_NSIDS = new Set([
   "social.scenius.setSignupProfile",
   "social.scenius.createCustodialAccount",
   "social.scenius.verifyEmail",
+  "social.scenius.beginOAuth",
+  "social.scenius.oauthCallback",
   "social.scenius.getSession",
   "social.scenius.getMyContactPref",
   "social.scenius.logout",

--- a/apps/web/src/app/xrpc/[...nsid]/route.ts
+++ b/apps/web/src/app/xrpc/[...nsid]/route.ts
@@ -1,0 +1,117 @@
+/**
+ * One-origin XRPC proxy — regenhub.xyz's door onto the regenOS AppView.
+ *
+ * Ported from regenOS's own `apps/liminal-web/src/app/xrpc/[...nsid]/route.ts`
+ * (which is itself a copy of scenius-web's). It is a ROUTE HANDLER, never a
+ * `next.config` rewrite: a rewrite cannot reliably re-emit `Set-Cookie`, and
+ * the whole point is the cookie.
+ *
+ * WHY IT MUST EXIST: the AppView's session cookie is `__Host-rs_session`, and
+ * the `__Host-` prefix FORBIDS a `Domain` attribute — so the cookie can only
+ * ever land on the origin that emitted the response. The browser therefore has
+ * to talk to regenOS through regenhub.xyz's own origin, or regenhub.xyz never
+ * sees a regenOS session at all.
+ *
+ * GATED ON THE FLAG: with REGENOS_LOGIN_ENABLED off this route 404s, so
+ * enabling regenOS events does not silently open an auth surface.
+ *
+ * NOT A GENERAL-PURPOSE OPEN PROXY: only the handful of NSIDs the login flow
+ * needs are forwarded. Everything else 404s. (The upstream copies forward the
+ * whole namespace because they *are* the regenOS frontend; we are a third
+ * domain borrowing one flow, so the smallest hole is the right hole.)
+ */
+import { type NextRequest, NextResponse } from "next/server";
+import { isRegenosLoginEnabled, regenosBaseUrl, REGENOS_TIMEOUT_MS } from "@/lib/regenos/config";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * The login flow's method surface, and nothing else.
+ * - beginSignup / setSignupProfile / createCustodialAccount — the signup wizard
+ * - verifySignup / verifyEmail — the magic-link redemptions
+ * - getSession / getMyContactPref — whoami, read by the browser for UI state
+ */
+const ALLOWED_NSIDS = new Set([
+  "social.scenius.beginSignup",
+  "social.scenius.verifySignup",
+  "social.scenius.setSignupProfile",
+  "social.scenius.createCustodialAccount",
+  "social.scenius.verifyEmail",
+  "social.scenius.getSession",
+  "social.scenius.getMyContactPref",
+  "social.scenius.logout",
+]);
+
+// Request headers we must NOT blindly forward (hop-by-hop / host-rewriting).
+const STRIP_REQUEST = new Set(["host", "connection", "content-length", "accept-encoding"]);
+// Response headers we must NOT copy back (Next re-computes encoding/length).
+const STRIP_RESPONSE = new Set(["content-encoding", "content-length", "transfer-encoding", "connection"]);
+
+async function proxy(req: NextRequest, nsid: string[]): Promise<NextResponse> {
+  if (!isRegenosLoginEnabled()) {
+    return NextResponse.json({ error: "NotFound" }, { status: 404 });
+  }
+
+  const method = nsid.join("/");
+  if (!ALLOWED_NSIDS.has(method)) {
+    return NextResponse.json({ error: "NotFound" }, { status: 404 });
+  }
+
+  const base = regenosBaseUrl()!;
+  const target = `${base}/xrpc/${method}${req.nextUrl.search}`;
+
+  const headers = new Headers();
+  req.headers.forEach((value, key) => {
+    if (STRIP_REQUEST.has(key.toLowerCase())) return;
+    headers.set(key, value);
+  });
+
+  const init: RequestInit = {
+    method: req.method,
+    headers,
+    redirect: "manual",
+    cache: "no-store",
+    signal: AbortSignal.timeout(REGENOS_TIMEOUT_MS),
+  };
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    init.body = await req.arrayBuffer();
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, init);
+  } catch {
+    // Same posture as every other external call in this app: a human-readable
+    // 502 rather than a stack trace (cf. api/lock/revoke/route.ts:25-34).
+    return NextResponse.json(
+      { error: "UpstreamUnavailable", message: "Can't reach regenOS right now." },
+      { status: 502 },
+    );
+  }
+
+  const body = await upstream.arrayBuffer();
+  const res = new NextResponse(body, { status: upstream.status });
+  upstream.headers.forEach((value, key) => {
+    if (!STRIP_RESPONSE.has(key.toLowerCase())) res.headers.set(key, value);
+  });
+  // getSetCookie() preserves multiple Set-Cookie headers a flat forEach would
+  // coalesce — relay each verbatim so the browser stores the AppView's own
+  // `__Host-rs_session` on regenhub.xyz.
+  const setCookies = upstream.headers.getSetCookie?.() ?? [];
+  if (setCookies.length > 0) {
+    res.headers.delete("set-cookie");
+    for (const c of setCookies) res.headers.append("set-cookie", c);
+  }
+  return res;
+}
+
+type Ctx = { params: Promise<{ nsid: string[] }> };
+
+export async function GET(req: NextRequest, ctx: Ctx): Promise<NextResponse> {
+  return proxy(req, (await ctx.params).nsid);
+}
+
+export async function POST(req: NextRequest, ctx: Ctx): Promise<NextResponse> {
+  return proxy(req, (await ctx.params).nsid);
+}

--- a/apps/web/src/app/xrpc/[...nsid]/route.ts
+++ b/apps/web/src/app/xrpc/[...nsid]/route.ts
@@ -16,9 +16,10 @@
  * enabling regenOS events does not silently open an auth surface.
  *
  * NOT A GENERAL-PURPOSE OPEN PROXY: only the handful of NSIDs the login flow
- * needs are forwarded. Everything else 404s. (The upstream copies forward the
- * whole namespace because they *are* the regenOS frontend; we are a third
- * domain borrowing one flow, so the smallest hole is the right hole.)
+ * and the in-portal events manager need are forwarded. Everything else 404s.
+ * (The upstream copies forward the whole namespace because they *are* the
+ * regenOS frontend; we are a third domain borrowing two flows, so the smallest
+ * hole is the right hole.)
  */
 import { type NextRequest, NextResponse } from "next/server";
 import { isRegenosLoginEnabled, regenosBaseUrl, REGENOS_TIMEOUT_MS } from "@/lib/regenos/config";
@@ -27,10 +28,15 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 /**
- * The login flow's method surface, and nothing else.
+ * The login flow's method surface, plus the event-stewardship writes, and
+ * nothing else.
  * - beginSignup / setSignupProfile / createCustodialAccount — the signup wizard
  * - verifySignup / verifyEmail — the magic-link redemptions
  * - getSession / getMyContactPref — whoami, read by the browser for UI state
+ * - createEvent / updateEvent / deleteEvent — /portal/events, the stewards'
+ *   in-portal calendar. These are the only WRITES on the list; each one is
+ *   gated server-side by the AppView on Builder+ of the event's authority
+ *   (`require_owner_or_builder`), so the proxy widens reach, never authority.
  */
 const ALLOWED_NSIDS = new Set([
   "social.scenius.beginSignup",
@@ -41,6 +47,9 @@ const ALLOWED_NSIDS = new Set([
   "social.scenius.getSession",
   "social.scenius.getMyContactPref",
   "social.scenius.logout",
+  "social.scenius.createEvent",
+  "social.scenius.updateEvent",
+  "social.scenius.deleteEvent",
 ]);
 
 // Request headers we must NOT blindly forward (hop-by-hop / host-rewriting).

--- a/apps/web/src/components/auth/OAuthCallback.tsx
+++ b/apps/web/src/components/auth/OAuthCallback.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { resolveOAuthCallback, type OAuthCallbackResult } from "@/lib/regenos/oauth";
+
+/**
+ * <OAuthCallback> — the browser side of `/oauth/callback`.
+ *
+ * The PDS lands the browser here (a top-level same-origin navigation, so the
+ * sealed AppView state cookie rides along). This hands `code`/`state`/`iss`
+ * to `resolveOAuthCallback`, which forwards them to the AppView's
+ * `social.scenius.oauthCallback` through this app's same-origin `/xrpc`
+ * proxy with `credentials:'include'` — the AppView verifies + mints, the
+ * proxy relays `Set-Cookie __Host-rs_session` onto regenhub.xyz.
+ *
+ * On success it does NOT stop there: unlike regenOS's own apps (where
+ * landing the cookie IS being signed in), regenhub.xyz still needs to run
+ * the SAME downstream handoff the magic-link lane uses — match the verified
+ * email to a `members` row, mint the Supabase session
+ * (`POST /api/auth/regenos/session`, `RegenosLoginPanel.tsx`'s `finish()`).
+ * This stays mounted only on failure, rendering the mapped error states;
+ * on success the navigation to `/portal` or `/membership` takes over.
+ *
+ * MUST run in the browser (the session cookie only "lands" via the
+ * browser's own fetch + cookie jar), hence a client component.
+ */
+type Failure = Extract<OAuthCallbackResult, { ok: false }>;
+
+interface SessionResponse {
+  ok?: boolean;
+  member?: boolean;
+  redirect?: string;
+  error?: string;
+}
+
+function reasonHeading(result: Failure): string {
+  switch (result.reason) {
+    case "denied":
+      return "Sign-in was cancelled";
+    case "state_mismatch":
+    case "invalid_callback":
+      return "That sign-in link didn't check out";
+    case "iss_mismatch":
+      return "We couldn't verify the sign-in provider";
+    case "as_error":
+    case "server_error":
+    default:
+      return "Sign-in couldn't be completed";
+  }
+}
+
+export function OAuthCallback() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const ranRef = useRef(false);
+  const [failure, setFailure] = useState<Failure | null>(null);
+
+  useEffect(() => {
+    if (ranRef.current) return;
+    ranRef.current = true;
+
+    (async () => {
+      const result = await resolveOAuthCallback({
+        code: searchParams.get("code"),
+        state: searchParams.get("state"),
+        iss: searchParams.get("iss"),
+        error: searchParams.get("error"),
+        errorDescription: searchParams.get("error_description"),
+      });
+
+      if (!result.ok) {
+        setFailure(result);
+        return;
+      }
+
+      // __Host-rs_session just landed on this origin. Finish exactly like the
+      // magic-link lane: match the verified email to a membership, mint the
+      // Supabase session, then go where that handoff says to go.
+      try {
+        const res = await fetch("/api/auth/regenos/session", { method: "POST" });
+        const data = (await res.json()) as SessionResponse;
+        if (!res.ok || !data.ok) {
+          setFailure({
+            ok: false,
+            reason: "server_error",
+            message: data.error ?? "Couldn't finish signing you in.",
+          });
+          return;
+        }
+        router.push(data.redirect ?? (data.member ? "/portal" : "/membership"));
+        router.refresh();
+      } catch {
+        setFailure({
+          ok: false,
+          reason: "server_error",
+          message: "Couldn't reach RegenHub. Try again in a moment.",
+        });
+      }
+    })();
+  }, [searchParams, router]);
+
+  if (!failure) {
+    return (
+      <div className="glass-panel-strong p-8 text-center space-y-2">
+        <p className="text-sm text-muted">Signing you in…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="glass-panel-strong p-8 text-center space-y-4">
+      <h1 className="text-2xl font-bold text-forest">{reasonHeading(failure)}</h1>
+      <p className="text-sm text-muted">{failure.message}</p>
+      <a href="/auth/login" className="btn-primary-glass inline-block px-6 py-2">
+        Try again
+      </a>
+    </div>
+  );
+}

--- a/apps/web/src/components/auth/OAuthSignInButton.tsx
+++ b/apps/web/src/components/auth/OAuthSignInButton.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RegenosOAuthError, requestAuthorizeUrl } from "@/lib/regenos/oauth";
+
+/**
+ * <OAuthSignInButton> — the real atproto OAuth sign-in affordance (the thing
+ * this build is FOR: regenOS acting like Google OAuth, not the email-match
+ * bridge). Coexists with the magic-link form above it in
+ * `RegenosLoginPanel.tsx` — both end up at the same
+ * `POST /api/auth/regenos/session` handoff once a regenOS session cookie
+ * exists on this origin, just via a different door.
+ *
+ * It's a minimal form, not a bare button: the AppView's real atrium OAuth
+ * client resolves the person's authorization server from an IDENTIFIER
+ * (handle / DID / PDS URL) before PAR, so one has to be collected up front —
+ * mirrors regenOS's own `<OAuthSignInButton>`
+ * (`apps/scenius-web/src/components/oauth-sign-in-button.tsx`).
+ *
+ * `requestAuthorizeUrl` POSTs `social.scenius.beginOAuth` (forwarding
+ * `{identifier, clientId, redirectUri}`) through this app's same-origin
+ * `/xrpc` proxy; on success this navigates the browser to the PDS consent
+ * screen it returns. A begin FAILURE (unresolvable handle, AppView error)
+ * surfaces inline instead.
+ */
+export function OAuthSignInButton() {
+  const [identifier, setIdentifier] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmed = identifier.trim();
+  const canSubmit = trimmed.length > 0 && !busy;
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setError(null);
+    setBusy(true);
+    try {
+      const authorizeUrl = await requestAuthorizeUrl(trimmed);
+      window.location.assign(authorizeUrl);
+      // Navigation takes over; leave `busy` true so nothing re-enables the
+      // form during the redirect.
+    } catch (err) {
+      setError(
+        err instanceof RegenosOAuthError && err.message
+          ? err.message
+          : "Could not start sign-in. Check the handle and try again.",
+      );
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-2">
+      <div className="space-y-2">
+        <Label htmlFor="regenos-oauth-identifier">Or sign in with your atproto handle</Label>
+        <Input
+          id="regenos-oauth-identifier"
+          value={identifier}
+          onChange={(e) => setIdentifier(e.target.value)}
+          placeholder="you.bsky.social"
+          autoComplete="username"
+          autoCapitalize="none"
+          spellCheck={false}
+          disabled={busy}
+          className="bg-white/10 border-white/20 text-foreground placeholder:text-muted"
+        />
+      </div>
+      {error && (
+        <p className="text-red-400 text-sm" role="alert">
+          {error}
+        </p>
+      )}
+      <Button type="submit" disabled={!canSubmit} className="btn-glass w-full">
+        {busy ? "Taking you there…" : "Sign in with atproto"}
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/src/components/auth/RegenosLoginPanel.tsx
+++ b/apps/web/src/components/auth/RegenosLoginPanel.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+/**
+ * The regenOS sign-in lane (Phase 2, behind REGENOS_LOGIN_ENABLED).
+ *
+ * Rendered ABOVE the existing Supabase form, never instead of it — the classic
+ * one-time-link door stays as the fallback lane for the whole transition, so a
+ * regenOS outage can never lock members out of their own door.
+ *
+ * The flow, all through this app's own same-origin /xrpc proxy so the AppView's
+ * `__Host-rs_session` cookie lands on regenhub.xyz:
+ *
+ *   beginSignup { email }
+ *     → stage "login"        (regenOS trusted the session immediately)  → finish
+ *     → stage "checkEmail"   (magic link sent)                          → wait, then finish
+ *     → stage "chooseHandle" (no regenOS account for this email)        → point at the classic lane
+ *
+ * "Finish" is POST /api/auth/regenos/session: match the verified email to a
+ * membership, link the DID, mint the RegenHub session.
+ */
+
+type Stage = "idle" | "sending" | "checkEmail" | "noAccount" | "finishing";
+
+interface BeginSignupResponse {
+  stage?: string;
+  returningUser?: boolean;
+}
+
+interface SessionResponse {
+  ok?: boolean;
+  member?: boolean;
+  redirect?: string;
+  error?: string;
+}
+
+export function RegenosLoginPanel({ next = "/portal" }: { next?: string }) {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [stage, setStage] = useState<Stage>("idle");
+  const [error, setError] = useState<string | null>(null);
+  /** A regenOS session already on this browser — e.g. they just clicked the link. */
+  const [existingHandle, setExistingHandle] = useState<string | null | undefined>(undefined);
+
+  // On mount, ask regenOS whether this browser is already signed in. If it is,
+  // we offer a one-click continue instead of asking for an email they've
+  // already proven. Anonymous callers get `{}` — no error, no noise.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/xrpc/social.scenius.getSession", { cache: "no-store" });
+        if (!res.ok) return;
+        const data = (await res.json()) as { did?: string; handle?: string };
+        if (!cancelled && data.did) setExistingHandle(data.handle ?? data.did);
+      } catch {
+        // regenOS unreachable — the classic lane below still works.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function finish() {
+    setStage("finishing");
+    setError(null);
+    try {
+      const res = await fetch("/api/auth/regenos/session", { method: "POST" });
+      const data = (await res.json()) as SessionResponse;
+      if (!res.ok || !data.ok) {
+        setError(data.error ?? "Couldn't finish signing you in.");
+        setStage("idle");
+        return;
+      }
+      router.push(data.member ? next : (data.redirect ?? "/membership"));
+      router.refresh();
+    } catch {
+      setError("Couldn't reach RegenHub. Try again in a moment.");
+      setStage("idle");
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setStage("sending");
+    setError(null);
+
+    let data: BeginSignupResponse;
+    try {
+      const res = await fetch("/xrpc/social.scenius.beginSignup", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      if (!res.ok) {
+        setError("regenOS didn't accept that email. Try the classic sign-in link below.");
+        setStage("idle");
+        return;
+      }
+      data = (await res.json()) as BeginSignupResponse;
+    } catch {
+      setError("Can't reach regenOS right now. Use the classic sign-in link below.");
+      setStage("idle");
+      return;
+    }
+
+    if (data.stage === "login") {
+      await finish();
+    } else if (data.stage === "checkEmail") {
+      setStage("checkEmail");
+    } else {
+      // "chooseHandle" — regenOS has no account for this email yet. Creating one
+      // is a signup wizard, not a login surface; the classic lane is the answer.
+      setStage("noAccount");
+    }
+  }
+
+  if (existingHandle) {
+    return (
+      <Panel>
+        <p className="text-sm text-muted">
+          You&apos;re signed in to regenOS as <strong>{existingHandle}</strong>.
+        </p>
+        {error && <p className="text-red-400 text-sm">{error}</p>}
+        <Button
+          onClick={finish}
+          disabled={stage === "finishing"}
+          className="btn-primary-glass w-full"
+        >
+          {stage === "finishing" ? "Signing you in…" : "Continue to RegenHub"}
+        </Button>
+      </Panel>
+    );
+  }
+
+  if (stage === "checkEmail") {
+    return (
+      <Panel>
+        <div className="text-center space-y-1">
+          <div className="text-3xl">📬</div>
+          <p className="text-sm text-muted">
+            regenOS sent a sign-in link to <strong>{email}</strong>. Open it, then come back here.
+          </p>
+        </div>
+        {error && <p className="text-red-400 text-sm">{error}</p>}
+        <Button
+          onClick={finish}
+          disabled={stage !== "checkEmail" && stage !== "finishing"}
+          className="btn-glass w-full"
+        >
+          I&apos;ve clicked the link
+        </Button>
+      </Panel>
+    );
+  }
+
+  if (stage === "noAccount") {
+    return (
+      <Panel>
+        <p className="text-sm text-muted">
+          No regenOS account for <strong>{email}</strong> yet. Use the classic sign-in link below —
+          it works exactly as it always has.
+        </p>
+        <Button onClick={() => setStage("idle")} className="btn-glass w-full">
+          Try a different email
+        </Button>
+      </Panel>
+    );
+  }
+
+  return (
+    <Panel>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="regenos-email">Sign in with your membership email</Label>
+          <Input
+            id="regenos-email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@example.com"
+            required
+            className="bg-white/10 border-white/20 text-foreground placeholder:text-muted"
+          />
+          <p className="text-xs text-muted">
+            Use your membership email — that&apos;s how we find your RegenHub account.
+          </p>
+        </div>
+        {error && <p className="text-red-400 text-sm">{error}</p>}
+        <Button
+          type="submit"
+          disabled={stage === "sending" || stage === "finishing"}
+          className="btn-primary-glass w-full"
+        >
+          {stage === "sending" ? "Checking…" : "Continue with regenOS"}
+        </Button>
+      </form>
+    </Panel>
+  );
+}
+
+function Panel({ children }: { children: React.ReactNode }) {
+  return <div className="space-y-4">{children}</div>;
+}

--- a/apps/web/src/components/auth/RegenosLoginPanel.tsx
+++ b/apps/web/src/components/auth/RegenosLoginPanel.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { OAuthSignInButton } from "@/components/auth/OAuthSignInButton";
 
 /**
  * The regenOS sign-in lane (Phase 2, behind REGENOS_LOGIN_ENABLED).
@@ -13,16 +14,25 @@ import { Label } from "@/components/ui/label";
  * one-time-link door stays as the fallback lane for the whole transition, so a
  * regenOS outage can never lock members out of their own door.
  *
- * The flow, all through this app's own same-origin /xrpc proxy so the AppView's
- * `__Host-rs_session` cookie lands on regenhub.xyz:
+ * Two regenOS doors into the SAME finish, both through this app's own
+ * same-origin /xrpc proxy so the AppView's `__Host-rs_session` cookie lands
+ * on regenhub.xyz:
  *
- *   beginSignup { email }
- *     → stage "login"        (regenOS trusted the session immediately)  → finish
- *     → stage "checkEmail"   (magic link sent)                          → wait, then finish
- *     → stage "chooseHandle" (no regenOS account for this email)        → point at the classic lane
+ *   1. Email bridge (below) — beginSignup { email }
+ *        → stage "login"        (regenOS trusted the session immediately)  → finish
+ *        → stage "checkEmail"   (magic link sent)                          → wait, then finish
+ *        → stage "chooseHandle" (no regenOS account for this email)        → point at the classic lane
+ *   2. Real atproto OAuth (<OAuthSignInButton>, `lib/regenos/oauth.ts`) — an
+ *      atproto handle → beginOAuth → PDS consent → `/oauth/callback` lands
+ *      the same session cookie → finish. This is the mechanism Aaron asked
+ *      for (regenOS acting like Google OAuth); the email bridge stays as a
+ *      second door, not a stepping-stone to be deleted.
  *
  * "Finish" is POST /api/auth/regenos/session: match the verified email to a
- * membership, link the DID, mint the RegenHub session.
+ * membership, link the DID, mint the RegenHub session. Both doors call it —
+ * <OAuthCallback> (`components/auth/OAuthCallback.tsx`) calls it itself once
+ * its own cookie has landed, so this component's `finish()` only ever
+ * services the email-bridge doors above.
  */
 
 /** Which view is on screen. `busy` is tracked separately so an in-flight
@@ -193,6 +203,7 @@ export function RegenosLoginPanel({ next = "/portal" }: { next?: string }) {
           {busy ? "Checking…" : "Continue with regenOS"}
         </Button>
       </form>
+      <OAuthSignInButton />
     </Panel>
   );
 }

--- a/apps/web/src/components/auth/RegenosLoginPanel.tsx
+++ b/apps/web/src/components/auth/RegenosLoginPanel.tsx
@@ -25,7 +25,9 @@ import { Label } from "@/components/ui/label";
  * membership, link the DID, mint the RegenHub session.
  */
 
-type Stage = "idle" | "sending" | "checkEmail" | "noAccount" | "finishing";
+/** Which view is on screen. `busy` is tracked separately so an in-flight
+ *  request never yanks the view out from under the person. */
+type Stage = "idle" | "checkEmail" | "noAccount";
 
 interface BeginSignupResponse {
   stage?: string;
@@ -43,6 +45,7 @@ export function RegenosLoginPanel({ next = "/portal" }: { next?: string }) {
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [stage, setStage] = useState<Stage>("idle");
+  const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   /** A regenOS session already on this browser — e.g. they just clicked the link. */
   const [existingHandle, setExistingHandle] = useState<string | null | undefined>(undefined);
@@ -68,27 +71,27 @@ export function RegenosLoginPanel({ next = "/portal" }: { next?: string }) {
   }, []);
 
   async function finish() {
-    setStage("finishing");
+    setBusy(true);
     setError(null);
     try {
       const res = await fetch("/api/auth/regenos/session", { method: "POST" });
       const data = (await res.json()) as SessionResponse;
       if (!res.ok || !data.ok) {
         setError(data.error ?? "Couldn't finish signing you in.");
-        setStage("idle");
         return;
       }
       router.push(data.member ? next : (data.redirect ?? "/membership"));
       router.refresh();
     } catch {
       setError("Couldn't reach RegenHub. Try again in a moment.");
-      setStage("idle");
+    } finally {
+      setBusy(false);
     }
   }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    setStage("sending");
+    setBusy(true);
     setError(null);
 
     let data: BeginSignupResponse;
@@ -100,17 +103,18 @@ export function RegenosLoginPanel({ next = "/portal" }: { next?: string }) {
       });
       if (!res.ok) {
         setError("regenOS didn't accept that email. Try the classic sign-in link below.");
-        setStage("idle");
         return;
       }
       data = (await res.json()) as BeginSignupResponse;
     } catch {
       setError("Can't reach regenOS right now. Use the classic sign-in link below.");
-      setStage("idle");
       return;
+    } finally {
+      setBusy(false);
     }
 
     if (data.stage === "login") {
+      // regenOS trusted the session immediately — no inbox round-trip.
       await finish();
     } else if (data.stage === "checkEmail") {
       setStage("checkEmail");
@@ -128,12 +132,8 @@ export function RegenosLoginPanel({ next = "/portal" }: { next?: string }) {
           You&apos;re signed in to regenOS as <strong>{existingHandle}</strong>.
         </p>
         {error && <p className="text-red-400 text-sm">{error}</p>}
-        <Button
-          onClick={finish}
-          disabled={stage === "finishing"}
-          className="btn-primary-glass w-full"
-        >
-          {stage === "finishing" ? "Signing you in…" : "Continue to RegenHub"}
+        <Button onClick={finish} disabled={busy} className="btn-primary-glass w-full">
+          {busy ? "Signing you in…" : "Continue to RegenHub"}
         </Button>
       </Panel>
     );
@@ -149,12 +149,8 @@ export function RegenosLoginPanel({ next = "/portal" }: { next?: string }) {
           </p>
         </div>
         {error && <p className="text-red-400 text-sm">{error}</p>}
-        <Button
-          onClick={finish}
-          disabled={stage !== "checkEmail" && stage !== "finishing"}
-          className="btn-glass w-full"
-        >
-          I&apos;ve clicked the link
+        <Button onClick={finish} disabled={busy} className="btn-glass w-full">
+          {busy ? "Signing you in…" : "I've clicked the link"}
         </Button>
       </Panel>
     );
@@ -193,12 +189,8 @@ export function RegenosLoginPanel({ next = "/portal" }: { next?: string }) {
           </p>
         </div>
         {error && <p className="text-red-400 text-sm">{error}</p>}
-        <Button
-          type="submit"
-          disabled={stage === "sending" || stage === "finishing"}
-          className="btn-primary-glass w-full"
-        >
-          {stage === "sending" ? "Checking…" : "Continue with regenOS"}
+        <Button type="submit" disabled={busy} className="btn-primary-glass w-full">
+          {busy ? "Checking…" : "Continue with regenOS"}
         </Button>
       </form>
     </Panel>

--- a/apps/web/src/components/events/EventList.tsx
+++ b/apps/web/src/components/events/EventList.tsx
@@ -1,0 +1,169 @@
+/**
+ * The shared event-rendering vocabulary — one visual language for the landing
+ * page's "Upcoming Events" panel and the public /events page.
+ *
+ * Extracted from components/landing/UpcomingEvents.tsx so the two surfaces
+ * cannot drift: glass-panel cards, sage accents, America/Denver times, and the
+ * Luma iframe that stands in whenever regenOS has nothing to say.
+ *
+ * ── Internal vs external links ───────────────────────────────────────────────
+ * Aaron's rule: regenhub.xyz IS the experience — a regenOS event never links
+ * out. `lib/regenos/events.ts` now hands us a SITE-RELATIVE `/events/<did>/<rkey>`,
+ * so those render as a `next/link` with no target and no external-arrow.
+ * The Luma fallback still yields absolute `https://lu.ma/...` URLs (we don't own
+ * those pages), so a URL that isn't site-relative keeps the honest new-tab
+ * treatment. One predicate — `isInternal` — decides, and nothing else has to.
+ */
+
+import Link from "next/link";
+import { ArrowUpRight, CalendarDays } from "lucide-react";
+import type { UpcomingEvent } from "@/lib/events";
+
+/** The collective's Luma calendar, embedded whenever regenOS has nothing for us. */
+export const LUMA_EMBED_SRC = "https://lu.ma/embed/calendar/cal-ZCWMKx1NMCXGd7v/events?lt=dark";
+
+export function LumaEmbed() {
+  return (
+    <div className="glass-panel-subtle rounded-lg overflow-hidden">
+      <div className="relative w-full" style={{ paddingBottom: "75%" }}>
+        <iframe
+          src={LUMA_EMBED_SRC}
+          className="absolute top-0 left-0 w-full h-full"
+          frameBorder="0"
+          allowFullScreen
+        />
+      </div>
+    </div>
+  );
+}
+
+/** A site-relative href — the only kind we render without a new tab. */
+function isInternal(url: string): boolean {
+  return url.startsWith("/");
+}
+
+/** Hub time, always. The collective is in Boulder and so is every event. */
+const DENVER = "America/Denver";
+
+/** `Sat, Aug 22, 6:00 PM` — the one date format both event surfaces use. */
+export function formatEventWhen(startAt: string): string {
+  const d = new Date(startAt);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleString("en-US", {
+    timeZone: DENVER,
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * The detail page's fuller line: `Saturday, August 22, 2026 · 6:00 – 8:00 PM`.
+ * An end time on the same calendar day collapses to a time; a different day
+ * gets spelled out in full. No end time ⇒ just the start.
+ */
+export function formatEventRange(startAt: string | null, endAt?: string | null): string {
+  if (!startAt) return "";
+  const start = new Date(startAt);
+  if (Number.isNaN(start.getTime())) return "";
+
+  const day = start.toLocaleDateString("en-US", {
+    timeZone: DENVER,
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+  const time = (d: Date) =>
+    d.toLocaleTimeString("en-US", { timeZone: DENVER, hour: "numeric", minute: "2-digit" });
+
+  const end = endAt ? new Date(endAt) : null;
+  if (!end || Number.isNaN(end.getTime())) return `${day} · ${time(start)}`;
+
+  const sameDay =
+    start.toLocaleDateString("en-US", { timeZone: DENVER }) ===
+    end.toLocaleDateString("en-US", { timeZone: DENVER });
+  if (sameDay) return `${day} · ${time(start)} – ${time(end)}`;
+
+  const endDay = end.toLocaleDateString("en-US", {
+    timeZone: DENVER,
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+  return `${day} · ${time(start)} – ${endDay} · ${time(end)}`;
+}
+
+function EventCardBody({ event, external }: { event: UpcomingEvent; external: boolean }) {
+  const when = formatEventWhen(event.startAt);
+  return (
+    <div className="glass-panel-subtle rounded-lg p-5 flex items-start gap-4 hover-lift">
+      <CalendarDays className="w-5 h-5 text-sage shrink-0 mt-1" />
+      <div className="min-w-0">
+        {when && <p className="text-sm text-muted mb-1">{when}</p>}
+        <p className="font-semibold text-lg leading-snug flex items-center gap-1.5">
+          {event.name}
+          {external && <ArrowUpRight className="w-4 h-4 text-sage shrink-0" />}
+        </p>
+        {event.description && (
+          <p className="text-sm text-muted mt-1 line-clamp-2">{event.description}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** One event card, linked in-site when we own the page and out when we don't. */
+export function EventCard({ event }: { event: UpcomingEvent }) {
+  if (!event.url) return <EventCardBody event={event} external={false} />;
+
+  if (isInternal(event.url)) {
+    return (
+      <Link href={event.url} className="block transition-opacity hover:opacity-90">
+        <EventCardBody event={event} external={false} />
+      </Link>
+    );
+  }
+
+  return (
+    <a
+      href={event.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="block transition-opacity hover:opacity-90"
+    >
+      <EventCardBody event={event} external />
+    </a>
+  );
+}
+
+export function EventList({ events }: { events: UpcomingEvent[] }) {
+  return (
+    <ul className="space-y-3">
+      {events.map((event) => (
+        <li key={event.id}>
+          <EventCard event={event} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * The calendar-subscription line. This ICS URL deliberately stays on the regenOS
+ * web app: it's a feed a calendar client subscribes to, not a page a person
+ * navigates to, so it isn't a link-out in the sense that matters.
+ */
+export function CalendarSubscribeNote({ icsUrl }: { icsUrl: string }) {
+  return (
+    <p className="text-center text-sm text-muted">
+      <a href={icsUrl} className="underline hover:text-sage transition-colors">
+        Subscribe to the calendar
+      </a>{" "}
+      to keep it in sync.
+    </p>
+  );
+}

--- a/apps/web/src/components/landing/RegenHubLanding.tsx
+++ b/apps/web/src/components/landing/RegenHubLanding.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { Suspense } from "react";
 import { Building2, HandHeart, Lightbulb, Sprout, MapPin, Calendar, Mail, Zap, Ticket, Key, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -7,6 +8,7 @@ import { MemberDirectory } from "@/components/landing/MemberDirectory";
 import { ForestMascot } from "@/components/landing/ForestMascot";
 import HeroInterestForm from "@/components/landing/HeroInterestForm";
 import CommunityGallery from "@/components/landing/CommunityGallery";
+import UpcomingEvents from "@/components/landing/UpcomingEvents";
 
 export type SignedInMember = { name: string } | null;
 import forestBackground from "@/assets/forest-background.jpg";
@@ -196,16 +198,10 @@ export default function RegenHubLanding({ signedInMember }: { signedInMember?: S
               <h2 className="text-3xl md:text-4xl font-bold mb-4 text-forest">Upcoming Events</h2>
               <p className="text-xl text-muted max-w-2xl mx-auto">Join us for community building, learning, and collaboration</p>
             </div>
-            <div className="glass-panel-subtle rounded-lg overflow-hidden">
-              <div className="relative w-full" style={{ paddingBottom: "75%" }}>
-                <iframe
-                  src="https://lu.ma/embed/calendar/cal-ZCWMKx1NMCXGd7v/events?lt=dark"
-                  className="absolute top-0 left-0 w-full h-full"
-                  frameBorder="0"
-                  allowFullScreen
-                />
-              </div>
-            </div>
+            {/* regenOS collective calendar when configured, Luma embed otherwise. */}
+            <Suspense fallback={<div className="h-24" />}>
+              <UpcomingEvents />
+            </Suspense>
           </div>
         </div>
       </section>

--- a/apps/web/src/components/landing/RegenHubLanding.tsx
+++ b/apps/web/src/components/landing/RegenHubLanding.tsx
@@ -64,11 +64,11 @@ export default function RegenHubLanding({ signedInMember }: { signedInMember?: S
                   Try a Free Day
                 </Button>
               </Link>
-              <a href="https://lu.ma/regenhub" target="_blank" rel="noopener noreferrer">
+              <Link href="/events">
                 <Button className="btn-glass px-8 py-3 text-lg">
                   View Events
                 </Button>
-              </a>
+              </Link>
             </div>
             {signedInMember ? (
               <p className="mt-6 text-sm text-muted">
@@ -242,9 +242,9 @@ export default function RegenHubLanding({ signedInMember }: { signedInMember?: S
                 <Link href="/freeday">
                   <Button className="btn-primary-glass px-6">Try a Free Day</Button>
                 </Link>
-                <a href="https://lu.ma/regenhub" target="_blank" rel="noopener noreferrer">
+                <Link href="/events">
                   <Button className="btn-glass px-6">View All Events</Button>
-                </a>
+                </Link>
               </div>
             </CardContent>
           </Card>
@@ -272,7 +272,7 @@ export default function RegenHubLanding({ signedInMember }: { signedInMember?: S
                 { label: "Apply", href: "/apply", external: false },
                 { label: "Stay in Touch", href: "/interest", external: false },
                 { label: "Dispatches", href: "/news", external: false },
-                { label: "Events", href: "https://lu.ma/regenhub", external: true },
+                { label: "Events", href: "/events", external: false },
                 { label: "Portal", href: "/portal", external: false },
               ].map(({ label, href, external }) => (
                 <Button key={label} variant="ghost" size="sm" className="btn-glass" asChild>

--- a/apps/web/src/components/landing/UpcomingEvents.tsx
+++ b/apps/web/src/components/landing/UpcomingEvents.tsx
@@ -1,0 +1,115 @@
+import { CalendarDays, ArrowUpRight } from "lucide-react";
+import { fetchUpcomingEvents } from "@/lib/events";
+import { isRegenosEventsConfigured } from "@/lib/regenos/config";
+import { regenosCalendarIcsUrl } from "@/lib/regenos/events";
+
+/**
+ * The landing page's "Upcoming Events" body.
+ *
+ * Async server component. Three states, in priority order:
+ *
+ *  1. regenOS not configured  → the Luma embed, byte-identical to before.
+ *  2. regenOS configured, events found → real event cards from the commons.
+ *  3. regenOS configured, nothing came back → the Luma embed again.
+ *
+ * State 3 is the load-bearing one: `fetchUpcomingEvents` cannot distinguish
+ * "the calendar is quiet" from "the AppView is down" (both are `[]` by
+ * contract, lib/regenos/events.ts), and it doesn't need to — either way the
+ * page falls back to what has always been there. **The site never breaks
+ * because regenOS is down.**
+ */
+
+const LUMA_EMBED_SRC = "https://lu.ma/embed/calendar/cal-ZCWMKx1NMCXGd7v/events?lt=dark";
+
+/** Days of calendar to show on the landing page. */
+const HORIZON_DAYS = 60;
+
+function LumaEmbed() {
+  return (
+    <div className="glass-panel-subtle rounded-lg overflow-hidden">
+      <div className="relative w-full" style={{ paddingBottom: "75%" }}>
+        <iframe
+          src={LUMA_EMBED_SRC}
+          className="absolute top-0 left-0 w-full h-full"
+          frameBorder="0"
+          allowFullScreen
+        />
+      </div>
+    </div>
+  );
+}
+
+function formatWhen(startAt: string): string {
+  const d = new Date(startAt);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleString("en-US", {
+    timeZone: "America/Denver",
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export default async function UpcomingEvents() {
+  if (!isRegenosEventsConfigured()) return <LumaEmbed />;
+
+  const { source, events } = await fetchUpcomingEvents(HORIZON_DAYS);
+  if (events.length === 0) return <LumaEmbed />;
+
+  const icsUrl = source === "regenos" ? regenosCalendarIcsUrl() : null;
+
+  return (
+    <div className="space-y-4">
+      <ul className="space-y-3">
+        {events.map((event) => {
+          const when = formatWhen(event.startAt);
+          const body = (
+            <div className="glass-panel-subtle rounded-lg p-5 flex items-start gap-4 hover-lift">
+              <CalendarDays className="w-5 h-5 text-sage shrink-0 mt-1" />
+              <div className="min-w-0">
+                {when && (
+                  <p className="text-sm text-muted mb-1">{when}</p>
+                )}
+                <p className="font-semibold text-lg leading-snug flex items-center gap-1.5">
+                  {event.name}
+                  {event.url && <ArrowUpRight className="w-4 h-4 text-sage shrink-0" />}
+                </p>
+                {event.description && (
+                  <p className="text-sm text-muted mt-1 line-clamp-2">{event.description}</p>
+                )}
+              </div>
+            </div>
+          );
+
+          return (
+            <li key={event.id}>
+              {event.url ? (
+                <a
+                  href={event.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block transition-opacity hover:opacity-90"
+                >
+                  {body}
+                </a>
+              ) : (
+                body
+              )}
+            </li>
+          );
+        })}
+      </ul>
+
+      {icsUrl && (
+        <p className="text-center text-sm text-muted">
+          <a href={icsUrl} className="underline hover:text-sage transition-colors">
+            Subscribe to the calendar
+          </a>{" "}
+          to keep it in sync.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/landing/UpcomingEvents.tsx
+++ b/apps/web/src/components/landing/UpcomingEvents.tsx
@@ -1,7 +1,9 @@
-import { CalendarDays, ArrowUpRight } from "lucide-react";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
 import { fetchUpcomingEvents } from "@/lib/events";
 import { isRegenosEventsConfigured } from "@/lib/regenos/config";
 import { regenosCalendarIcsUrl } from "@/lib/regenos/events";
+import { CalendarSubscribeNote, EventList, LumaEmbed } from "@/components/events/EventList";
 
 /**
  * The landing page's "Upcoming Events" body.
@@ -17,40 +19,14 @@ import { regenosCalendarIcsUrl } from "@/lib/regenos/events";
  * contract, lib/regenos/events.ts), and it doesn't need to — either way the
  * page falls back to what has always been there. **The site never breaks
  * because regenOS is down.**
+ *
+ * The cards themselves live in components/events/EventList.tsx, shared with the
+ * full /events page so the two can't drift. A regenOS event links IN-SITE
+ * (`/events/<did>/<rkey>`) — no link-out, ever.
  */
 
-const LUMA_EMBED_SRC = "https://lu.ma/embed/calendar/cal-ZCWMKx1NMCXGd7v/events?lt=dark";
-
-/** Days of calendar to show on the landing page. */
+/** Days of calendar to show on the landing page; /events shows a longer horizon. */
 const HORIZON_DAYS = 60;
-
-function LumaEmbed() {
-  return (
-    <div className="glass-panel-subtle rounded-lg overflow-hidden">
-      <div className="relative w-full" style={{ paddingBottom: "75%" }}>
-        <iframe
-          src={LUMA_EMBED_SRC}
-          className="absolute top-0 left-0 w-full h-full"
-          frameBorder="0"
-          allowFullScreen
-        />
-      </div>
-    </div>
-  );
-}
-
-function formatWhen(startAt: string): string {
-  const d = new Date(startAt);
-  if (Number.isNaN(d.getTime())) return "";
-  return d.toLocaleString("en-US", {
-    timeZone: "America/Denver",
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
-}
 
 export default async function UpcomingEvents() {
   if (!isRegenosEventsConfigured()) return <LumaEmbed />;
@@ -62,54 +38,19 @@ export default async function UpcomingEvents() {
 
   return (
     <div className="space-y-4">
-      <ul className="space-y-3">
-        {events.map((event) => {
-          const when = formatWhen(event.startAt);
-          const body = (
-            <div className="glass-panel-subtle rounded-lg p-5 flex items-start gap-4 hover-lift">
-              <CalendarDays className="w-5 h-5 text-sage shrink-0 mt-1" />
-              <div className="min-w-0">
-                {when && (
-                  <p className="text-sm text-muted mb-1">{when}</p>
-                )}
-                <p className="font-semibold text-lg leading-snug flex items-center gap-1.5">
-                  {event.name}
-                  {event.url && <ArrowUpRight className="w-4 h-4 text-sage shrink-0" />}
-                </p>
-                {event.description && (
-                  <p className="text-sm text-muted mt-1 line-clamp-2">{event.description}</p>
-                )}
-              </div>
-            </div>
-          );
+      <EventList events={events} />
 
-          return (
-            <li key={event.id}>
-              {event.url ? (
-                <a
-                  href={event.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block transition-opacity hover:opacity-90"
-                >
-                  {body}
-                </a>
-              ) : (
-                body
-              )}
-            </li>
-          );
-        })}
-      </ul>
+      <p className="text-center">
+        <Link
+          href="/events"
+          className="inline-flex items-center gap-1.5 text-sm text-sage hover:underline"
+        >
+          See the full calendar
+          <ArrowRight className="w-4 h-4" />
+        </Link>
+      </p>
 
-      {icsUrl && (
-        <p className="text-center text-sm text-muted">
-          <a href={icsUrl} className="underline hover:text-sage transition-colors">
-            Subscribe to the calendar
-          </a>{" "}
-          to keep it in sync.
-        </p>
-      )}
+      {icsUrl && <CalendarSubscribeNote icsUrl={icsUrl} />}
     </div>
   );
 }

--- a/apps/web/src/components/portal/ManageEvents.tsx
+++ b/apps/web/src/components/portal/ManageEvents.tsx
@@ -1,0 +1,399 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent } from "@/components/ui/card";
+import { CalendarPlus, Loader2, Lock, Globe, Pencil, Trash2, X, ExternalLink } from "lucide-react";
+import {
+  EMPTY_EVENT_FORM,
+  buildCreateEventInput,
+  buildDeleteEventInput,
+  buildUpdateEventInput,
+  eventBodyToFormValues,
+  mintRkey,
+  type CalendarEventBody,
+  type EventFormValues,
+  type EventVisibility,
+} from "@/lib/regenos/eventForm";
+
+export interface ManageableEvent {
+  uri: string;
+  rkey: string;
+  name: string;
+  startAt: string | null;
+  visibility: EventVisibility;
+  /** The stored `community.lexicon.calendar.event` body — the edit form's source of truth. */
+  value: CalendarEventBody;
+  url: string | null;
+}
+
+/** RegenHub is in Boulder; pinning the zone keeps server and client renders identical. */
+const TZ = "America/Denver";
+
+function formatWhen(iso: string | null): string {
+  if (!iso) return "No time set";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "No time set";
+  return d.toLocaleString("en-US", {
+    timeZone: TZ,
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+/** Every mutation is a same-origin `/xrpc` POST; the regenOS session cookie rides along by itself. */
+async function xrpcPost(nsid: string, body: unknown): Promise<void> {
+  const res = await fetch(`/xrpc/${nsid}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const json = await res.json().catch(() => null);
+    throw new Error(json?.message ?? json?.error ?? `regenOS returned ${res.status}`);
+  }
+}
+
+export function ManageEvents({
+  authority,
+  events,
+}: {
+  authority: string;
+  events: ManageableEvent[];
+}) {
+  // `null` = no form open; a string = the rkey being edited; "" = the new-event form.
+  const [editing, setEditing] = useState<string | null>(null);
+  const [form, setForm] = useState<EventFormValues>(EMPTY_EVENT_FORM);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busyRkey, setBusyRkey] = useState<string | null>(null);
+  const router = useRouter();
+
+  function set<K extends keyof EventFormValues>(key: K) {
+    return (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
+      setForm((f) => ({ ...f, [key]: e.target.value as EventFormValues[K] }));
+  }
+
+  function openCreate() {
+    setForm(EMPTY_EVENT_FORM);
+    setError(null);
+    setEditing("");
+  }
+
+  function openEdit(event: ManageableEvent) {
+    setForm(eventBodyToFormValues(event.value, event.visibility));
+    setError(null);
+    setEditing(event.rkey);
+  }
+
+  /** Drop the landing page's 5-minute events cache so the change is visible immediately. */
+  async function refresh() {
+    await fetch("/api/portal/events/revalidate", { method: "POST" }).catch(() => {});
+    router.refresh();
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      if (editing) {
+        await xrpcPost(
+          "social.scenius.updateEvent",
+          buildUpdateEventInput(form, { authority, rkey: editing }),
+        );
+      } else {
+        await xrpcPost(
+          "social.scenius.createEvent",
+          buildCreateEventInput(form, { authority, rkey: mintRkey() }),
+        );
+      }
+      setEditing(null);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleCancel(event: ManageableEvent) {
+    if (!window.confirm(`Cancel "${event.name}"? Anyone who RSVP'd will be told it's called off.`)) {
+      return;
+    }
+    setBusyRkey(event.rkey);
+    setError(null);
+    try {
+      await xrpcPost(
+        "social.scenius.deleteEvent",
+        buildDeleteEventInput({ authority, rkey: event.rkey }),
+      );
+      if (editing === event.rkey) setEditing(null);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setBusyRkey(null);
+    }
+  }
+
+  const now = Date.now();
+  const upcoming = events.filter((e) => !e.startAt || Date.parse(e.startAt) >= now);
+  const past = events.filter((e) => e.startAt && Date.parse(e.startAt) < now).reverse();
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <div className="glass-panel p-4 border border-red-500/40 bg-red-500/5">
+          <p className="text-sm text-red-400">{error}</p>
+        </div>
+      )}
+
+      {editing === null ? (
+        <Button onClick={openCreate} className="btn-primary-glass gap-2 px-6">
+          <CalendarPlus className="w-4 h-4" />
+          New event
+        </Button>
+      ) : (
+        <Card className="glass-panel">
+          <CardContent className="p-6">
+            <form onSubmit={handleSubmit} className="space-y-5">
+              <div className="flex items-start justify-between gap-4">
+                <h2 className="text-lg font-semibold">{editing ? "Edit event" : "New event"}</h2>
+                <button
+                  type="button"
+                  onClick={() => setEditing(null)}
+                  className="text-muted hover:text-foreground transition-colors"
+                  aria-label="Close"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="ev-name">Name</Label>
+                <Input id="ev-name" value={form.name} onChange={set("name")} required className="glass-input" />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="ev-description">Description</Label>
+                <textarea
+                  id="ev-description"
+                  value={form.description}
+                  onChange={set("description")}
+                  rows={3}
+                  className="glass-input w-full px-3 py-2 rounded text-sm"
+                />
+              </div>
+
+              <div className="grid sm:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="ev-starts">Starts</Label>
+                  <Input
+                    id="ev-starts"
+                    type="datetime-local"
+                    value={form.startsAt}
+                    onChange={set("startsAt")}
+                    required
+                    className="glass-input"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="ev-ends">Ends</Label>
+                  <Input
+                    id="ev-ends"
+                    type="datetime-local"
+                    value={form.endsAt}
+                    onChange={set("endsAt")}
+                    className="glass-input"
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="ev-place">Place</Label>
+                <Input
+                  id="ev-place"
+                  value={form.placeName}
+                  onChange={set("placeName")}
+                  placeholder="RegenHub"
+                  className="glass-input"
+                />
+              </div>
+
+              <div className="grid sm:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="ev-street">Street</Label>
+                  <Input
+                    id="ev-street"
+                    value={form.street}
+                    onChange={set("street")}
+                    placeholder="1515 Walnut St, Suite 200"
+                    className="glass-input"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="ev-postal">Postal code</Label>
+                  <Input
+                    id="ev-postal"
+                    value={form.postalCode}
+                    onChange={set("postalCode")}
+                    placeholder="80302"
+                    className="glass-input"
+                  />
+                </div>
+              </div>
+              <p className="text-xs text-muted">
+                Boulder, CO is assumed. The address is published with the event — don&apos;t use one you
+                wouldn&apos;t put on a poster.
+              </p>
+
+              {editing ? (
+                <p className="text-xs text-muted">
+                  This event is {form.visibility === "private" ? "private" : "public"}. Visibility and
+                  sign-up mode are set when an event is created and can&apos;t be changed here — cancel
+                  and recreate it if you need to change them.
+                </p>
+              ) : (
+                <div className="grid sm:grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="ev-visibility">Visibility</Label>
+                    <select
+                      id="ev-visibility"
+                      value={form.visibility}
+                      onChange={set("visibility")}
+                      className="glass-input w-full px-3 py-2 rounded text-sm"
+                    >
+                      <option value="public">Public — anyone can see it</option>
+                      <option value="private">Private — members and invitees only</option>
+                    </select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="ev-attendance">Sign-up</Label>
+                    <select
+                      id="ev-attendance"
+                      value={form.attendance}
+                      onChange={set("attendance")}
+                      className="glass-input w-full px-3 py-2 rounded text-sm"
+                    >
+                      <option value="open">Open — RSVP is a seat</option>
+                      <option value="approval">Approval — you confirm each person</option>
+                    </select>
+                  </div>
+                </div>
+              )}
+
+              <div className="flex gap-2">
+                <Button type="submit" disabled={saving} className="btn-primary-glass gap-2 px-6">
+                  {saving && <Loader2 className="w-4 h-4 animate-spin" />}
+                  {editing ? "Save changes" : "Create event"}
+                </Button>
+                <Button type="button" onClick={() => setEditing(null)} className="btn-glass px-6">
+                  Cancel
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      )}
+
+      <EventList
+        title="Upcoming"
+        events={upcoming}
+        emptyLabel="Nothing on the calendar yet."
+        busyRkey={busyRkey}
+        onEdit={openEdit}
+        onCancel={handleCancel}
+      />
+      {past.length > 0 && (
+        <EventList
+          title="Past"
+          events={past}
+          emptyLabel=""
+          busyRkey={busyRkey}
+          onEdit={openEdit}
+          onCancel={handleCancel}
+        />
+      )}
+
+      <p className="text-xs text-muted">Times shown in Mountain Time.</p>
+    </div>
+  );
+}
+
+function EventList({
+  title,
+  events,
+  emptyLabel,
+  busyRkey,
+  onEdit,
+  onCancel,
+}: {
+  title: string;
+  events: ManageableEvent[];
+  emptyLabel: string;
+  busyRkey: string | null;
+  onEdit: (e: ManageableEvent) => void;
+  onCancel: (e: ManageableEvent) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <h2 className="text-sm font-medium text-muted uppercase tracking-wide">{title}</h2>
+      {events.length === 0 ? (
+        <p className="text-sm text-muted">{emptyLabel}</p>
+      ) : (
+        events.map((event) => (
+          <Card key={event.uri} className="glass-panel">
+            <CardContent className="p-5 flex flex-col sm:flex-row sm:items-center gap-4">
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <h3 className="font-semibold truncate">{event.name}</h3>
+                  {event.visibility === "private" ? (
+                    <Lock className="w-3.5 h-3.5 text-gold shrink-0" aria-label="Private" />
+                  ) : (
+                    <Globe className="w-3.5 h-3.5 text-sage shrink-0" aria-label="Public" />
+                  )}
+                </div>
+                <p className="text-sm text-muted mt-0.5">{formatWhen(event.startAt)}</p>
+                {event.url && (
+                  <a
+                    href={event.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-xs text-sage hover:text-sage/80 inline-flex items-center gap-1 mt-1"
+                  >
+                    Public page <ExternalLink className="w-3 h-3" />
+                  </a>
+                )}
+              </div>
+              <div className="flex gap-2 shrink-0">
+                <Button onClick={() => onEdit(event)} className="btn-glass gap-2 px-4">
+                  <Pencil className="w-3.5 h-3.5" />
+                  Edit
+                </Button>
+                <Button
+                  onClick={() => onCancel(event)}
+                  disabled={busyRkey === event.rkey}
+                  className="btn-glass gap-2 px-4 text-red-400"
+                >
+                  {busyRkey === event.rkey ? (
+                    <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                  ) : (
+                    <Trash2 className="w-3.5 h-3.5" />
+                  )}
+                  Cancel event
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ))
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/portal/ManageEvents.tsx
+++ b/apps/web/src/components/portal/ManageEvents.tsx
@@ -2,11 +2,12 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent } from "@/components/ui/card";
-import { CalendarPlus, Loader2, Lock, Globe, Pencil, Trash2, X, ExternalLink } from "lucide-react";
+import { CalendarPlus, Loader2, Lock, Globe, Pencil, Trash2, X, ArrowRight } from "lucide-react";
 import {
   EMPTY_EVENT_FORM,
   buildCreateEventInput,
@@ -361,15 +362,15 @@ function EventList({
                   )}
                 </div>
                 <p className="text-sm text-muted mt-0.5">{formatWhen(event.startAt)}</p>
-                {event.url && (
-                  <a
+                {/* In-site now (`/events/<did>/<rkey>`), so a plain internal link — and only for a
+                    PUBLIC event, since the public page 404s anything the AppView keeps private. */}
+                {event.url && event.visibility === "public" && (
+                  <Link
                     href={event.url}
-                    target="_blank"
-                    rel="noreferrer"
                     className="text-xs text-sage hover:text-sage/80 inline-flex items-center gap-1 mt-1"
                   >
-                    Public page <ExternalLink className="w-3 h-3" />
-                  </a>
+                    View event page <ArrowRight className="w-3 h-3" />
+                  </Link>
                 )}
               </div>
               <div className="flex gap-2 shrink-0">

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -29,6 +29,11 @@ const OPTIONAL_BUT_WARN = [
   "TELEGRAM_GROUP_CHAT_ID",
   // Cron auth — past-due sweep returns 503 without it
   "CRON_SECRET",
+  // regenOS AppView — without it the landing page falls back to the Luma
+  // embed and the one-login lane stays off no matter what the flag says.
+  "REGENOS_BASE_URL",
+  // The RegenHub collective's DID — without it there is no calendar to read.
+  "REGENOS_COLLECTIVE_DID",
 ] as const;
 
 let validated = false;

--- a/apps/web/src/lib/events.test.ts
+++ b/apps/web/src/lib/events.test.ts
@@ -27,11 +27,13 @@ function eventRow(rkey: string, name: string, startsAt: string, extra: Record<st
 
 /** Stub global fetch with one canned regenOS getEvents response. */
 function stubGetEvents(events: unknown[], init: { ok?: boolean; status?: number } = {}) {
-  const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => ({
-    ok: init.ok ?? true,
-    status: init.status ?? 200,
-    json: async () => ({ scene: SCENE, events }),
-  }));
+  const fetchMock = vi.fn<typeof fetch>(async () =>
+    ({
+      ok: init.ok ?? true,
+      status: init.status ?? 200,
+      json: async () => ({ scene: SCENE, events }),
+    }) as unknown as Response,
+  );
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
 }

--- a/apps/web/src/lib/events.test.ts
+++ b/apps/web/src/lib/events.test.ts
@@ -7,7 +7,7 @@ vi.mock("@/lib/luma", () => ({
 }));
 
 import { fetchUpcomingEvents } from "@/lib/events";
-import { fetchUpcomingRegenosEvents } from "@/lib/regenos/events";
+import { fetchPublicRegenosEvent, fetchUpcomingRegenosEvents } from "@/lib/regenos/events";
 import { fetchUpcomingLumaEvents } from "@/lib/luma";
 
 // Freeze "now" so the upcoming-window filter is deterministic.
@@ -101,15 +101,22 @@ describe("fetchUpcomingRegenosEvents", () => {
     expect(events.map((e) => e.name)).toEqual(["This week"]);
   });
 
-  it("builds public event links only when REGENOS_WEB_URL is set", async () => {
+  // regenhub.xyz IS the experience — an event link never leaves the site, and
+  // never depends on REGENOS_WEB_URL (which now only feeds the ICS feed).
+  it("links events in-site, whether or not REGENOS_WEB_URL is set", async () => {
+    const expected = `/events/${encodeURIComponent(SCENE)}/abc123`;
+
     stubGetEvents([eventRow("abc123", "Potluck", "2026-08-18T18:00:00Z")]);
-    expect((await fetchUpcomingRegenosEvents())[0].url).toBeNull();
+    expect((await fetchUpcomingRegenosEvents())[0].url).toBe(expected);
 
     process.env.REGENOS_WEB_URL = "https://scenius.example/";
     stubGetEvents([eventRow("abc123", "Potluck", "2026-08-18T18:00:00Z")]);
-    expect((await fetchUpcomingRegenosEvents())[0].url).toBe(
-      `https://scenius.example/events/${encodeURIComponent(SCENE)}/abc123`,
-    );
+    expect((await fetchUpcomingRegenosEvents())[0].url).toBe(expected);
+  });
+
+  it("leaves the link null for an AT-URI it can't split", async () => {
+    stubGetEvents([{ uri: "not-an-at-uri", value: { name: "Mystery", startsAt: "2026-08-18T18:00:00Z" } }]);
+    expect((await fetchUpcomingRegenosEvents())[0].url).toBeNull();
   });
 
   it("returns [] on a non-2xx instead of throwing", async () => {
@@ -122,6 +129,127 @@ describe("fetchUpcomingRegenosEvents", () => {
       throw new Error("ECONNREFUSED");
     }));
     await expect(fetchUpcomingRegenosEvents()).resolves.toEqual([]);
+  });
+});
+
+/** Stub global fetch with one canned regenOS getEvent response. */
+function stubGetEvent(body: unknown, init: { ok?: boolean; status?: number } = {}) {
+  const fetchMock = vi.fn<typeof fetch>(async () =>
+    ({
+      ok: init.ok ?? true,
+      status: init.status ?? 200,
+      json: async () => body,
+    }) as unknown as Response,
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+const ADDRESS = {
+  $type: "community.lexicon.location.address",
+  name: "RegenHub",
+  street: "1515 Walnut St, Suite 200",
+  locality: "Boulder",
+  region: "CO",
+  postalCode: "80302",
+  country: "US",
+};
+
+describe("fetchPublicRegenosEvent (the in-site detail page's read)", () => {
+  it("returns null and never calls out when regenOS isn't configured", async () => {
+    delete process.env.REGENOS_BASE_URL;
+    const fetchMock = stubGetEvent({});
+
+    expect(await fetchPublicRegenosEvent(SCENE, "abc123")).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a repo segment that isn't a DID without calling out", async () => {
+    const fetchMock = stubGetEvent({});
+
+    expect(await fetchPublicRegenosEvent("regenhub.scenius.social", "abc123")).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reads one event by did/rkey through social.scenius.getEvent", async () => {
+    const fetchMock = stubGetEvent({
+      uri: `at://${SCENE}/community.lexicon.calendar.event/abc123`,
+      cid: "bafytest",
+      visibility: "public",
+      hostName: "RegenHub",
+      value: {
+        name: "Commons potluck",
+        description: "Bring a dish.\n\nAll welcome.",
+        startsAt: "2026-08-18T18:00:00Z",
+        endsAt: "2026-08-18T20:00:00Z",
+        locations: [{ $type: "community.lexicon.location.hthree", value: "8a2a" }, ADDRESS],
+      },
+    });
+
+    const event = await fetchPublicRegenosEvent(SCENE, "abc123");
+
+    expect(event).toMatchObject({
+      did: SCENE,
+      rkey: "abc123",
+      name: "Commons potluck",
+      startAt: "2026-08-18T18:00:00Z",
+      endAt: "2026-08-18T20:00:00Z",
+      description: "Bring a dish.\n\nAll welcome.",
+      hostName: "RegenHub",
+    });
+    // The address face, picked out of a locations array that also carries an H3 cell.
+    expect(event?.location).toEqual({
+      name: "RegenHub",
+      street: "1515 Walnut St, Suite 200",
+      locality: "Boulder",
+      region: "CO",
+      postalCode: "80302",
+    });
+
+    const url = new URL(vi.mocked(fetchMock).mock.calls[0][0] as unknown as string);
+    expect(url.pathname).toBe("/xrpc/social.scenius.getEvent");
+    expect(url.searchParams.get("uri")).toBe(
+      `at://${SCENE}/community.lexicon.calendar.event/abc123`,
+    );
+  });
+
+  it("carries no location when the public face published no address", async () => {
+    stubGetEvent({
+      uri: `at://${SCENE}/community.lexicon.calendar.event/rough`,
+      visibility: "public",
+      value: {
+        name: "Somewhere in Boulder",
+        startsAt: "2026-08-18T18:00:00Z",
+        locations: [{ $type: "community.lexicon.location.hthree", value: "8a2a" }],
+      },
+    });
+
+    expect((await fetchPublicRegenosEvent(SCENE, "rough"))?.location).toBeNull();
+  });
+
+  it("refuses an event the AppView classified as private — this page has no viewer", async () => {
+    stubGetEvent({
+      uri: `at://${SCENE}/community.lexicon.calendar.event/secret`,
+      visibility: "private",
+      value: { name: "Stewards only", startsAt: "2026-08-18T18:00:00Z" },
+    });
+
+    expect(await fetchPublicRegenosEvent(SCENE, "secret")).toBeNull();
+  });
+
+  it("returns null on a 404 or an anonymous 401 instead of throwing", async () => {
+    stubGetEvent({}, { ok: false, status: 404 });
+    expect(await fetchPublicRegenosEvent(SCENE, "nope")).toBeNull();
+
+    stubGetEvent({}, { ok: false, status: 401 });
+    expect(await fetchPublicRegenosEvent(SCENE, "private")).toBeNull();
+  });
+
+  it("returns null when the AppView is unreachable instead of throwing", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }));
+    await expect(fetchPublicRegenosEvent(SCENE, "abc123")).resolves.toBeNull();
   });
 });
 

--- a/apps/web/src/lib/events.test.ts
+++ b/apps/web/src/lib/events.test.ts
@@ -27,7 +27,7 @@ function eventRow(rkey: string, name: string, startsAt: string, extra: Record<st
 
 /** Stub global fetch with one canned regenOS getEvents response. */
 function stubGetEvents(events: unknown[], init: { ok?: boolean; status?: number } = {}) {
-  const fetchMock = vi.fn(async () => ({
+  const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => ({
     ok: init.ok ?? true,
     status: init.status ?? 200,
     json: async () => ({ scene: SCENE, events }),

--- a/apps/web/src/lib/events.test.ts
+++ b/apps/web/src/lib/events.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Luma is the fallback lane — stub it so these tests never touch the network
+// and so "did we fall back?" is directly observable.
+vi.mock("@/lib/luma", () => ({
+  fetchUpcomingLumaEvents: vi.fn(async () => []),
+}));
+
+import { fetchUpcomingEvents } from "@/lib/events";
+import { fetchUpcomingRegenosEvents } from "@/lib/regenos/events";
+import { fetchUpcomingLumaEvents } from "@/lib/luma";
+
+// Freeze "now" so the upcoming-window filter is deterministic.
+const NOW = new Date("2026-08-15T12:00:00.000Z");
+
+const SCENE = "did:plc:regenhubcollective";
+
+function eventRow(rkey: string, name: string, startsAt: string, extra: Record<string, unknown> = {}) {
+  return {
+    uri: `at://${SCENE}/community.lexicon.calendar.event/${rkey}`,
+    cid: "bafytest",
+    value: { name, startsAt, ...extra },
+    source: "public",
+    sceneName: "RegenHub",
+  };
+}
+
+/** Stub global fetch with one canned regenOS getEvents response. */
+function stubGetEvents(events: unknown[], init: { ok?: boolean; status?: number } = {}) {
+  const fetchMock = vi.fn(async () => ({
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    json: async () => ({ scene: SCENE, events }),
+  }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  process.env.REGENOS_BASE_URL = "http://localhost:8080";
+  process.env.REGENOS_COLLECTIVE_DID = SCENE;
+  delete process.env.REGENOS_WEB_URL;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  delete process.env.REGENOS_BASE_URL;
+  delete process.env.REGENOS_COLLECTIVE_DID;
+  delete process.env.REGENOS_WEB_URL;
+});
+
+describe("fetchUpcomingRegenosEvents", () => {
+  it("returns [] and never calls out when regenOS isn't configured", async () => {
+    delete process.env.REGENOS_COLLECTIVE_DID;
+    const fetchMock = stubGetEvents([]);
+
+    expect(await fetchUpcomingRegenosEvents()).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores a collective DID that isn't a DID", async () => {
+    process.env.REGENOS_COLLECTIVE_DID = "regenhub.scenius.social";
+    const fetchMock = stubGetEvents([]);
+
+    expect(await fetchUpcomingRegenosEvents()).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("queries the collective's calendar and sorts by start time, soonest first", async () => {
+    // The AppView orders by INDEXING time, not start time — so a later-indexed
+    // earlier event must still come out first.
+    const fetchMock = stubGetEvents([
+      eventRow("b", "Later", "2026-08-25T18:00:00Z"),
+      eventRow("a", "Sooner", "2026-08-18T18:00:00Z"),
+    ]);
+
+    const events = await fetchUpcomingRegenosEvents(21);
+
+    expect(events.map((e) => e.name)).toEqual(["Sooner", "Later"]);
+    const url = new URL(vi.mocked(fetchMock).mock.calls[0][0] as unknown as string);
+    expect(url.pathname).toBe("/xrpc/social.scenius.getEvents");
+    expect(url.searchParams.get("scene")).toBe(SCENE);
+  });
+
+  it("drops events in the past, beyond the horizon, or missing a start time", async () => {
+    stubGetEvents([
+      eventRow("past", "Yesterday", "2026-08-14T18:00:00Z"),
+      eventRow("soon", "This week", "2026-08-18T18:00:00Z"),
+      eventRow("far", "Next quarter", "2026-12-01T18:00:00Z"),
+      { uri: `at://${SCENE}/community.lexicon.calendar.event/nodate`, value: { name: "Undated" } },
+    ]);
+
+    const events = await fetchUpcomingRegenosEvents(21);
+
+    expect(events.map((e) => e.name)).toEqual(["This week"]);
+  });
+
+  it("builds public event links only when REGENOS_WEB_URL is set", async () => {
+    stubGetEvents([eventRow("abc123", "Potluck", "2026-08-18T18:00:00Z")]);
+    expect((await fetchUpcomingRegenosEvents())[0].url).toBeNull();
+
+    process.env.REGENOS_WEB_URL = "https://scenius.example/";
+    stubGetEvents([eventRow("abc123", "Potluck", "2026-08-18T18:00:00Z")]);
+    expect((await fetchUpcomingRegenosEvents())[0].url).toBe(
+      `https://scenius.example/events/${encodeURIComponent(SCENE)}/abc123`,
+    );
+  });
+
+  it("returns [] on a non-2xx instead of throwing", async () => {
+    stubGetEvents([], { ok: false, status: 503 });
+    expect(await fetchUpcomingRegenosEvents()).toEqual([]);
+  });
+
+  it("returns [] when the AppView is unreachable instead of throwing", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }));
+    await expect(fetchUpcomingRegenosEvents()).resolves.toEqual([]);
+  });
+});
+
+describe("fetchUpcomingEvents (the seam)", () => {
+  it("prefers regenOS when it has events", async () => {
+    stubGetEvents([eventRow("a", "Commons potluck", "2026-08-18T18:00:00Z")]);
+
+    const { source, events } = await fetchUpcomingEvents();
+
+    expect(source).toBe("regenos");
+    expect(events).toHaveLength(1);
+    expect(fetchUpcomingLumaEvents).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Luma when regenOS is unreachable — the site must not break", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }));
+    vi.mocked(fetchUpcomingLumaEvents).mockResolvedValue([
+      { name: "Luma night", startAt: "2026-08-20T18:00:00Z", url: "https://lu.ma/x" },
+    ]);
+
+    const { source, events } = await fetchUpcomingEvents();
+
+    expect(source).toBe("luma");
+    expect(events[0].name).toBe("Luma night");
+  });
+
+  it("reports 'none' when neither backend has anything, rather than failing", async () => {
+    stubGetEvents([]);
+    vi.mocked(fetchUpcomingLumaEvents).mockResolvedValue([]);
+
+    await expect(fetchUpcomingEvents()).resolves.toEqual({ source: "none", events: [] });
+  });
+});

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -1,0 +1,87 @@
+/**
+ * The events seam.
+ *
+ * lib/luma.ts:10-11 promised that "when RegenHub's own events platform lands,
+ * this module gets swapped for a local query and nothing upstream changes."
+ * This is that swap, made explicit: ONE `UpcomingEvent` shape, TWO possible
+ * sources, chosen by configuration.
+ *
+ *   regenOS configured (REGENOS_BASE_URL + REGENOS_COLLECTIVE_DID)
+ *     → the RegenHub collective's public calendar on the commons.
+ *   otherwise, or if that call comes back empty
+ *     → Luma, exactly as before.
+ *
+ * `source` tells the caller which door opened — the landing page uses it to
+ * decide between rendering real event cards and falling back to the Luma
+ * embed. `none` means neither backend had anything to say; render something
+ * calm, never an error.
+ *
+ * Like lib/luma.ts, this never throws.
+ */
+
+import { fetchUpcomingLumaEvents } from "@/lib/luma";
+import { fetchUpcomingRegenosEvents } from "@/lib/regenos/events";
+import { isRegenosEventsConfigured } from "@/lib/regenos/config";
+
+export type EventSource = "regenos" | "luma" | "none";
+
+export interface UpcomingEvent {
+  /** Stable key — an AT-URI for regenOS events, the event URL for Luma. */
+  id: string;
+  name: string;
+  /** ISO start time. */
+  startAt: string;
+  /** ISO end time, when known. */
+  endAt?: string;
+  description?: string;
+  /** Public event page, or null when the source can't produce one. */
+  url: string | null;
+}
+
+export interface UpcomingEvents {
+  source: EventSource;
+  events: UpcomingEvent[];
+}
+
+/**
+ * Upcoming events for the next `daysAhead` days, soonest first.
+ *
+ * Never throws and never rejects. A regenOS outage degrades to Luma; a Luma
+ * outage degrades to an empty list.
+ */
+export async function fetchUpcomingEvents(daysAhead = 21): Promise<UpcomingEvents> {
+  if (isRegenosEventsConfigured()) {
+    const regen = await fetchUpcomingRegenosEvents(daysAhead);
+    if (regen.length > 0) {
+      return {
+        source: "regenos",
+        events: regen.map((e) => ({
+          id: e.uri,
+          name: e.name,
+          startAt: e.startAt,
+          endAt: e.endAt,
+          description: e.description,
+          url: e.url,
+        })),
+      };
+    }
+    // Empty is ambiguous — a quiet calendar and an unreachable AppView look the
+    // same from here (both are `[]` by contract). Falling through to Luma keeps
+    // the page useful either way.
+  }
+
+  const luma = await fetchUpcomingLumaEvents(daysAhead);
+  if (luma.length > 0) {
+    return {
+      source: "luma",
+      events: luma.map((e) => ({
+        id: e.url,
+        name: e.name,
+        startAt: e.startAt,
+        url: e.url,
+      })),
+    };
+  }
+
+  return { source: "none", events: [] };
+}

--- a/apps/web/src/lib/regenos/auth.ts
+++ b/apps/web/src/lib/regenos/auth.ts
@@ -1,0 +1,100 @@
+/**
+ * regenOS identity reads — the server side of the one-login lane (Phase 2).
+ *
+ * The browser holds a regenOS `__Host-rs_session` cookie (set on OUR origin by
+ * the /xrpc proxy at app/xrpc/[...nsid]/route.ts). These helpers replay that
+ * cookie to the AppView to learn WHO the caller is, server-to-server.
+ *
+ * ── Why two calls ────────────────────────────────────────────────────────────
+ * `social.scenius.getSession` returns `{did, handle, kind, …}` and NO EMAIL
+ * (crates/regenos-appview/src/xrpc/auth_routes.rs `get_session`). The email we
+ * need to match a `members` row comes from `social.scenius.getMyContactPref`,
+ * which is owner-only and returns the caller's channels.
+ *
+ * ── Why that email is trustworthy ────────────────────────────────────────────
+ * A `{kind:"email", verified:true}` channel is ALWAYS the account's login
+ * anchor, never a user-asserted address:
+ *   * it is seeded server-side from `email_identities` at sign-in
+ *     (`seed_verified_email_channel`, called from `verifyEmail`
+ *     auth_routes.rs:75 and the beta login branch onboarding.rs:316);
+ *   * `saveContactPref` refuses any email that isn't the login anchor —
+ *     `if !is_login { continue; }` (contact_pref.rs, the "email" arm).
+ * regenOS's `email_identities` is a bijection (one email → at most one DID,
+ * forever), so this is the same possession proof Supabase's own OTP gives.
+ *
+ * **We require `verified === true` and ignore every other channel.** Anything
+ * less and a regenOS account could claim a RegenHub member's row.
+ */
+
+import { REGENOS_TIMEOUT_MS, regenosBaseUrl } from "./config";
+
+/** The regenOS session cookie the AppView sets. `__Host-` ⇒ host-scoped, no Domain. */
+export const REGENOS_SESSION_COOKIE = "__Host-rs_session";
+
+export interface RegenosIdentity {
+  did: string;
+  handle: string | null;
+  /** The verified login-anchor email, lowercased. Null when the account has none (BYOD/passkey). */
+  email: string | null;
+}
+
+interface GetSessionOutput {
+  did?: string;
+  handle?: string;
+  kind?: string;
+}
+
+interface ContactChannel {
+  kind?: string;
+  address?: string;
+  verified?: boolean;
+}
+
+async function xrpcGet<T>(nsid: string, cookieHeader: string): Promise<T | null> {
+  const base = regenosBaseUrl();
+  if (!base) return null;
+  try {
+    const res = await fetch(`${base}/xrpc/${nsid}`, {
+      headers: { accept: "application/json", cookie: cookieHeader },
+      signal: AbortSignal.timeout(REGENOS_TIMEOUT_MS),
+      cache: "no-store",
+    });
+    if (!res.ok) {
+      console.warn(`[regenOS] ${nsid} returned ${res.status}`);
+      return null;
+    }
+    return (await res.json()) as T;
+  } catch (err) {
+    console.warn(`[regenOS] ${nsid} failed:`, err);
+    return null;
+  }
+}
+
+/**
+ * Resolve the caller's regenOS identity from their session cookie.
+ *
+ * Returns null when there is no live regenOS session (anonymous callers get
+ * `{}` from getSession, which has no `did`) or when regenOS is unreachable —
+ * the caller turns that into a 401, never a 500.
+ */
+export async function fetchRegenosIdentity(cookieHeader: string): Promise<RegenosIdentity | null> {
+  if (!cookieHeader.includes(REGENOS_SESSION_COOKIE)) return null;
+
+  const session = await xrpcGet<GetSessionOutput>("social.scenius.getSession", cookieHeader);
+  if (!session?.did) return null;
+
+  const prefs = await xrpcGet<{ channels?: ContactChannel[] }>(
+    "social.scenius.getMyContactPref",
+    cookieHeader,
+  );
+
+  const verifiedEmail = (prefs?.channels ?? []).find(
+    (c) => c.kind === "email" && c.verified === true && !!c.address,
+  );
+
+  return {
+    did: session.did,
+    handle: session.handle ?? null,
+    email: verifiedEmail?.address?.trim().toLowerCase() ?? null,
+  };
+}

--- a/apps/web/src/lib/regenos/auth.ts
+++ b/apps/web/src/lib/regenos/auth.ts
@@ -98,3 +98,53 @@ export async function fetchRegenosIdentity(cookieHeader: string): Promise<Regeno
     email: verifiedEmail?.address?.trim().toLowerCase() ?? null,
   };
 }
+
+/** The scene roles that may write events, mirroring the AppView's `owner_or_builder` gate. */
+const EVENT_WRITE_ROLES = new Set(["builder", "facilitator", "steward"]);
+
+export interface RegenosSceneStanding {
+  /** The caller's DIRECT role in the scene (`member`/`builder`/`facilitator`/`steward`), or null. */
+  role: string | null;
+  /** The AppView's own steward verdict for the caller — transitive, so it can be true with no direct role. */
+  steward: boolean;
+  /** Whether the AppView would accept an event write from this caller. */
+  canManageEvents: boolean;
+}
+
+/**
+ * The caller's standing in the collective, read from the AppView with their cookie.
+ *
+ * ── Why `getSceneMembers` ────────────────────────────────────────────────────
+ * It is the only viewer-aware read that answers "what is MY role here". `getScene`
+ * is a pure `(scene) → descriptor` function with no viewer input at all, and there
+ * is no `getMyMemberships`. `getSceneMembers` returns the roster (`{did, role}` per
+ * member, direct roles only) PLUS a top-level `steward` boolean the AppView computes
+ * for the CALLER through the trust resolver — so a transitive steward is reflected
+ * even though the roster only carries direct claims
+ * (crates/regenos-appview/src/xrpc/scene.rs `GetSceneMembersOutput`).
+ *
+ * We mirror the AppView's actual write gate for events — `owner_or_builder`, i.e.
+ * the authority itself OR Builder+ (role ≥ 20) of it (`trust/mod.rs:73`) — by
+ * OR-ing that `steward` flag with our own roster row being builder+. This is a UI
+ * courtesy ONLY: every mutation is re-decided server-side by the AppView, which
+ * 403s a non-steward regardless of what we render.
+ */
+export async function fetchRegenosSceneStanding(
+  cookieHeader: string,
+  sceneDid: string,
+  viewerDid: string,
+): Promise<RegenosSceneStanding> {
+  const out = await xrpcGet<{ members?: { did?: string; role?: string }[]; steward?: boolean }>(
+    `social.scenius.getSceneMembers?scene=${encodeURIComponent(sceneDid)}`,
+    cookieHeader,
+  );
+  const role = out?.members?.find((m) => m.did === viewerDid)?.role ?? null;
+  const steward = out?.steward === true;
+  return {
+    role,
+    steward,
+    // The authority hosting as itself also passes the AppView's gate — irrelevant for
+    // a person viewer, but it costs nothing to be exact about the rule we're mirroring.
+    canManageEvents: steward || viewerDid === sceneDid || (!!role && EVENT_WRITE_ROLES.has(role)),
+  };
+}

--- a/apps/web/src/lib/regenos/config.ts
+++ b/apps/web/src/lib/regenos/config.ts
@@ -1,0 +1,61 @@
+/**
+ * regenOS (atproto AppView) configuration.
+ *
+ * regenOS is the commons backend RegenHub is moving its *public* identity onto:
+ * the RegenHub collective (a "scene") holds the events calendar, and — behind a
+ * flag — the magic-link login lane. Operations (door codes, Stripe, PIN slots)
+ * stay on Supabase.
+ *
+ * Env is read INLINE at call time, never captured at module load, because
+ * Coolify injects env at runtime (same reason as lib/stripe.ts:26).
+ *
+ * Everything here is capability-probe shaped — `isRegenosEventsConfigured()` /
+ * `isRegenosLoginEnabled()` — so callers can degrade instead of failing. See
+ * lib/stripe.ts:33 and lib/email.ts:11 for the same idiom.
+ */
+
+/** Base URL of the regenOS AppView, no trailing slash. e.g. http://localhost:8080 */
+export function regenosBaseUrl(): string | null {
+  const raw = process.env.REGENOS_BASE_URL?.trim();
+  if (!raw) return null;
+  return raw.replace(/\/+$/, "");
+}
+
+/** DID of the RegenHub collective (scene) whose events we publish. */
+export function regenosCollectiveDid(): string | null {
+  const raw = process.env.REGENOS_COLLECTIVE_DID?.trim();
+  if (!raw) return null;
+  // A DID is the only thing we ever accept here — a handle would silently 400
+  // upstream and look like "regenOS is down".
+  if (!raw.startsWith("did:")) {
+    console.warn(`[regenOS] REGENOS_COLLECTIVE_DID is not a DID (${raw}) — ignoring`);
+    return null;
+  }
+  return raw;
+}
+
+/**
+ * Events come from regenOS only when BOTH the AppView URL and the collective
+ * DID are set. Missing either = fall back to Luma (see lib/events.ts).
+ */
+export function isRegenosEventsConfigured(): boolean {
+  return !!regenosBaseUrl() && !!regenosCollectiveDid();
+}
+
+/**
+ * The one-login lane (Phase 2). OFF unless REGENOS_LOGIN_ENABLED is truthy AND
+ * the AppView URL is set. Flag off ⇒ the Supabase OTP door is the only door and
+ * nothing about it changes.
+ *
+ * Deliberately NOT a NEXT_PUBLIC_ var: it's read server-side and passed into
+ * the login form as a prop, so flipping it is an env change + restart rather
+ * than a rebuild (CLAUDE.md: NEXT_PUBLIC_* are baked at build time).
+ */
+export function isRegenosLoginEnabled(): boolean {
+  const flag = process.env.REGENOS_LOGIN_ENABLED?.trim().toLowerCase();
+  const on = flag === "1" || flag === "true" || flag === "yes";
+  return on && !!regenosBaseUrl();
+}
+
+/** Timeout for every regenOS call. A slow commons must never stall a page render. */
+export const REGENOS_TIMEOUT_MS = 8_000;

--- a/apps/web/src/lib/regenos/eventForm.test.ts
+++ b/apps/web/src/lib/regenos/eventForm.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import {
+  EMPTY_EVENT_FORM,
+  buildCreateEventInput,
+  buildDeleteEventInput,
+  buildUpdateEventInput,
+  eventBodyToFormValues,
+  isoToLocalInput,
+  localInputToIso,
+  mintRkey,
+  type EventFormValues,
+} from "./eventForm";
+
+const AUTHORITY = "did:plc:regenhubcollective";
+
+const FILLED: EventFormValues = {
+  name: "  Repair Café  ",
+  description: "  Bring the broken thing.  ",
+  startsAt: "2026-09-03T18:00",
+  endsAt: "2026-09-03T21:00",
+  placeName: " RegenHub ",
+  street: " 1515 Walnut St ",
+  postalCode: " 80302 ",
+  visibility: "private",
+  attendance: "approval",
+};
+
+describe("datetime round-trip", () => {
+  it("gives the AppView an offset-bearing ISO string", () => {
+    const iso = localInputToIso("2026-09-03T18:00");
+    expect(iso).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  });
+
+  it("round-trips through the local input format", () => {
+    // Timezone-independent by construction: whatever zone the runner is in,
+    // local → ISO → local must land on the same wall clock.
+    const local = "2026-09-03T18:00";
+    expect(isoToLocalInput(localInputToIso(local))).toBe(local);
+  });
+
+  it("treats blank and unparseable as absent", () => {
+    expect(localInputToIso("")).toBeNull();
+    expect(localInputToIso("   ")).toBeNull();
+    expect(localInputToIso("not a date")).toBeNull();
+    expect(isoToLocalInput(null)).toBe("");
+    expect(isoToLocalInput("nonsense")).toBe("");
+  });
+});
+
+describe("buildCreateEventInput", () => {
+  const input = buildCreateEventInput(FILLED, { authority: AUTHORITY, rkey: "ev-1" });
+
+  it("matches the CreateEventInput field names", () => {
+    expect(input).toMatchObject({
+      authority: AUTHORITY,
+      rkey: "ev-1",
+      name: "Repair Café",
+      description: "Bring the broken thing.",
+      placeName: "RegenHub",
+      street: "1515 Walnut St",
+      postalCode: "80302",
+      locality: "Boulder",
+      region: "CO",
+      country: "US",
+      visibility: "private",
+      attendance: "approval",
+      publicFace: "exact",
+    });
+  });
+
+  it("sends the address at the exact face so an edit can read it back", () => {
+    // A rough face routes street/placeName into the gated event.detail record,
+    // which the edit form cannot read — the address would vanish on first save.
+    expect(input.publicFace).toBe("exact");
+  });
+
+  it("omits empty optional fields rather than sending blanks", () => {
+    const sparse = buildCreateEventInput(
+      { ...EMPTY_EVENT_FORM, name: "Coworking", startsAt: "2026-09-03T09:00" },
+      { authority: AUTHORITY, rkey: "ev-2" },
+    );
+    expect(Object.keys(sparse).sort()).toEqual(
+      [
+        "attendance",
+        "authority",
+        "country",
+        "locality",
+        "name",
+        "publicFace",
+        "region",
+        "rkey",
+        "startsAt",
+        "visibility",
+      ].sort(),
+    );
+  });
+});
+
+describe("buildUpdateEventInput", () => {
+  it("omits visibility and attendance, which updateEvent ignores", () => {
+    const input = buildUpdateEventInput(FILLED, { authority: AUTHORITY, rkey: "ev-1" });
+    expect(input).not.toHaveProperty("visibility");
+    expect(input).not.toHaveProperty("attendance");
+    expect(input).toMatchObject({ authority: AUTHORITY, rkey: "ev-1", name: "Repair Café" });
+  });
+
+  it("resends every descriptive field — an omitted field is a deleted field upstream", () => {
+    const input = buildUpdateEventInput(FILLED, { authority: AUTHORITY, rkey: "ev-1" });
+    for (const key of ["description", "startsAt", "endsAt", "placeName", "street", "postalCode"]) {
+      expect(input).toHaveProperty(key);
+    }
+  });
+});
+
+describe("buildDeleteEventInput", () => {
+  it("is exactly {authority, rkey}", () => {
+    expect(buildDeleteEventInput({ authority: AUTHORITY, rkey: "ev-1" })).toEqual({
+      authority: AUTHORITY,
+      rkey: "ev-1",
+    });
+  });
+});
+
+describe("eventBodyToFormValues", () => {
+  it("reads the address out of the locations union, ignoring the geo sibling", () => {
+    const values = eventBodyToFormValues(
+      {
+        name: "Repair Café",
+        description: "Bring the broken thing.",
+        startsAt: localInputToIso("2026-09-03T18:00")!,
+        endsAt: localInputToIso("2026-09-03T21:00")!,
+        locations: [
+          { $type: "community.lexicon.location.geo", name: "pin" },
+          {
+            $type: "community.lexicon.location.address",
+            name: "RegenHub",
+            street: "1515 Walnut St",
+            postalCode: "80302",
+          },
+        ],
+      },
+      "public",
+    );
+    expect(values).toEqual({
+      name: "Repair Café",
+      description: "Bring the broken thing.",
+      startsAt: "2026-09-03T18:00",
+      endsAt: "2026-09-03T21:00",
+      placeName: "RegenHub",
+      street: "1515 Walnut St",
+      postalCode: "80302",
+      visibility: "public",
+      attendance: "open",
+    });
+  });
+
+  it("survives an event with no location or times", () => {
+    expect(eventBodyToFormValues({ name: "TBD" }, "private")).toEqual({
+      ...EMPTY_EVENT_FORM,
+      name: "TBD",
+      visibility: "private",
+    });
+  });
+});
+
+describe("mintRkey", () => {
+  it("stays inside the atproto rkey charset and is unique per call", () => {
+    const keys = new Set(Array.from({ length: 50 }, mintRkey));
+    expect(keys.size).toBe(50);
+    for (const k of keys) expect(k).toMatch(/^[A-Za-z0-9._:~-]{1,512}$/);
+  });
+});

--- a/apps/web/src/lib/regenos/eventForm.ts
+++ b/apps/web/src/lib/regenos/eventForm.ts
@@ -1,0 +1,200 @@
+/**
+ * The wire shape of the regenOS event form — pure, so it can be tested without
+ * a browser or an AppView.
+ *
+ * Everything here mirrors `CreateEventInput` in
+ * crates/regenos-appview/src/xrpc/event.rs. `updateEvent` deliberately reuses
+ * that SAME struct (event.rs:474) and re-runs the whole create fan-out with the
+ * same rkey, so **an edit must resend every field it wants to keep** — an
+ * omitted `street` is a deleted street, not an untouched one. That is why the
+ * edit form prefills from the stored event rather than starting blank.
+ *
+ * ── Why `publicFace: "exact"` ────────────────────────────────────────────────
+ * The AppView's default face is `rough`, which routes street / postal code /
+ * place name into the GATED `event.detail` record and publishes only an H3 cell
+ * (event.rs `build_public_and_gated`). We can't read that gated record back
+ * (`getDetail` is attendee-gated), so a rough event would silently lose its
+ * address on the first edit. RegenHub's events happen at a published street
+ * address on purpose, so `exact` is both honest and lossless here.
+ */
+
+/** The RegenHub collective sits in Boulder; the address lexicon REQUIRES `country`. */
+export const BOULDER = { locality: "Boulder", region: "CO", country: "US" } as const;
+
+export type EventVisibility = "public" | "private";
+export type EventAttendance = "open" | "approval";
+
+/** The v1 field set, in the browser's own vocabulary (datetime-local strings). */
+export interface EventFormValues {
+  name: string;
+  description: string;
+  /** `YYYY-MM-DDTHH:mm`, local — what `<input type="datetime-local">` yields. */
+  startsAt: string;
+  endsAt: string;
+  placeName: string;
+  street: string;
+  postalCode: string;
+  visibility: EventVisibility;
+  attendance: EventAttendance;
+}
+
+export const EMPTY_EVENT_FORM: EventFormValues = {
+  name: "",
+  description: "",
+  startsAt: "",
+  endsAt: "",
+  placeName: "",
+  street: "",
+  postalCode: "",
+  visibility: "public",
+  attendance: "open",
+};
+
+/**
+ * `YYYY-MM-DDTHH:mm` (local, no offset) → RFC 3339 with an offset.
+ * The AppView's `parse_opt_datetime` 400s on a datetime with no timezone, and
+ * `new Date(local).toISOString()` is exactly the "in the viewer's own timezone"
+ * reading a datetime-local input means. Empty/unparseable ⇒ null (omitted).
+ */
+export function localInputToIso(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const d = new Date(trimmed);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString();
+}
+
+/** The inverse, for prefilling an edit form. Empty string when there's nothing to show. */
+export function isoToLocalInput(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/**
+ * A fresh base record key for `createEvent`. Time-ordered so the collection
+ * sorts sensibly, and inside atproto's rkey charset (`[A-Za-z0-9._:~-]`).
+ */
+export function mintRkey(): string {
+  const stamp = Date.now().toString(36);
+  const noise = Math.random().toString(36).slice(2, 8);
+  return `ev-${stamp}${noise}`;
+}
+
+/** Trim, and treat blank as absent — the AppView trims too, but an omitted field reads clearer on the wire. */
+function present(value: string): string | undefined {
+  const t = value.trim();
+  return t ? t : undefined;
+}
+
+export interface EventInputTarget {
+  /** `REGENOS_COLLECTIVE_DID` — the scene the event belongs to. */
+  authority: string;
+  rkey: string;
+}
+
+/** The descriptive half both writes share — name, times, address. */
+function describedEvent(
+  values: EventFormValues,
+  target: EventInputTarget,
+): Record<string, unknown> {
+  const input: Record<string, unknown> = {
+    authority: target.authority,
+    rkey: target.rkey,
+    name: values.name.trim(),
+    publicFace: "exact",
+    ...BOULDER,
+  };
+  const description = present(values.description);
+  if (description) input.description = description;
+  const startsAt = localInputToIso(values.startsAt);
+  if (startsAt) input.startsAt = startsAt;
+  const endsAt = localInputToIso(values.endsAt);
+  if (endsAt) input.endsAt = endsAt;
+  const placeName = present(values.placeName);
+  if (placeName) input.placeName = placeName;
+  const street = present(values.street);
+  if (street) input.street = street;
+  const postalCode = present(values.postalCode);
+  if (postalCode) input.postalCode = postalCode;
+  return input;
+}
+
+/** The `createEvent` request body — the two controls only exist here. */
+export function buildCreateEventInput(
+  values: EventFormValues,
+  target: EventInputTarget,
+): Record<string, unknown> {
+  return {
+    ...describedEvent(values, target),
+    visibility: values.visibility,
+    attendance: values.attendance,
+  };
+}
+
+/**
+ * The `updateEvent` request body — the SAME struct minus the two controls,
+ * because `updateEvent` ignores them (event.rs:469-471: an edit never moves an
+ * event between stores or rewrites its seat config). Sending them anyway would
+ * be a lie on the wire, so we don't, and the edit UI doesn't offer them.
+ */
+export function buildUpdateEventInput(
+  values: EventFormValues,
+  target: EventInputTarget,
+): Record<string, unknown> {
+  return describedEvent(values, target);
+}
+
+/** The `deleteEvent` request body — `{authority, rkey}` and nothing else (event.rs `DeleteEventInput`). */
+export function buildDeleteEventInput(target: EventInputTarget): Record<string, unknown> {
+  return { authority: target.authority, rkey: target.rkey };
+}
+
+/** The slice of `community.lexicon.location.address` the form round-trips. */
+interface AddressItem {
+  $type?: string;
+  name?: string;
+  street?: string;
+  postalCode?: string;
+}
+
+/** The bits of a stored `community.lexicon.calendar.event` body the form reads back. */
+export interface CalendarEventBody {
+  name?: string;
+  description?: string;
+  startsAt?: string;
+  endsAt?: string;
+  locations?: AddressItem[];
+}
+
+/**
+ * Read a stored event back into form values. The address rides `locations` as a
+ * `community.lexicon.location.address` item (fanout.rs `build_calendar_event`);
+ * a `geo`/`hthree` sibling in the same array carries no street, so we pick by type.
+ *
+ * `attendance` is NOT recoverable here — it lives in the sibling
+ * `coop.lexicon.event.config` record, which no read we make returns. It lands as
+ * `open` and the edit UI never shows it, which is exactly right: `updateEvent`
+ * preserves the stored config regardless.
+ */
+export function eventBodyToFormValues(
+  body: CalendarEventBody,
+  visibility: EventVisibility,
+): EventFormValues {
+  const address = (body.locations ?? []).find(
+    (l) => l?.$type === "community.lexicon.location.address",
+  );
+  return {
+    name: body.name ?? "",
+    description: body.description ?? "",
+    startsAt: isoToLocalInput(body.startsAt),
+    endsAt: isoToLocalInput(body.endsAt),
+    placeName: address?.name ?? "",
+    street: address?.street ?? "",
+    postalCode: address?.postalCode ?? "",
+    visibility,
+    attendance: "open",
+  };
+}

--- a/apps/web/src/lib/regenos/events.ts
+++ b/apps/web/src/lib/regenos/events.ts
@@ -130,6 +130,106 @@ export async function fetchUpcomingRegenosEvents(daysAhead = 21): Promise<Regeno
   }
 }
 
+/** One of the collective's events as the in-portal manager sees it: whole, editable, past or future. */
+export interface ManagedRegenosEvent {
+  uri: string;
+  /** The event's repo DID — always the collective, since the collective is the authority. */
+  did: string;
+  /** The base record key `updateEvent`/`deleteEvent` address the event by. */
+  rkey: string;
+  /** Which store the row came from — the AppView's authoritative public/private signal. */
+  visibility: "public" | "private";
+  /** The raw `community.lexicon.calendar.event` body, for prefilling the edit form. */
+  value: CalendarEventValue & { locations?: { $type?: string; name?: string; street?: string; postalCode?: string }[] };
+  name: string;
+  /** ISO start, or null for an event with no time set. */
+  startAt: string | null;
+  url: string | null;
+}
+
+function toManaged(uri: string, value: unknown, visibility: "public" | "private"): ManagedRegenosEvent | null {
+  const parts = splitAtUri(uri);
+  const v = (value ?? {}) as ManagedRegenosEvent["value"];
+  if (!parts || !v.name) return null;
+  return {
+    uri,
+    did: parts.did,
+    rkey: parts.rkey,
+    visibility,
+    value: v,
+    name: v.name,
+    startAt: v.startsAt ?? null,
+    url: eventUrl(uri),
+  };
+}
+
+/**
+ * EVERY event the collective owns — past and future, public and private —
+ * soonest-first. The management view, not the landing page's shop window.
+ *
+ * Two reads, because no single AppView method answers this:
+ *   * `getEvents?scene=<did>` is the scene's own calendar but is deliberately
+ *     viewer-independent, so it can only ever return PUBLIC events
+ *     (crates/regenos-appview/src/xrpc/scene.rs `get_events`).
+ *   * `getVisibleEvents` is the viewer-scoped cross-scene feed — it carries the
+ *     private events this caller may read, so we call it with the steward's
+ *     cookie and keep the rows whose repo DID is the collective. (Filtering on
+ *     the URI's DID, not the joined `sceneDid`, because the collective IS the
+ *     authority of the events it hosts, and that join can lag the firehose.)
+ *
+ * Returns [] on any failure — a steward seeing an empty list is recoverable; a
+ * 500 on the portal page is not.
+ */
+export async function fetchCollectiveEventsForManagement(
+  cookieHeader: string,
+): Promise<ManagedRegenosEvent[]> {
+  const base = regenosBaseUrl();
+  const scene = regenosCollectiveDid();
+  if (!base || !scene) return [];
+
+  const get = async (path: string): Promise<{ events?: { uri?: string; value?: unknown; source?: string }[] } | null> => {
+    try {
+      const res = await fetch(`${base}/xrpc/${path}`, {
+        headers: { accept: "application/json", cookie: cookieHeader },
+        signal: AbortSignal.timeout(REGENOS_TIMEOUT_MS),
+        cache: "no-store",
+      });
+      if (!res.ok) {
+        console.warn(`[regenOS] ${path} returned ${res.status}`);
+        return null;
+      }
+      return await res.json();
+    } catch (err) {
+      console.warn(`[regenOS] ${path} failed:`, err);
+      return null;
+    }
+  };
+
+  const [own, visible] = await Promise.all([
+    get(`social.scenius.getEvents?scene=${encodeURIComponent(scene)}&limit=${FETCH_LIMIT}`),
+    get(`social.scenius.getVisibleEvents?limit=${FETCH_LIMIT}`),
+  ]);
+
+  const byUri = new Map<string, ManagedRegenosEvent>();
+  for (const row of own?.events ?? []) {
+    const e = row.uri ? toManaged(row.uri, row.value, "public") : null;
+    if (e) byUri.set(e.uri, e);
+  }
+  for (const row of visible?.events ?? []) {
+    if (!row.uri || byUri.has(row.uri)) continue;
+    const e = toManaged(row.uri, row.value, row.source === "private" ? "private" : "public");
+    if (e && e.did === scene) byUri.set(e.uri, e);
+  }
+
+  // Undated events sort last; everything else soonest-first (the AppView orders
+  // by INDEXING time, which is not what a calendar wants).
+  return [...byUri.values()].sort((a, b) => {
+    if (!a.startAt) return b.startAt ? 1 : 0;
+    if (!b.startAt) return -1;
+    return a.startAt.localeCompare(b.startAt);
+  });
+}
+
 /**
  * The collective's subscribable calendar feed on the regenOS web app
  * (`/scenes/<did>/calendar.ics`), or null when unconfigured. The Luma-

--- a/apps/web/src/lib/regenos/events.ts
+++ b/apps/web/src/lib/regenos/events.ts
@@ -1,0 +1,143 @@
+/**
+ * regenOS events client — the RegenHub collective's public calendar.
+ *
+ * This is the "local query" lib/luma.ts:10-11 anticipated: the same
+ * `{ name, startAt, url }` shape comes out, so nothing upstream changes.
+ *
+ * SAME CONTRACT AS LUMA: graceful degradation. Every function returns `[]` and
+ * never throws. regenOS being down, misconfigured, or mid-migration must never
+ * break the landing page or the newsletter — callers fall back (lib/events.ts).
+ *
+ * Wire contract (regenOS `main` @ 41e7c96):
+ *   GET {base}/xrpc/social.scenius.getEvents?scene=<did>&limit=<n>
+ *     → { scene, events: [{ uri, cid, value, source, sceneName, sceneDid, hostName }] }
+ *   `value` is the borrowed `community.lexicon.calendar.event` body.
+ *   The endpoint takes NO viewer input (crates/regenos-appview/src/xrpc/scene.rs
+ *   `get_events`) — anonymous, member and non-member callers get byte-identical
+ *   responses, and permissioned events are structurally absent. So we call it
+ *   with no credentials at all.
+ *   Rows come back newest-INDEXED first (`ORDER BY e.time_us DESC`), NOT by
+ *   start time — an old-but-upcoming event would otherwise sort wrong, so we
+ *   filter + sort on `startsAt` here.
+ */
+
+import {
+  REGENOS_TIMEOUT_MS,
+  isRegenosEventsConfigured,
+  regenosBaseUrl,
+  regenosCollectiveDid,
+} from "./config";
+
+/** The AppView clamps `limit` to 200; ask for the whole calendar and window it locally. */
+const FETCH_LIMIT = 200;
+
+export interface RegenosEvent {
+  /** Stable identity — the `community.lexicon.calendar.event` AT-URI. */
+  uri: string;
+  name: string;
+  /** ISO start time. */
+  startAt: string;
+  /** ISO end time, when the event has one. */
+  endAt?: string;
+  description?: string;
+  /** Public event page on the regenOS web app, or null when REGENOS_WEB_URL is unset. */
+  url: string | null;
+}
+
+/** The bits of `community.lexicon.calendar.event` we render. Tolerant — extra fields are ignored. */
+interface CalendarEventValue {
+  name?: string;
+  description?: string;
+  startsAt?: string;
+  endsAt?: string;
+}
+
+interface GetEventsRow {
+  uri?: string;
+  value?: CalendarEventValue;
+}
+
+/** `at://did:plc:xyz/community.lexicon.calendar.event/3k2a` → `["did:plc:xyz", "3k2a"]`. */
+function splitAtUri(uri: string): { did: string; rkey: string } | null {
+  const m = /^at:\/\/([^/]+)\/[^/]+\/(.+)$/.exec(uri);
+  if (!m) return null;
+  return { did: m[1], rkey: m[2] };
+}
+
+/**
+ * Public event page URL on the regenOS web app — the same route scenius-web's
+ * ICS feed links to (`/events/<did>/<rkey>`). Null when REGENOS_WEB_URL is
+ * unset: we'd rather render an unlinked event than a broken link.
+ */
+function eventUrl(atUri: string): string | null {
+  const webBase = process.env.REGENOS_WEB_URL?.trim().replace(/\/+$/, "");
+  if (!webBase) return null;
+  const parts = splitAtUri(atUri);
+  if (!parts) return null;
+  return `${webBase}/events/${encodeURIComponent(parts.did)}/${parts.rkey}`;
+}
+
+/**
+ * Fetch the collective's upcoming public events, soonest first.
+ * Returns [] on any failure or when regenOS isn't configured — never throws.
+ */
+export async function fetchUpcomingRegenosEvents(daysAhead = 21): Promise<RegenosEvent[]> {
+  const base = regenosBaseUrl();
+  const scene = regenosCollectiveDid();
+  if (!base || !scene || !isRegenosEventsConfigured()) return [];
+
+  const url = new URL(`${base}/xrpc/social.scenius.getEvents`);
+  url.searchParams.set("scene", scene);
+  url.searchParams.set("limit", String(FETCH_LIMIT));
+
+  try {
+    const res = await fetch(url, {
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(REGENOS_TIMEOUT_MS),
+      // The listing is viewer-independent, so a short shared cache is honest.
+      next: { revalidate: 300 },
+    });
+    if (!res.ok) {
+      console.warn(`[regenOS] getEvents returned ${res.status} — skipping events`);
+      return [];
+    }
+
+    const data = (await res.json()) as { events?: GetEventsRow[] };
+    const now = Date.now();
+    const horizon = now + daysAhead * 24 * 60 * 60 * 1000;
+
+    const events: RegenosEvent[] = [];
+    for (const row of data.events ?? []) {
+      const v = row.value;
+      if (!row.uri || !v?.name || !v.startsAt) continue;
+      const startMs = Date.parse(v.startsAt);
+      if (Number.isNaN(startMs) || startMs < now || startMs > horizon) continue;
+      events.push({
+        uri: row.uri,
+        name: v.name,
+        startAt: v.startsAt,
+        endAt: v.endsAt,
+        description: v.description,
+        url: eventUrl(row.uri),
+      });
+    }
+
+    events.sort((a, b) => a.startAt.localeCompare(b.startAt));
+    return events;
+  } catch (err) {
+    console.warn("[regenOS] getEvents failed — skipping events:", err);
+    return [];
+  }
+}
+
+/**
+ * The collective's subscribable calendar feed on the regenOS web app
+ * (`/scenes/<did>/calendar.ics`), or null when unconfigured. The Luma-
+ * calendar-subscription parity piece, already built upstream.
+ */
+export function regenosCalendarIcsUrl(): string | null {
+  const webBase = process.env.REGENOS_WEB_URL?.trim().replace(/\/+$/, "");
+  const scene = regenosCollectiveDid();
+  if (!webBase || !scene) return null;
+  return `${webBase}/scenes/${encodeURIComponent(scene)}/calendar.ics`;
+}

--- a/apps/web/src/lib/regenos/events.ts
+++ b/apps/web/src/lib/regenos/events.ts
@@ -31,6 +31,9 @@ import {
 /** The AppView clamps `limit` to 200; ask for the whole calendar and window it locally. */
 const FETCH_LIMIT = 200;
 
+/** The borrowed event collection every RegenHub event lives in. */
+const EVENT_COLLECTION = "community.lexicon.calendar.event";
+
 export interface RegenosEvent {
   /** Stable identity — the `community.lexicon.calendar.event` AT-URI. */
   uri: string;
@@ -40,8 +43,19 @@ export interface RegenosEvent {
   /** ISO end time, when the event has one. */
   endAt?: string;
   description?: string;
-  /** Public event page on the regenOS web app, or null when REGENOS_WEB_URL is unset. */
+  /** In-site event page (`/events/<did>/<rkey>`), or null for an unparseable URI. */
   url: string | null;
+}
+
+/** The slice of `community.lexicon.location.address` an event card/page shows. */
+interface AddressValue {
+  $type?: string;
+  name?: string;
+  street?: string;
+  locality?: string;
+  region?: string;
+  postalCode?: string;
+  country?: string;
 }
 
 /** The bits of `community.lexicon.calendar.event` we render. Tolerant — extra fields are ignored. */
@@ -50,6 +64,7 @@ interface CalendarEventValue {
   description?: string;
   startsAt?: string;
   endsAt?: string;
+  locations?: AddressValue[];
 }
 
 interface GetEventsRow {
@@ -65,16 +80,20 @@ function splitAtUri(uri: string): { did: string; rkey: string } | null {
 }
 
 /**
- * Public event page URL on the regenOS web app — the same route scenius-web's
- * ICS feed links to (`/events/<did>/<rkey>`). Null when REGENOS_WEB_URL is
- * unset: we'd rather render an unlinked event than a broken link.
+ * The event's page **on regenhub.xyz** — `/events/<did>/<rkey>`, served by
+ * `app/events/[did]/[rkey]/page.tsx`.
+ *
+ * This used to point at REGENOS_WEB_URL (scenius.social). Per Aaron: regenhub.xyz
+ * is the whole experience, so an event link must never leave the site. The route
+ * shape is deliberately the same one scenius-web uses, so an old link and a new
+ * one are the same path under a different origin.
+ *
+ * Env-independent — the only reason for null is an AT-URI we can't split.
  */
 function eventUrl(atUri: string): string | null {
-  const webBase = process.env.REGENOS_WEB_URL?.trim().replace(/\/+$/, "");
-  if (!webBase) return null;
   const parts = splitAtUri(atUri);
   if (!parts) return null;
-  return `${webBase}/events/${encodeURIComponent(parts.did)}/${parts.rkey}`;
+  return `/events/${encodeURIComponent(parts.did)}/${parts.rkey}`;
 }
 
 /**
@@ -127,6 +146,124 @@ export async function fetchUpcomingRegenosEvents(daysAhead = 21): Promise<Regeno
   } catch (err) {
     console.warn("[regenOS] getEvents failed — skipping events:", err);
     return [];
+  }
+}
+
+/** A public street address on an event, as the detail page shows it. */
+export interface RegenosEventLocation {
+  /** The venue's name, e.g. "RegenHub". */
+  name?: string;
+  street?: string;
+  locality?: string;
+  region?: string;
+  postalCode?: string;
+}
+
+/** One public event, whole — what `/events/<did>/<rkey>` renders. */
+export interface RegenosEventDetail {
+  uri: string;
+  did: string;
+  rkey: string;
+  name: string;
+  /** ISO start, or null for an event with no time set. */
+  startAt: string | null;
+  endAt: string | null;
+  /** The full description — the detail page doesn't clamp it. */
+  description: string | null;
+  /** The public address, when the event carries one (only an `exact` public face does). */
+  location: RegenosEventLocation | null;
+  /** The host's display name off the event's own repo DID, when the AppView has it indexed. */
+  hostName: string | null;
+}
+
+/** Pull the `community.lexicon.location.address` face out of an event's `locations` array. */
+function publicAddress(value: CalendarEventValue): RegenosEventLocation | null {
+  const address = (value.locations ?? []).find(
+    (l) => l?.$type === "community.lexicon.location.address",
+  );
+  if (!address) return null;
+  const location: RegenosEventLocation = {
+    name: address.name,
+    street: address.street,
+    locality: address.locality,
+    region: address.region,
+    postalCode: address.postalCode,
+  };
+  // A `rough` public face publishes an H3 cell and no address fields at all; an
+  // all-empty address is nothing to show, so say so rather than render a blank.
+  return Object.values(location).some((v) => v && v.trim()) ? location : null;
+}
+
+/**
+ * One public event by `did`/`rkey`, for the in-site detail page.
+ *
+ * Wire contract (regenOS `main`, crates/regenos-appview/src/xrpc/event.rs `get_event`):
+ *   GET {base}/xrpc/social.scenius.getEvent?uri=at://<did>/community.lexicon.calendar.event/<rkey>
+ *     → { uri, cid, value, visibility: "public" | "private", hostName? }
+ *
+ * We call it **anonymously**, exactly like `getEvents`. The handler is the
+ * visibility-routed getRecord adapter: a PUBLIC summary reads for anyone
+ * including an anonymous caller; a PRIVATE one 401s an anonymous caller and
+ * never leaks that it exists. So an anonymous 4xx and "no such event" are the
+ * same answer to us — `null` — which is precisely what a public page should say.
+ *
+ * We ALSO refuse a non-`public` visibility defensively: this page has no viewer,
+ * so anything the AppView classified as private has no business on it.
+ *
+ * Returns null on any failure and never throws — same contract as everything
+ * else in this module.
+ */
+export async function fetchPublicRegenosEvent(
+  did: string,
+  rkey: string,
+): Promise<RegenosEventDetail | null> {
+  const base = regenosBaseUrl();
+  if (!base || !isRegenosEventsConfigured()) return null;
+  if (!did.startsWith("did:") || !rkey) return null;
+
+  const atUri = `at://${did}/${EVENT_COLLECTION}/${rkey}`;
+  const url = new URL(`${base}/xrpc/social.scenius.getEvent`);
+  url.searchParams.set("uri", atUri);
+
+  try {
+    const res = await fetch(url, {
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(REGENOS_TIMEOUT_MS),
+      // Viewer-independent (we send no credentials), so a short shared cache is honest.
+      next: { revalidate: 300 },
+    });
+    if (!res.ok) {
+      // 404 unknown, 401 anonymous-on-private — both mean "not a public event".
+      if (res.status !== 404 && res.status !== 401) {
+        console.warn(`[regenOS] getEvent returned ${res.status} — treating as not found`);
+      }
+      return null;
+    }
+
+    const data = (await res.json()) as {
+      uri?: string;
+      value?: CalendarEventValue;
+      visibility?: string;
+      hostName?: string;
+    };
+    const v = data.value;
+    if (!v?.name) return null;
+    if (data.visibility && data.visibility !== "public") return null;
+
+    return {
+      uri: data.uri ?? atUri,
+      did,
+      rkey,
+      name: v.name,
+      startAt: v.startsAt ?? null,
+      endAt: v.endsAt ?? null,
+      description: v.description ?? null,
+      location: publicAddress(v),
+      hostName: data.hostName ?? null,
+    };
+  } catch (err) {
+    console.warn("[regenOS] getEvent failed — treating as not found:", err);
+    return null;
   }
 }
 

--- a/apps/web/src/lib/regenos/oauth.test.ts
+++ b/apps/web/src/lib/regenos/oauth.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildClientMetadataDoc,
+  regenosOAuthConfig,
+  RegenosOAuthError,
+  requestAuthorizeUrl,
+  resolveOAuthCallback,
+} from "./oauth";
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_SITE_URL = "https://regenhub.xyz";
+  delete process.env.REGENOS_OAUTH_JWKS_URI;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("regenosOAuthConfig", () => {
+  it("derives client_id and redirect_uri from the site origin", () => {
+    expect(regenosOAuthConfig()).toEqual({
+      clientId: "https://regenhub.xyz/oauth-client-metadata.json",
+      redirectUri: "https://regenhub.xyz/oauth/callback",
+    });
+  });
+
+  it("falls back to https://regenhub.xyz when NEXT_PUBLIC_SITE_URL is unset", () => {
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+    expect(regenosOAuthConfig().clientId).toBe("https://regenhub.xyz/oauth-client-metadata.json");
+  });
+
+  it("strips a trailing slash", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "https://regenhub.xyz/";
+    expect(regenosOAuthConfig().redirectUri).toBe("https://regenhub.xyz/oauth/callback");
+  });
+});
+
+describe("buildClientMetadataDoc", () => {
+  it("is a public client (token_endpoint_auth_method: none) with no jwks_uri configured", () => {
+    const doc = buildClientMetadataDoc();
+    expect(doc).toMatchObject({
+      client_id: "https://regenhub.xyz/oauth-client-metadata.json",
+      redirect_uris: ["https://regenhub.xyz/oauth/callback"],
+      scope: "atproto transition:generic",
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      application_type: "web",
+      token_endpoint_auth_method: "none",
+      dpop_bound_access_tokens: true,
+    });
+    expect(doc.jwks_uri).toBeUndefined();
+    expect(doc.token_endpoint_auth_signing_alg).toBeUndefined();
+  });
+
+  it("becomes a confidential private_key_jwt client once REGENOS_OAUTH_JWKS_URI is set", () => {
+    process.env.REGENOS_OAUTH_JWKS_URI = "https://scenius.social/oauth/jwks.json";
+    const doc = buildClientMetadataDoc();
+    expect(doc.token_endpoint_auth_method).toBe("private_key_jwt");
+    expect(doc.token_endpoint_auth_signing_alg).toBe("ES256");
+    expect(doc.jwks_uri).toBe("https://scenius.social/oauth/jwks.json");
+  });
+
+  it("carries no secrets — no inline key material, only a public jwks_uri reference", () => {
+    process.env.REGENOS_OAUTH_JWKS_URI = "https://scenius.social/oauth/jwks.json";
+    const doc = buildClientMetadataDoc() as unknown as Record<string, unknown>;
+    expect(doc).not.toHaveProperty("client_secret");
+    expect(doc).not.toHaveProperty("jwks"); // inline keyset — only jwks_uri (a public URL) is allowed
+    expect(doc.jwks_uri).toMatch(/^https:\/\//);
+  });
+});
+
+describe("requestAuthorizeUrl", () => {
+  it("POSTs beginOAuth through the same-origin /xrpc proxy and returns the authorizeUrl", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ authorizeUrl: "https://pds.example/oauth/authorize?request_uri=abc" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const url = await requestAuthorizeUrl("alice.bsky.social", fetchImpl);
+
+    expect(url).toBe("https://pds.example/oauth/authorize?request_uri=abc");
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "/xrpc/social.scenius.beginOAuth",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+      }),
+    );
+    const body = JSON.parse((fetchImpl.mock.calls[0][1] as RequestInit).body as string);
+    expect(body).toEqual({
+      identifier: "alice.bsky.social",
+      clientId: "https://regenhub.xyz/oauth-client-metadata.json",
+      redirectUri: "https://regenhub.xyz/oauth/callback",
+    });
+  });
+
+  it("throws RegenosOAuthError with the AppView's message on a non-2xx", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "InvalidRequest", message: "Unknown handle." }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await expect(requestAuthorizeUrl("nobody", fetchImpl)).rejects.toMatchObject({
+      message: "Unknown handle.",
+      body: { error: "InvalidRequest", message: "Unknown handle." },
+    });
+  });
+
+  it("throws when the AppView returns 2xx with no authorizeUrl", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200, headers: { "content-type": "application/json" } }),
+    );
+
+    await expect(requestAuthorizeUrl("alice.bsky.social", fetchImpl)).rejects.toBeInstanceOf(RegenosOAuthError);
+  });
+});
+
+describe("resolveOAuthCallback", () => {
+  it("resolves ok on an opaque redirect (the AppView's own 302, Set-Cookie already applied)", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ type: "opaqueredirect", status: 0 } as Response);
+
+    const result = await resolveOAuthCallback(
+      { code: "abc", state: "xyz", iss: "https://pds.example" },
+      fetchImpl,
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "/xrpc/social.scenius.oauthCallback?code=abc&state=xyz&iss=https%3A%2F%2Fpds.example",
+      expect.objectContaining({ method: "GET", credentials: "include", redirect: "manual" }),
+    );
+  });
+
+  it("resolves ok on a direct 2xx", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    const result = await resolveOAuthCallback({ code: "abc", state: "xyz" }, fetchImpl);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("maps a state-mismatch AppView error to reason:state_mismatch", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "InvalidState", message: "state did not match" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const result = await resolveOAuthCallback({ code: "abc", state: "wrong" }, fetchImpl);
+
+    expect(result).toEqual({ ok: false, reason: "state_mismatch", message: "state did not match" });
+  });
+
+  it("maps error=access_denied to reason:denied without touching the AppView", async () => {
+    const fetchImpl = vi.fn();
+
+    const result = await resolveOAuthCallback({ error: "access_denied" }, fetchImpl);
+
+    expect(result).toEqual({ ok: false, reason: "denied", message: "Sign-in was cancelled." });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns invalid_callback when code or state is missing", async () => {
+    const fetchImpl = vi.fn();
+
+    const result = await resolveOAuthCallback({ code: "abc" }, fetchImpl);
+
+    expect(result.ok).toBe(false);
+    expect((result as { reason: string }).reason).toBe("invalid_callback");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("collapses a thrown fetch to reason:server_error", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("network down"));
+
+    const result = await resolveOAuthCallback({ code: "abc", state: "xyz" }, fetchImpl);
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "server_error",
+      message: "Could not reach the sign-in service. Please try again.",
+    });
+  });
+});

--- a/apps/web/src/lib/regenos/oauth.ts
+++ b/apps/web/src/lib/regenos/oauth.ts
@@ -1,0 +1,265 @@
+/**
+ * regenOS atproto OAuth — the thin client glue for the real login mechanism.
+ *
+ * Supersedes nothing: the magic-link bridge (`lib/regenos/auth.ts`,
+ * `api/auth/regenos/session/route.ts`) still does every bit of downstream
+ * work (email→member match, `members.did` write, Supabase session mint). This
+ * module only gets a regenOS session COOKIE onto regenhub.xyz's own origin,
+ * the same way the magic-link lane does — just via real atproto OAuth
+ * (PAR/PKCE/DPoP/token exchange) instead of an email round-trip.
+ *
+ * ── Why this is thin ──────────────────────────────────────────────────────
+ * All OAuth machinery lives in regenOS's AppView (`atrium-oauth`, Rust). This
+ * app never holds or refreshes a token — it POSTs `beginOAuth` to get an
+ * `authorizeUrl`, sends the browser there, and on return POSTs `oauthCallback`
+ * with the PDS's `code`/`state`/`iss`. The AppView verifies, exchanges, and
+ * mints, then Set-Cookies `__Host-rs_session` on THIS origin (relayed by the
+ * `/xrpc` proxy — see `app/xrpc/[...nsid]/route.ts` for why that cookie can
+ * only ever land via a same-origin proxy).
+ *
+ * Re-authored from regenOS's own `packages/ui/src/auth/{sign-in,callback,
+ * client-metadata,config}.ts` (a private workspace package, not importable
+ * cross-repo) and adapted to this app's conventions:
+ *   - the app origin is `NEXT_PUBLIC_SITE_URL` (this repo's existing
+ *     convention — see every `api/**\/route.ts` that builds an absolute URL),
+ *     NOT the live request origin regenOS's own frontends use. `client_id`
+ *     and `redirect_uri` are exact-match registered on the AppView side
+ *     (`OAUTH_CLIENTS`), so they must be stable values, not derived from a
+ *     spoofable `Host` header.
+ *   - all browser fetches go through the SAME `/xrpc` proxy the magic-link
+ *     lane already uses (`app/xrpc/[...nsid]/route.ts`), not a bespoke path.
+ */
+
+const DEFAULT_SITE_ORIGIN = "https://regenhub.xyz";
+
+const NSID_BEGIN_OAUTH = "social.scenius.beginOAuth";
+const NSID_OAUTH_CALLBACK = "social.scenius.oauthCallback";
+
+/** Where the static client-metadata document is served — this URL IS the atproto `client_id`. */
+export const CLIENT_METADATA_PATH = "/oauth-client-metadata.json";
+/** The clean, exact-match registered OAuth `redirect_uri` (NOT the `/xrpc` proxy path). */
+export const CALLBACK_PATH = "/oauth/callback";
+
+/** This app's own origin, no trailing slash. Same fallback every other route in this repo uses. */
+export function siteOrigin(): string {
+  return (process.env.NEXT_PUBLIC_SITE_URL?.trim() || DEFAULT_SITE_ORIGIN).replace(/\/+$/, "");
+}
+
+/**
+ * The AppView's published JWKS URL. When set, regenhub.xyz registers as a CONFIDENTIAL
+ * (`private_key_jwt`) OAuth client sharing the AppView's one signing key — the same posture
+ * scenius-web/liminal-web run in prod (`deploy/cutover-oauth-liminal.sh`: `OAUTH_CLIENTS` entries all
+ * carry the same `jwksUri`). Unset ⇒ the served metadata declares a PUBLIC client
+ * (`token_endpoint_auth_method: "none"`) — usable against a dev/staging AppView with no signing key
+ * configured, but MUST match whatever mode the AppView's `OAUTH_CLIENTS` entry for regenhub.xyz
+ * actually uses, or the PDS will see two different stories about this client and refuse it.
+ */
+export function regenosOAuthJwksUri(): string | undefined {
+  return process.env.REGENOS_OAUTH_JWKS_URI?.trim() || undefined;
+}
+
+/** regenhub.xyz's own `OAuthAppConfig` — the per-app contract `beginOAuth`/the metadata doc consume. */
+export interface RegenosOAuthConfig {
+  clientId: string;
+  redirectUri: string;
+}
+
+export function regenosOAuthConfig(): RegenosOAuthConfig {
+  const origin = siteOrigin();
+  return {
+    clientId: `${origin}${CLIENT_METADATA_PATH}`,
+    redirectUri: `${origin}${CALLBACK_PATH}`,
+  };
+}
+
+/** The atproto OAuth client-metadata document shape (snake_case — the OAuth/atproto wire convention). */
+export interface OAuthClientMetadataDoc {
+  client_id: string;
+  client_name: string;
+  client_uri: string;
+  redirect_uris: string[];
+  scope: string;
+  grant_types: string[];
+  response_types: string[];
+  application_type: "web";
+  token_endpoint_auth_method: "private_key_jwt" | "none";
+  token_endpoint_auth_signing_alg?: string;
+  dpop_bound_access_tokens: true;
+  jwks_uri?: string;
+}
+
+/**
+ * Build the document regenhub.xyz serves at `CLIENT_METADATA_PATH` — mirrors regenOS's own
+ * `buildClientMetadata` shape exactly (`packages/ui/src/auth/client-metadata.ts`).
+ */
+export function buildClientMetadataDoc(): OAuthClientMetadataDoc {
+  const cfg = regenosOAuthConfig();
+  const jwksUri = regenosOAuthJwksUri();
+  const confidential = jwksUri !== undefined;
+
+  const doc: OAuthClientMetadataDoc = {
+    client_id: cfg.clientId,
+    client_name: "RegenHub Boulder",
+    client_uri: siteOrigin(),
+    redirect_uris: [cfg.redirectUri],
+    scope: "atproto transition:generic",
+    grant_types: ["authorization_code", "refresh_token"],
+    response_types: ["code"],
+    application_type: "web",
+    token_endpoint_auth_method: confidential ? "private_key_jwt" : "none",
+    dpop_bound_access_tokens: true,
+  };
+  if (confidential) {
+    doc.token_endpoint_auth_signing_alg = "ES256";
+    doc.jwks_uri = jwksUri;
+  }
+  return doc;
+}
+
+// ── the sign-in initiator (POST beginOAuth → the authorizeUrl to navigate to) ─────────────────────
+
+/** The atproto-shaped XRPC error body the AppView returns on a non-2xx. */
+export interface XrpcErrorBody {
+  error: string;
+  message: string;
+}
+
+/** A failed `beginOAuth`/`oauthCallback` call — the parsed AppView error body, when there was one. */
+export class RegenosOAuthError extends Error {
+  constructor(
+    message: string,
+    readonly body: XrpcErrorBody | null = null,
+  ) {
+    super(message);
+    this.name = "RegenosOAuthError";
+  }
+}
+
+interface BeginOAuthOutput {
+  authorizeUrl?: string;
+}
+
+/**
+ * Run `beginOAuth` through the same-origin `/xrpc` proxy and resolve the authorization URL to send the
+ * browser to. Framework-agnostic core (no DOM) — the click handler navigates; this only fetches.
+ * Mirrors regenOS's `requestAuthorizeUrl` (`packages/ui/src/auth/sign-in.ts`).
+ */
+export async function requestAuthorizeUrl(
+  identifier: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<string> {
+  const cfg = regenosOAuthConfig();
+  const res = await fetchImpl(`/xrpc/${NSID_BEGIN_OAUTH}`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "content-type": "application/json", accept: "application/json" },
+    body: JSON.stringify({ identifier, clientId: cfg.clientId, redirectUri: cfg.redirectUri }),
+  });
+
+  const json = (await res.json().catch(() => null)) as (BeginOAuthOutput & Partial<XrpcErrorBody>) | null;
+
+  if (!res.ok) {
+    const body: XrpcErrorBody | null =
+      json && typeof json.error === "string" ? { error: json.error, message: json.message ?? "" } : null;
+    throw new RegenosOAuthError(body?.message || "Could not start sign-in just now.", body);
+  }
+
+  if (!json?.authorizeUrl) {
+    throw new RegenosOAuthError("regenOS returned no authorizeUrl — the begin response is malformed.");
+  }
+  return json.authorizeUrl;
+}
+
+// ── the /oauth/callback resolver (hand code/state/iss to the AppView → the session lands) ─────────
+
+export interface OAuthCallbackQuery {
+  code?: string | null;
+  state?: string | null;
+  iss?: string | null;
+  error?: string | null;
+  errorDescription?: string | null;
+}
+
+/**
+ * Why a callback did NOT establish a session — mirrors regenOS's `OAuthCallbackErrorReason`
+ * (`packages/ui/src/auth/types.ts`):
+ *   - `denied`           — the user declined consent at the AS (`error=access_denied`).
+ *   - `as_error`         — any other AS-side error on the callback query.
+ *   - `state_mismatch`   — the AppView rejected the callback: query `state` didn't match its state cookie.
+ *   - `iss_mismatch`     — the AppView rejected the callback: `iss` didn't match the resolved issuer.
+ *   - `invalid_callback` — the callback carried neither a usable `code`+`state` nor an `error`.
+ *   - `server_error`     — the AppView/token-exchange failed for another reason.
+ */
+export type OAuthCallbackErrorReason =
+  | "denied"
+  | "as_error"
+  | "state_mismatch"
+  | "iss_mismatch"
+  | "invalid_callback"
+  | "server_error";
+
+export type OAuthCallbackResult = { ok: true } | { ok: false; reason: OAuthCallbackErrorReason; message: string };
+
+/** Best-effort AppView-error → reason mapping (mirrors regenOS's `defaultMapAppViewError`). */
+function mapAppViewError(body: XrpcErrorBody | null): OAuthCallbackErrorReason {
+  const code = (body?.error ?? "").toLowerCase();
+  if (code.includes("state")) return "state_mismatch";
+  if (code.includes("iss")) return "iss_mismatch";
+  return "server_error";
+}
+
+/**
+ * Resolve `/oauth/callback`'s query to an outcome. Hands `code`/`state`/`iss` to `oauthCallback` through
+ * the same-origin `/xrpc` proxy with `credentials:'include'` (so the browser sends the sealed state
+ * cookie the AppView binds `state` against) and `redirect:'manual'` (so the AppView's own 302 isn't
+ * auto-followed by fetch — its `Set-Cookie __Host-rs_session` still lands, relayed by the proxy).
+ *
+ * A `GET`, not a `POST` — mirrors regenOS's `resolveOAuthCallback` (`packages/ui/src/auth/callback.ts`)
+ * exactly: `code`/`state`/`iss` ride the query string, same as `beginOAuth`'s `authorizeUrl` redirect
+ * convention.
+ *
+ * Never throws: a thrown fetch collapses to `{ ok:false, reason:'server_error' }`.
+ */
+export async function resolveOAuthCallback(
+  query: OAuthCallbackQuery,
+  fetchImpl: typeof fetch = fetch,
+): Promise<OAuthCallbackResult> {
+  // 1. The AS bounced back with an error (consent denied / authorization failure) — no code to exchange.
+  if (query.error) {
+    const denied = query.error === "access_denied";
+    return {
+      ok: false,
+      reason: denied ? "denied" : "as_error",
+      message: query.errorDescription ?? (denied ? "Sign-in was cancelled." : "The sign-in provider returned an error."),
+    };
+  }
+
+  // 2. A well-formed authorization response must carry both a code and the state to bind it.
+  if (!query.code || !query.state) {
+    return { ok: false, reason: "invalid_callback", message: "The sign-in link was incomplete. Please start again." };
+  }
+
+  const params = new URLSearchParams({ code: query.code, state: query.state });
+  if (query.iss) params.set("iss", query.iss);
+
+  let res: Response;
+  try {
+    res = await fetchImpl(`/xrpc/${NSID_OAUTH_CALLBACK}?${params}`, {
+      method: "GET",
+      credentials: "include",
+      redirect: "manual",
+      headers: { accept: "application/json" },
+    });
+  } catch {
+    return { ok: false, reason: "server_error", message: "Could not reach the sign-in service. Please try again." };
+  }
+
+  // An opaque redirect (the AppView's own 302; its Set-Cookie is applied even under redirect:'manual')
+  // or any 2xx means the session landed on this origin.
+  if (res.type === "opaqueredirect" || (res.status >= 200 && res.status < 400)) {
+    return { ok: true };
+  }
+
+  const body = (await res.json().catch(() => null)) as XrpcErrorBody | null;
+  return { ok: false, reason: mapAppViewError(body), message: body?.message ?? "Sign-in could not be completed." };
+}

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -93,6 +93,7 @@ export interface Database {
           email: string | null;
           telegram_username: string | null;
           ethereum_address: string | null;
+          did: string | null;
           nfc_key_address: string | null;
           pin_code: string | null;
           pin_code_slot: number | null;
@@ -123,6 +124,7 @@ export interface Database {
           email?: string | null;
           telegram_username?: string | null;
           ethereum_address?: string | null;
+          did?: string | null;
           nfc_key_address?: string | null;
           pin_code?: string | null;
           pin_code_slot?: number | null;

--- a/supabase/migrations/042_members_did.sql
+++ b/supabase/migrations/042_members_did.sql
@@ -1,0 +1,36 @@
+-- Migration 042: members.did — the regenOS (atproto) identity
+--
+-- RegenHub's commons layer is moving onto regenOS: the RegenHub collective
+-- holds the public calendar, and (behind REGENOS_LOGIN_ENABLED) the login
+-- door becomes the regenOS magic link. Each human there is a DID.
+--
+-- This column is the fourth identity in the existing four-way stitch
+-- (see CLAUDE.md "Identity linkage"): interests row ↔ members row ↔
+-- auth.users row ↔ regenOS DID. Email stays the join key — every one of
+-- those links is already made by email (triggers 004, 013, 020), and
+-- regenOS's own account model is email-anchored too (one email → at most
+-- one DID, forever).
+--
+-- Shape is modeled on `stripe_customer_id` (021:20-21), NOT on
+-- `ethereum_address` (001:23):
+--   * server-written, never user-supplied — a custodial DID is minted by
+--     regenOS and only ever written by /api/auth/regenos/session after
+--     regenOS has proved the caller owns the email. It is deliberately
+--     ABSENT from the self-edit whitelist in api/portal/profile/route.ts
+--     (that route's own comment at :63-65 says not to add columns unless
+--     they're safe for self-edit — this one isn't).
+--   * `unique` — one DID belongs to exactly one member row, mirroring
+--     regenOS's own `email_identities` bijection. A collision means two
+--     member rows claim one person; the route turns that into a 409 rather
+--     than a 500, same as the telegram-handle precedent (036 + profile
+--     route :78-86).
+--
+-- Nullable and unbackfilled by design: a member's DID appears the first time
+-- they sign in through regenOS. No migration of rows, no downtime, and with
+-- the flag off nothing writes here at all.
+
+alter table members add column did text unique;
+create index on members (did);
+
+comment on column members.did is
+  'regenOS (atproto) DID. Server-written only, by /api/auth/regenos/session after regenOS verifies the email. Not self-editable.';

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,15 @@
+-- Local-dev seed, applied automatically by `supabase start` / `supabase db reset`.
+--
+-- The hosted/self-hosted Supabase this app runs on grants the API roles access
+-- to `public` tables at the platform level, so no migration ever states them.
+-- A fresh local stack has no such grants: every RLS-scoped query (the portal's
+-- member lookup, the admin routes' service-role reads) fails with 42501
+-- "permission denied" before RLS is even consulted. Mirror the platform grants
+-- here — RLS policies still decide which ROWS each role can see.
+grant usage on schema public to anon, authenticated, service_role;
+grant all on all tables in schema public to anon, authenticated, service_role;
+grant all on all sequences in schema public to anon, authenticated, service_role;
+grant all on all functions in schema public to anon, authenticated, service_role;
+alter default privileges in schema public grant all on tables to anon, authenticated, service_role;
+alter default privileges in schema public grant all on sequences to anon, authenticated, service_role;
+alter default privileges in schema public grant all on functions to anon, authenticated, service_role;


### PR DESCRIPTION
## regenOS integration: events + one-login (both off by default)

This wires regenhub.xyz to the regenOS backend in the two places Phase 1/2 of the
integration plan calls for — public events and a single sign-in — with both features
**fully gated by env config**. Unconfigured, the site
builds and behaves byte-for-byte as today.

### Events (on when `REGENOS_BASE_URL` + `REGENOS_COLLECTIVE_DID` are set)

- The landing page's "Upcoming Events" renders the RegenHub collective's public
  calendar from `social.scenius.getEvents` instead of the Luma iframe.
- Fetch is anonymous (the AppView's handler takes no viewer input, so permissioned
  events are structurally absent from the response). `lib/events.ts` is the seam
  `lib/luma.ts` promised: one `UpcomingEvent` shape, two sources.
- **Zero events for any reason — quiet calendar, AppView down, timeout — falls back
  to the Luma embed.** The page never breaks because regenOS is down.
- The newsletter deliberately still reads Luma; its copy is Luma-branded end to end
  and switching it is a product decision.

### One-login (`REGENOS_LOGIN_ENABLED`, default OFF)

regenOS becomes the front door; Supabase stays the session + RLS substrate, so every
existing RLS policy, `auth.getUser()` call site, and the whole portal work untouched.

- `/auth/login` grows a "continue with regenOS" lane above the existing one-time-link
  form (which stays, as the fallback for the whole transition).
- A same-origin `/xrpc` proxy (allowlisted to the login NSIDs, 404 when the flag is
  off) carries the AppView's `__Host-rs_session` cookie, which cannot cross origins.
- `POST /api/auth/regenos/session` does the handoff: regenOS session → verified
  login-anchor email → match `members` by email (the same join the existing stitching
  triggers use) → write `members.did` (migration 042, server-written only, deliberately
  NOT in the profile self-edit whitelist) → mint a real Supabase session via
  `generateLink` + `verifyOtp` (admin API — no second email).
- **No member match is not an error**: that's a *participant* — a real session with
  public features only, routed to `/membership`.

### A bug the e2e loop caught before it shipped

GoTrue's `admin generate_link(type: magiclink)` does **not** error for a missing auth
user — it silently auto-creates an unconfirmed user and mints a `signup`-type token.
Redeeming that as `"magiclink"` fails with "Email link is invalid or has expired",
which would have broken **exactly the first sign-in of every newly provisioned
member** (the retry works, masking it). Fixed by redeeming with the
`verification_type` GoTrue says it minted; unit test pins it.

### Verified end to end, locally

Full loop on a local stack (seeded regenOS AppView + local Supabase + this app):

| Path | Result |
|---|---|
| Landing page, regenOS configured | 6 seeded events render; no Luma iframe in the DOM |
| Landing page, regenOS down (warm cache) | events keep serving from the 5-min shared fetch cache (`revalidate: 300`) — a brief AppView outage is invisible |
| Landing page, regenOS down (cold render) | Luma embed fallback renders; server log shows the designed `getEvents failed — skipping events` |
| Member first sign-in (fresh member row, no auth user) | `ok:true, member:true` first try; `members.did` written; auth user auto-provisioned + linked by trigger 004 |
| Participant (regenOS account, no membership) | `ok:true, member:false, redirect:/membership`, no member row created |
| `/portal` with the minted session | 200 |
| `/portal` anonymous (control) | 307 → `/auth/login` |

Unit tests: 39 passed. Lint: clean (one pre-existing warning). Screen recording in
the PR comment below.

### Known upstream gap (documented in README + CLAUDE.md)

The AppView's `verify_base_url`/`app_base_url` are global and single-valued, so in
production a magic link started from regenhub.xyz would email a scenius.social URL.
Locally you point them at regenhub; fixing it for real is the multi-app-origin PR
against regenOS (in review on the regenos-dev channel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
