### PR TITLE
fix(auth): serve the /login magic-link landing that signup emails point at

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,18 @@ the session + RLS substrate. Two doors, same finish:
 - **Email bridge** (`RegenosLoginPanel.tsx`'s magic-link form) — proves identity by email possession
   instead of real OAuth; kept as a second door, not superseded. Its
   `beginSignup`/`checkEmail`/`chooseHandle` stages are unchanged by the OAuth addition.
+- **`/login?token=…`** (`app/login/page.tsx` + `components/auth/MagicLinkWizard.tsx`) — the landing
+  page for the link regenOS EMAILS, and the second half of that same wizard. Prod regenOS runs email
+  mode, so an address it doesn't know comes back `checkEmail` (not the beta-mode `chooseHandle`
+  `RegenosLoginPanel` was written against) and mails `<app_base_url>/login?token=…`; with regenhub.xyz
+  as that base the link lands here. The wizard runs `verifySignup` (redeems the token, bound to the
+  `__Host-rs_pending` cookie `beginSignup` set on this origin — so a link opened on a *different*
+  device can't resume) → handle step (18 chars, `[a-z0-9-]`, **never pre-filled from the email**,
+  debounced `checkHandle` probe that never blocks on its own failures) → `setSignupProfile` →
+  `createCustodialAccount` (this is what lands `__Host-rs_session`) → the same
+  `POST /api/auth/regenos/session` handoff. Wire contract + validation live in
+  `lib/regenos/signupWizard.ts` (pure + unit-tested; vitest here is node-env with no jsdom). Flag off
+  or no `token` ⇒ redirect to `/auth/login`.
 
 Both doors land the AppView's session cookie on this origin then call the one shared handoff:
 

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,0 +1,62 @@
+import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+import { MagicLinkWizard } from "@/components/auth/MagicLinkWizard";
+import { isRegenosLoginEnabled } from "@/lib/regenos/config";
+
+/**
+ * `/login?token=…` — the landing page for the link regenOS EMAILS.
+ *
+ * This URL isn't ours to choose: prod regenOS (email mode) mails
+ * `<app_base_url>/login?token=…` to any address it doesn't know, and with
+ * regenhub.xyz as that base the link points here. Until now this app served no
+ * `/login`, so every new member's link 404'd — the majority path, since most
+ * RegenHub members have no regenOS account yet. `<MagicLinkWizard>` is the
+ * second half of the wizard `RegenosLoginPanel` starts.
+ *
+ * NOT the sign-in page — that stays `/auth/login`. Both redirect cases below
+ * land there rather than showing anything: the flag being off means this
+ * surface shouldn't exist at all, and a bare `/login` (someone shortening the
+ * URL, a bookmark, a link with the query stripped by a mail client) has no
+ * token to redeem, so the honest answer to both is "here's the front door".
+ * A redirect, not a 404, because `/login` is a name people TYPE.
+ */
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Finish signing in — RegenHub",
+  // A single-use redemption URL should never be indexed or followed.
+  robots: { index: false, follow: false },
+};
+
+interface PageProps {
+  searchParams: Promise<{ token?: string }>;
+}
+
+export default async function MagicLinkLoginPage({ searchParams }: PageProps) {
+  if (!isRegenosLoginEnabled()) {
+    redirect("/auth/login");
+  }
+
+  const { token } = await searchParams;
+  if (!token) {
+    redirect("/auth/login");
+  }
+
+  // Same shell as /auth/login — one card, centred, so arriving from the inbox
+  // looks like the page they'd have reached by hand.
+  return (
+    <div className="min-h-screen flex items-center justify-center px-6">
+      <div className="w-full max-w-md">
+        <div className="glass-panel-strong p-8">
+          <div className="text-center mb-8">
+            <h1 className="text-2xl font-bold text-forest mb-2">Almost there</h1>
+            <p className="text-muted text-sm">
+              Your email is confirmed. Pick a name and we&apos;ll finish setting up your account.
+            </p>
+          </div>
+          <MagicLinkWizard token={token} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -50,8 +50,10 @@ export default async function MagicLinkLoginPage({ searchParams }: PageProps) {
         <div className="glass-panel-strong p-8">
           <div className="text-center mb-8">
             <h1 className="text-2xl font-bold text-forest mb-2">Almost there</h1>
+            {/* Neutral on purpose: the wizard below hasn't redeemed the token yet,
+                so this header can't claim the email is confirmed. */}
             <p className="text-muted text-sm">
-              Your email is confirmed. Pick a name and we&apos;ll finish setting up your account.
+              One more step — pick a name and we&apos;ll finish setting up your account.
             </p>
           </div>
           <MagicLinkWizard token={token} />

--- a/apps/web/src/app/xrpc/[...nsid]/route.test.ts
+++ b/apps/web/src/app/xrpc/[...nsid]/route.test.ts
@@ -59,6 +59,20 @@ describe("xrpc proxy allowlist", () => {
     expect(upstream).toHaveBeenCalledOnce();
   });
 
+  it("forwards checkHandle (GET) — the /login wizard's availability probe", async () => {
+    const res = await GET(req("social.scenius.checkHandle", "GET"), ctx("social.scenius.checkHandle"));
+    expect(res.status).toBe(200);
+    expect(upstream).toHaveBeenCalledOnce();
+    expect(upstream.mock.calls[0][0]).toBe("https://appview.test/xrpc/social.scenius.checkHandle");
+  });
+
+  it("404s checkHandle when the login flag is off", async () => {
+    vi.mocked(isRegenosLoginEnabled).mockReturnValue(false);
+    const res = await GET(req("social.scenius.checkHandle", "GET"), ctx("social.scenius.checkHandle"));
+    expect(res.status).toBe(404);
+    expect(upstream).not.toHaveBeenCalled();
+  });
+
   it("forwards beginOAuth (POST)", async () => {
     const res = await POST(req("social.scenius.beginOAuth"), ctx("social.scenius.beginOAuth"));
     expect(res.status).toBe(200);

--- a/apps/web/src/app/xrpc/[...nsid]/route.ts
+++ b/apps/web/src/app/xrpc/[...nsid]/route.ts
@@ -39,6 +39,8 @@ export const runtime = "nodejs";
  *   cookie the magic-link lane lands. Same trust posture as the rest of this
  *   list — the AppView does the real verification, this proxy only carries
  *   the cookie onto regenhub.xyz's origin.
+ * - checkHandle — the /login wizard's live availability probe; a read-only,
+ *   pre-auth, PUBLIC AppView method (it answers anonymous callers by design)
  * - getSession / getMyContactPref — whoami, read by the browser for UI state
  * - createEvent / updateEvent / deleteEvent — /portal/events, the stewards'
  *   in-portal calendar. These are the only WRITES on the list; each one is
@@ -51,6 +53,7 @@ const ALLOWED_NSIDS = new Set([
   "social.scenius.setSignupProfile",
   "social.scenius.createCustodialAccount",
   "social.scenius.verifyEmail",
+  "social.scenius.checkHandle",
   "social.scenius.beginOAuth",
   "social.scenius.oauthCallback",
   "social.scenius.getSession",

--- a/apps/web/src/components/auth/MagicLinkWizard.tsx
+++ b/apps/web/src/components/auth/MagicLinkWizard.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  MAX_HANDLE,
+  createCustodialAccount,
+  finishSession,
+  probeHandle,
+  setSignupProfile,
+  validateHandle,
+  verifySignup,
+  type HandleProbe,
+} from "@/lib/regenos/signupWizard";
+
+/**
+ * <MagicLinkWizard> — the browser side of `/login?token=…`, the landing page for
+ * the link regenOS emails a NEW member.
+ *
+ * The gap it closes: `RegenosLoginPanel`'s email door reads a `chooseHandle`
+ * response as "no account — use the classic lane", but that's the AppView's
+ * BETA-mode answer. Prod runs email mode, where a new address comes back
+ * `checkEmail` and regenOS mails a link pointing HERE. Without this page the
+ * link 404s, which is the majority path for RegenHub (most members have no
+ * regenOS account yet).
+ *
+ * Two steps, in the order the AppView enforces (see `lib/regenos/signupWizard.ts`
+ * for the wire contract and the pending-cookie story):
+ *   1. `verifySignup` on mount — redeem the token, bound to the
+ *      `__Host-rs_pending` cookie `beginSignup` set on this origin.
+ *   2. pick a name → `setSignupProfile` → `createCustodialAccount` (this is
+ *      what lands the real session cookie) → the SAME
+ *      `POST /api/auth/regenos/session` handoff both existing doors finish
+ *      through (`RegenosLoginPanel.finish()`).
+ *
+ * Deliberately NOT here: the email step (that's `/auth/login`) and the contact
+ * step (scenius's own post-mint surface — RegenHub already knows how to reach
+ * its members). This is the shortest honest path from a clicked link to a
+ * RegenHub session.
+ */
+
+/** Which view is on screen. `busy` is tracked separately so an in-flight request never yanks it. */
+type Step = "verifying" | "handle" | "linkFailed";
+
+/** Keystroke→probe debounce, in lockstep with scenius's own availability hook. */
+const PROBE_DEBOUNCE_MS = 400;
+
+export function MagicLinkWizard({ token }: { token: string }) {
+  const router = useRouter();
+  const [step, setStep] = useState<Step>("verifying");
+  const [handle, setHandle] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // The probe's last answer, carrying the label it ANSWERED ABOUT — that pairing
+  // is what lets "are we still waiting?" be derived instead of stored (no
+  // setState in an effect body, and no way for a stale answer to be shown
+  // against a newer label).
+  const [probe, setProbe] = useState<HandleProbe & { label: string }>({ status: "idle", label: "" });
+
+  // The token is single-use: a second `verifySignup` would burn nothing (it's
+  // already spent) but WOULD show a spurious failure, so this fires exactly
+  // once even under React's development double-mount. Same ref guard as
+  // <OAuthCallback>.
+  const verifiedRef = useRef(false);
+  useEffect(() => {
+    if (verifiedRef.current) return;
+    verifiedRef.current = true;
+    (async () => {
+      const result = await verifySignup(token);
+      if (!result.ok) {
+        setError(result.message);
+        setStep("linkFailed");
+        return;
+      }
+      setStep("handle");
+    })();
+  }, [token]);
+
+  // The live availability probe. Only a LOCALLY VALID label is worth a
+  // round-trip, and the monotonic request id means a slow answer for `ali`
+  // can never overwrite a fresh one for `alice`.
+  const local = validateHandle(handle);
+  const probeableLabel = local.ok ? local.label : "";
+  const probeId = useRef(0);
+  useEffect(() => {
+    if (step !== "handle" || !probeableLabel) return;
+    probeId.current += 1;
+    const id = probeId.current;
+    const timer = setTimeout(async () => {
+      const result = await probeHandle(probeableLabel);
+      if (id !== probeId.current) return; // a newer keystroke won — drop this stale answer
+      setProbe({ ...result, label: probeableLabel });
+    }, PROBE_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [probeableLabel, step]);
+
+  // We only "have an answer" while the stored one is about the label on screen;
+  // anything else means a probe is still owed (debouncing or in flight).
+  const answered = probeableLabel.length > 0 && probe.label === probeableLabel;
+  const checking = probeableLabel.length > 0 && !answered;
+  const availability: HandleProbe = answered ? probe : { status: "idle" };
+
+  // Submit gate, exactly scenius's: locally valid, no KNOWN collision, no probe
+  // in flight, nothing already running. A probe that failed (`unknown`) is
+  // NEUTRAL and never blocks — the AppView's 409 is the real backstop.
+  const canSubmit = local.ok && availability.status !== "taken" && !checking && !busy;
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit || !local.ok) return;
+    setError(null);
+    setBusy(true);
+
+    const profile = await setSignupProfile(local.label);
+    if (!profile.ok) {
+      setError(profile.message);
+      setBusy(false);
+      return;
+    }
+
+    // The mint. A 409 `HandleTaken` here means the label was raced between the
+    // probe and this call — stay on THIS step with the "pick another" copy
+    // (the message carries the AppView's `<label>2` offer) rather than
+    // bouncing someone who did nothing wrong.
+    const account = await createCustodialAccount();
+    if (!account.ok) {
+      setError(account.message);
+      setBusy(false);
+      return;
+    }
+
+    // The regenOS session cookie has landed on this origin; finish the way
+    // every other regenOS door finishes.
+    const finished = await finishSession();
+    if (!finished.ok) {
+      setError(finished.message);
+      setBusy(false);
+      return;
+    }
+    router.push(finished.redirect);
+    router.refresh();
+    // Leave `busy` true — the navigation is taking over, and re-enabling the
+    // button would invite a second mint.
+  }
+
+  if (step === "verifying") {
+    return (
+      <Panel>
+        <p className="text-sm text-muted text-center">Confirming your link…</p>
+      </Panel>
+    );
+  }
+
+  if (step === "linkFailed") {
+    return (
+      <Panel>
+        <p className="text-sm text-muted">{error}</p>
+        <a href="/auth/login" className="btn-primary-glass inline-block w-full text-center px-6 py-2">
+          Start again
+        </a>
+      </Panel>
+    );
+  }
+
+  return (
+    <Panel>
+      <form onSubmit={onSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="regenos-handle">Pick a name for your account</Label>
+          <Input
+            id="regenos-handle"
+            value={handle}
+            // Lowercase as they type: the charset is lowercase-only, and
+            // silently fixing a capital is kinder than scolding them for it.
+            onChange={(e) => setHandle(e.target.value.toLowerCase())}
+            placeholder="yourname"
+            maxLength={MAX_HANDLE}
+            autoComplete="off"
+            autoCapitalize="none"
+            spellCheck={false}
+            autoFocus
+            disabled={busy}
+            className="bg-white/10 border-white/20 text-foreground placeholder:text-muted"
+          />
+          <AvailabilityNote
+            handle={handle}
+            probe={availability}
+            checking={checking}
+            localMessage={local.ok ? null : local.message}
+          />
+        </div>
+        {error && (
+          <p className="text-red-400 text-sm" role="alert">
+            {error}
+          </p>
+        )}
+        <Button type="submit" disabled={!canSubmit} className="btn-primary-glass w-full">
+          {busy ? "Setting you up…" : "Finish signing in"}
+        </Button>
+      </form>
+    </Panel>
+  );
+}
+
+/**
+ * The one-line note under the field. Order matters: a local problem is the
+ * person's next action, so it wins over anything the probe has to say — and a
+ * probe that couldn't reach the AppView says nothing at all rather than
+ * implying an answer it doesn't have.
+ */
+function AvailabilityNote({
+  handle,
+  probe,
+  checking,
+  localMessage,
+}: {
+  handle: string;
+  probe: HandleProbe;
+  checking: boolean;
+  localMessage: string | null;
+}) {
+  if (handle.trim().length > 0 && localMessage) {
+    return <p className="text-xs text-red-400">{localMessage}</p>;
+  }
+  if (checking) {
+    return <p className="text-xs text-muted">Checking…</p>;
+  }
+  if (probe.status === "free") {
+    return <p className="text-xs text-forest">{probe.handle ?? handle.trim()} is available.</p>;
+  }
+  if (probe.status === "taken") {
+    return (
+      <p className="text-xs text-red-400">
+        {probe.handle ?? handle.trim()} is taken.
+        {probe.suggestion ? ` ${probe.suggestion} is free.` : ""}
+      </p>
+    );
+  }
+  return <p className="text-xs text-muted">Lowercase letters, numbers, and hyphens — up to {MAX_HANDLE}.</p>;
+}
+
+/** Same wrapper `RegenosLoginPanel` uses, so both regenOS surfaces sit identically in the page's card. */
+function Panel({ children }: { children: React.ReactNode }) {
+  return <div className="space-y-4">{children}</div>;
+}

--- a/apps/web/src/components/auth/RegenosLoginPanel.tsx
+++ b/apps/web/src/components/auth/RegenosLoginPanel.tsx
@@ -129,8 +129,13 @@ export function RegenosLoginPanel({ next = "/portal" }: { next?: string }) {
     } else if (data.stage === "checkEmail") {
       setStage("checkEmail");
     } else {
-      // "chooseHandle" — regenOS has no account for this email yet. Creating one
-      // is a signup wizard, not a login surface; the classic lane is the answer.
+      // "chooseHandle" — regenOS has no account for this email yet AND trusted
+      // the address without an inbox round-trip. That's BETA mode; PROD runs
+      // email mode, where a new address comes back "checkEmail" above and the
+      // emailed link lands on `/login?token=…` (`app/login/page.tsx`), which
+      // finishes the signup wizard in-app. So this branch is the beta-only
+      // tail: creating an account inline is a wizard, not a login surface, and
+      // the classic lane is the answer.
       setStage("noAccount");
     }
   }

--- a/apps/web/src/lib/regenos/signupWizard.test.ts
+++ b/apps/web/src/lib/regenos/signupWizard.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  LINK_FAILED_MESSAGE,
+  MAX_HANDLE,
+  createCustodialAccount,
+  finishSession,
+  probeHandle,
+  setSignupProfile,
+  validateHandle,
+  verifySignup,
+} from "./signupWizard";
+
+/** A JSON response, the shape every AppView reply (and the proxy's relay of it) actually has. */
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("verifySignup", () => {
+  it("GETs the token through the same-origin /xrpc proxy", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(json({ stage: "chooseHandle" }));
+
+    await expect(verifySignup("tok-123", fetchImpl)).resolves.toEqual({ ok: true });
+    expect(fetchImpl.mock.calls[0][0]).toBe("/xrpc/social.scenius.verifySignup?token=tok-123");
+  });
+
+  it("url-encodes the token rather than splicing it raw", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(json({ stage: "chooseHandle" }));
+
+    await verifySignup("a+b/c=", fetchImpl);
+
+    expect(fetchImpl.mock.calls[0][0]).toBe("/xrpc/social.scenius.verifySignup?token=a%2Bb%2Fc%3D");
+  });
+
+  it("maps a 400 (expired token OR missing pending cookie) to the one warm link-failed message", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(json({ error: "InvalidRequest", message: "no pending signup in progress" }, 400));
+
+    await expect(verifySignup("stale", fetchImpl)).resolves.toEqual({
+      ok: false,
+      reason: "invalid_link",
+      message: LINK_FAILED_MESSAGE,
+    });
+  });
+
+  it("maps a thrown fetch to reason:unreachable, not a dead link", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("network down"));
+
+    const result = await verifySignup("tok", fetchImpl);
+
+    expect(result).toMatchObject({ ok: false, reason: "unreachable" });
+  });
+});
+
+describe("the handle write sequence", () => {
+  it("POSTs the label alone — never a bio, never anything derived from the email", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(json({ stage: "ready", handle: "alice.scenius.social" }));
+
+    const result = await setSignupProfile("  alice  ", fetchImpl);
+
+    expect(result).toEqual({ ok: true, handle: "alice.scenius.social" });
+    expect(fetchImpl.mock.calls[0][0]).toBe("/xrpc/social.scenius.setSignupProfile");
+    const init = fetchImpl.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({ handle: "alice" });
+  });
+
+  it("mints with an empty body and returns the handle + did", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(json({ handle: "alice.scenius.social", did: "did:plc:alice" }));
+
+    const result = await createCustodialAccount(fetchImpl);
+
+    expect(result).toEqual({ ok: true, handle: "alice.scenius.social", did: "did:plc:alice" });
+    expect(JSON.parse((fetchImpl.mock.calls[0][1] as RequestInit).body as string)).toEqual({});
+  });
+
+  it("maps the 409 HandleTaken mint backstop to reason:handle_taken, keeping the server's suggestion", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      json({ error: "HandleTaken", message: "handle unavailable: try alice2.scenius.social" }, 409),
+    );
+
+    const result = await createCustodialAccount(fetchImpl);
+
+    expect(result).toMatchObject({ ok: false, reason: "handle_taken" });
+    expect((result as { message: string }).message).toContain("pick another");
+    // The `<label>2` offer rides the server message — losing it would lose the offer.
+    expect((result as { message: string }).message).toContain("alice2.scenius.social");
+  });
+
+  it("surfaces any other AppView refusal as-is (reserved / already claimed)", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(json({ error: "InvalidRequest", message: "that handle is reserved — try a different one." }, 400));
+
+    await expect(setSignupProfile("admin", fetchImpl)).resolves.toEqual({
+      ok: false,
+      reason: "rejected",
+      message: "that handle is reserved — try a different one.",
+    });
+  });
+
+  it("runs the whole happy path in order: profile → mint → RegenHub handoff", async () => {
+    const calls: string[] = [];
+    const fetchImpl = vi.fn(async (url: string) => {
+      calls.push(url);
+      if (url.includes("setSignupProfile")) return json({ stage: "ready", handle: "alice.scenius.social" });
+      if (url.includes("createCustodialAccount")) return json({ handle: "alice.scenius.social", did: "did:plc:alice" });
+      return json({ ok: true, member: true });
+    }) as unknown as typeof fetch;
+
+    const profile = await setSignupProfile("alice", fetchImpl);
+    const account = await createCustodialAccount(fetchImpl);
+    const finished = await finishSession(fetchImpl);
+
+    expect(profile.ok && account.ok && finished.ok).toBe(true);
+    expect(calls).toEqual([
+      "/xrpc/social.scenius.setSignupProfile",
+      "/xrpc/social.scenius.createCustodialAccount",
+      "/api/auth/regenos/session",
+    ]);
+  });
+});
+
+describe("finishSession", () => {
+  it("sends a matched member to /portal", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(json({ ok: true, member: true }));
+
+    await expect(finishSession(fetchImpl)).resolves.toEqual({ ok: true, redirect: "/portal" });
+  });
+
+  it("sends a non-member participant where the handoff says, defaulting to /membership", async () => {
+    const withRedirect = vi.fn().mockResolvedValue(json({ ok: true, member: false, redirect: "/membership?new=1" }));
+    const without = vi.fn().mockResolvedValue(json({ ok: true, member: false }));
+
+    await expect(finishSession(withRedirect)).resolves.toEqual({ ok: true, redirect: "/membership?new=1" });
+    await expect(finishSession(without)).resolves.toEqual({ ok: true, redirect: "/membership" });
+  });
+
+  it("surfaces the handoff's own error, and never redirects on ok:false", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(json({ ok: false, error: "No verified email on that account." }, 400));
+
+    await expect(finishSession(fetchImpl)).resolves.toEqual({
+      ok: false,
+      reason: "rejected",
+      message: "No verified email on that account.",
+    });
+  });
+});
+
+describe("probeHandle", () => {
+  it("reads a 200 available:true as free", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(json({ handle: "alice.scenius.social", available: true }));
+
+    await expect(probeHandle("alice", fetchImpl)).resolves.toEqual({
+      status: "free",
+      handle: "alice.scenius.social",
+    });
+    expect(fetchImpl.mock.calls[0][0]).toBe("/xrpc/social.scenius.checkHandle?handle=alice");
+  });
+
+  it("reads a 200 available:false as taken and keeps the suggestion (NOT an error status)", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      json({ handle: "alice.scenius.social", available: false, suggestion: "alice2.scenius.social" }),
+    );
+
+    await expect(probeHandle("alice", fetchImpl)).resolves.toEqual({
+      status: "taken",
+      handle: "alice.scenius.social",
+      suggestion: "alice2.scenius.social",
+    });
+  });
+
+  it("stays NEUTRAL (unknown) on a blip — a failed probe must never read as available or taken", async () => {
+    const thrown = vi.fn().mockRejectedValue(new Error("offline"));
+    const serverError = vi.fn().mockResolvedValue(json({ error: "InternalServerError" }, 500));
+    const garbled = vi.fn().mockResolvedValue(json({ nonsense: true }));
+
+    await expect(probeHandle("alice", thrown)).resolves.toEqual({ status: "unknown" });
+    await expect(probeHandle("alice", serverError)).resolves.toEqual({ status: "unknown" });
+    await expect(probeHandle("alice", garbled)).resolves.toEqual({ status: "unknown" });
+  });
+
+  it("falls silent (idle) on a 400 — local validation already speaks to a syntax problem", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(json({ error: "InvalidRequest", message: "reserved" }, 400));
+
+    await expect(probeHandle("admin", fetchImpl)).resolves.toEqual({ status: "idle" });
+  });
+});
+
+describe("validateHandle", () => {
+  it("accepts a plain label and returns it trimmed", () => {
+    expect(validateHandle("  alice-99  ")).toEqual({ ok: true, label: "alice-99" });
+  });
+
+  it("rejects an empty (or whitespace-only) field", () => {
+    expect(validateHandle("")).toMatchObject({ ok: false, problem: "empty" });
+    expect(validateHandle("   ")).toMatchObject({ ok: false, problem: "empty" });
+  });
+
+  it("holds the length boundary exactly at MAX_HANDLE", () => {
+    expect(MAX_HANDLE).toBe(18);
+    expect(validateHandle("a".repeat(18))).toMatchObject({ ok: true });
+    expect(validateHandle("a".repeat(19))).toMatchObject({ ok: false, problem: "tooLong" });
+  });
+
+  it("rejects characters outside [a-z0-9-], including uppercase and a typed-in domain", () => {
+    // Each sample is within the length cap, so `badChars` is the reason under test, not `tooLong`.
+    for (const bad of ["Alice", "alice.social", "alice_b", "alice b", "ali@ce", "élise"]) {
+      expect(validateHandle(bad)).toMatchObject({ ok: false, problem: "badChars" });
+    }
+  });
+});

--- a/apps/web/src/lib/regenos/signupWizard.ts
+++ b/apps/web/src/lib/regenos/signupWizard.ts
@@ -1,0 +1,317 @@
+/**
+ * The regenOS signup wizard's wire contract — the four calls the emailed
+ * magic link lands on, plus the handle rules, as pure functions.
+ *
+ * ── Why this module exists at all ─────────────────────────────────────────
+ * `RegenosLoginPanel`'s email door POSTs `beginSignup`. In PROD (email mode)
+ * an email regenOS has never seen comes back `stage: "checkEmail"` and the
+ * AppView MAILS a link at `<app_base_url>/login?token=…` — i.e. at THIS app,
+ * once regenhub.xyz is the configured base. Clicking it used to 404: this app
+ * served no `/login`. Since most RegenHub members have no regenOS account yet,
+ * that dead end was the majority path, not an edge.
+ *
+ * `/login` is therefore the SECOND half of the same wizard: the link's `token`
+ * resumes the pending signup and the person picks a handle. The sequence
+ * mirrors regenOS's own `apps/scenius-web/src/lib/{signup.ts,use-signup-wizard.ts}`
+ * byte-for-byte — deviating would mean this app and scenius disagree about the
+ * same AppView:
+ *
+ *     verifySignup ─▶ setSignupProfile ─▶ createCustodialAccount ─▶ finishSession
+ *
+ * The whole pre-mint half runs PENDING-COOKIE-authed — there is no session yet.
+ * `beginSignup` set the sealed `__Host-rs_pending` cookie on THIS origin (via
+ * the `/xrpc` proxy — `app/xrpc/[...nsid]/route.ts` explains why a same-origin
+ * proxy is the only way a `__Host-` cookie can land here), every step below
+ * reads it, and the real `__Host-rs_session` cookie is minted ONLY by
+ * `createCustodialAccount`. That cookie-binding is also why a link opened on a
+ * DIFFERENT device than the one that started the signup cannot resume: there's
+ * no pending cookie there to bind the token to. The failure copy says so.
+ *
+ * Split out of the component (same reason as `lib/regenos/oauth.ts`) because
+ * this repo's vitest runs in a `node` environment with no jsdom or
+ * @testing-library — testable logic has to live outside the JSX. Every call
+ * takes an injectable `fetchImpl` for exactly that.
+ *
+ * Same-origin `fetch` sends cookies by default and `RegenosLoginPanel` relies
+ * on that, so these do too — no `credentials` option, deliberately.
+ */
+
+/** Handle length cap — matches the AppView's too-long boundary (scenius `MAX_HANDLE`). */
+export const MAX_HANDLE = 18;
+
+/** Allowed handle characters: lowercase letters, digits, hyphens — the shape the AppView accepts. */
+export const HANDLE_OK = /^[a-z0-9-]+$/;
+
+const NSID_VERIFY_SIGNUP = "social.scenius.verifySignup";
+const NSID_SET_SIGNUP_PROFILE = "social.scenius.setSignupProfile";
+const NSID_CREATE_CUSTODIAL_ACCOUNT = "social.scenius.createCustodialAccount";
+const NSID_CHECK_HANDLE = "social.scenius.checkHandle";
+
+/** The regenHub handoff both regenOS doors finish through (`RegenosLoginPanel.finish()`). */
+const SESSION_HANDOFF_PATH = "/api/auth/regenos/session";
+
+/** The atproto-shaped XRPC error body the AppView returns on a non-2xx (cf. `lib/regenos/oauth.ts`). */
+interface XrpcErrorBody {
+  error?: string;
+  message?: string;
+}
+
+/**
+ * Why a wizard step didn't advance:
+ *   - `invalid_link`  — the token was bad/expired, or there's no pending cookie on THIS browser.
+ *   - `handle_taken`  — the 409 `HandleTaken` backstop: the label was raced between the probe and the mint.
+ *   - `rejected`      — any other AppView refusal (reserved/invalid label, expired pending session).
+ *   - `unreachable`   — the call never landed (network, timeout, proxy 502).
+ */
+export type WizardErrorReason = "invalid_link" | "handle_taken" | "rejected" | "unreachable";
+
+export interface WizardFailure {
+  ok: false;
+  reason: WizardErrorReason;
+  message: string;
+}
+
+/** Warm copy for a call that never landed — same posture as every other regenOS call in this app. */
+const UNREACHABLE = "Couldn't reach regenOS right now. Try again in a moment.";
+
+/**
+ * The link failed. Deliberately NOT the AppView's own wording ("no pending signup in progress"),
+ * which is true but unreadable to a member: the two real causes are an expired/reused token and a
+ * link opened somewhere the pending cookie isn't, so we name both.
+ */
+export const LINK_FAILED_MESSAGE =
+  "That sign-in link didn't work — it may have expired, or you may have opened it on a different device than the one you started on.";
+
+function unreachable(): WizardFailure {
+  return { ok: false, reason: "unreachable", message: UNREACHABLE };
+}
+
+/** Parse an XRPC error body, tolerating a non-JSON body (a proxy 502 is HTML-ish, not a lexicon error). */
+async function errorBody(res: Response): Promise<XrpcErrorBody | null> {
+  return (await res.json().catch(() => null)) as XrpcErrorBody | null;
+}
+
+/**
+ * Map a failed handle write to a reason + message. The 409 `HandleTaken` leg is the exact-or-fail
+ * mint backstop (onboarding.rs `map_mint_error`): the AppView NEVER silently renames you to
+ * `<label>2`, it refuses and puts the suggestion in its message — so we lead with a warm "pick
+ * another" and append the server's line so the offer survives.
+ */
+function handleFailure(body: XrpcErrorBody | null, status: number): WizardFailure {
+  if (status === 409 && body?.error === "HandleTaken") {
+    return {
+      ok: false,
+      reason: "handle_taken",
+      message: `That name was just taken — pick another. ${body.message ?? ""}`.trim(),
+    };
+  }
+  // Everything else the AppView says here is already plain enough to show as-is
+  // (reserved / invalid / "you've already chosen your handle").
+  return {
+    ok: false,
+    reason: "rejected",
+    message: body?.message || "That name didn't work — try another.",
+  };
+}
+
+// ── Step 1: redeem the emailed token ─────────────────────────────────────────────────────────────
+
+/**
+ * `GET verifySignup` — consume the single-use token AND bind it to this browser's
+ * `__Host-rs_pending` cookie (onboarding.rs `verify_signup`). Success is `{ stage: "chooseHandle" }`.
+ *
+ * A 400 covers both real causes (bad/expired token, missing pending cookie) and gets the one warm
+ * message above; the AppView's own copy isn't surfaced because it can't tell a member which of the
+ * two happened either.
+ */
+export async function verifySignup(
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ ok: true } | WizardFailure> {
+  let res: Response;
+  try {
+    res = await fetchImpl(`/xrpc/${NSID_VERIFY_SIGNUP}?token=${encodeURIComponent(token)}`, {
+      headers: { accept: "application/json" },
+      cache: "no-store",
+    });
+  } catch {
+    return unreachable();
+  }
+  if (!res.ok) {
+    return { ok: false, reason: "invalid_link", message: LINK_FAILED_MESSAGE };
+  }
+  return { ok: true };
+}
+
+// ── Step 2: capture the chosen label ─────────────────────────────────────────────────────────────
+
+/**
+ * `POST setSignupProfile` — store the validated base label on the pending row; the AppView echoes
+ * the full `<label>.<domain>` it will mint. Bio is deliberately omitted: RegenHub's portal has its
+ * own profile, and one field is one field too many on a sign-in path.
+ */
+export async function setSignupProfile(
+  label: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ ok: true; handle: string } | WizardFailure> {
+  let res: Response;
+  try {
+    res = await fetchImpl(`/xrpc/${NSID_SET_SIGNUP_PROFILE}`, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify({ handle: label.trim() }),
+    });
+  } catch {
+    return unreachable();
+  }
+  if (!res.ok) return handleFailure(await errorBody(res), res.status);
+  const json = (await res.json().catch(() => null)) as { handle?: string } | null;
+  return { ok: true, handle: json?.handle ?? label.trim() };
+}
+
+// ── Step 3: the mint (this is what lands the real session cookie) ────────────────────────────────
+
+/**
+ * `POST createCustodialAccount` — the single relocated PLC op. On success the AppView sets the real
+ * `__Host-rs_session` cookie, which our `/xrpc` proxy relays onto regenhub.xyz; only after that does
+ * the RegenHub handoff below have a session to read.
+ */
+export async function createCustodialAccount(
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ ok: true; handle: string; did: string } | WizardFailure> {
+  let res: Response;
+  try {
+    res = await fetchImpl(`/xrpc/${NSID_CREATE_CUSTODIAL_ACCOUNT}`, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify({}),
+    });
+  } catch {
+    return unreachable();
+  }
+  if (!res.ok) return handleFailure(await errorBody(res), res.status);
+  const json = (await res.json().catch(() => null)) as { handle?: string; did?: string } | null;
+  return { ok: true, handle: json?.handle ?? "", did: json?.did ?? "" };
+}
+
+// ── Step 4: the shared RegenHub handoff ──────────────────────────────────────────────────────────
+
+interface SessionResponse {
+  ok?: boolean;
+  member?: boolean;
+  redirect?: string;
+  error?: string;
+}
+
+/**
+ * `POST /api/auth/regenos/session` — the SAME handoff both existing regenOS doors run
+ * (`RegenosLoginPanel.finish()`, `OAuthCallback`): match the verified email to a membership, link
+ * the DID, mint the Supabase session. No member match is not an error — that's a participant, and
+ * the route says where to send them.
+ */
+export async function finishSession(
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ ok: true; redirect: string } | WizardFailure> {
+  let res: Response;
+  let data: SessionResponse;
+  try {
+    res = await fetchImpl(SESSION_HANDOFF_PATH, { method: "POST" });
+    data = ((await res.json().catch(() => null)) ?? {}) as SessionResponse;
+  } catch {
+    return { ok: false, reason: "unreachable", message: "Couldn't reach RegenHub. Try again in a moment." };
+  }
+  if (!res.ok || !data.ok) {
+    return {
+      ok: false,
+      reason: "rejected",
+      message: data.error ?? "Couldn't finish signing you in.",
+    };
+  }
+  return { ok: true, redirect: data.member ? "/portal" : (data.redirect ?? "/membership") };
+}
+
+// ── The live availability probe (nice-to-have, never load-bearing) ───────────────────────────────
+
+/**
+ * The probe's answer. `unknown` is NEUTRAL — "we couldn't check", never "available" and never
+ * "taken". Only a KNOWN `taken` (or an in-flight `checking`, tracked by the caller) may gate submit;
+ * the AppView stays the final word via the 409 backstop above.
+ */
+export type HandleProbeStatus = "idle" | "free" | "taken" | "unknown";
+
+export interface HandleProbe {
+  status: HandleProbeStatus;
+  /** The AppView's `<label>2.<domain>` offer, present only when `status === "taken"`. */
+  suggestion?: string;
+  /** The full `<label>.<domain>` the label resolves to, echoed back on a 200. */
+  handle?: string;
+}
+
+/**
+ * `GET checkHandle` — a PUBLIC, pre-auth availability read (change_handle.rs `check_handle`). A
+ * label someone else holds is a **200 `available:false`** with a suggestion, not an error; a 400 is
+ * a true syntax/reserved problem, which our own `validateHandle` already speaks to, so it lands
+ * `idle` rather than echoing the server twice. Anything else is a blip ⇒ `unknown`.
+ */
+export async function probeHandle(
+  label: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<HandleProbe> {
+  let res: Response;
+  try {
+    res = await fetchImpl(`/xrpc/${NSID_CHECK_HANDLE}?handle=${encodeURIComponent(label.trim())}`, {
+      headers: { accept: "application/json" },
+      cache: "no-store",
+    });
+  } catch {
+    return { status: "unknown" };
+  }
+  if (res.status === 400) return { status: "idle" };
+  if (!res.ok) return { status: "unknown" };
+  const json = (await res.json().catch(() => null)) as
+    | { handle?: string; available?: boolean; suggestion?: string }
+    | null;
+  if (!json || typeof json.available !== "boolean") return { status: "unknown" };
+  return json.available
+    ? { status: "free", handle: json.handle }
+    : { status: "taken", suggestion: json.suggestion, handle: json.handle };
+}
+
+// ── Local handle validation (the same rules, before we spend a round-trip) ───────────────────────
+
+export type HandleProblem = "empty" | "tooLong" | "badChars";
+
+export type HandleValidation =
+  | { ok: true; label: string }
+  | { ok: false; problem: HandleProblem; message: string };
+
+/**
+ * Validate a typed label locally. Purely a fast-feedback + probe gate — the AppView revalidates
+ * everything (and owns reserved words, which we deliberately don't mirror: a duplicated reserved
+ * list would drift).
+ *
+ * NEVER call this on a label derived from the email local-part: the handle field starts blank and
+ * is never seeded from the email. That's regenOS's own §6.3 rule — the address is the person's free
+ * choice, and pre-filling it is exactly the leak the pre-auth flow exists to prevent.
+ */
+export function validateHandle(raw: string): HandleValidation {
+  const label = raw.trim();
+  if (label.length === 0) {
+    return { ok: false, problem: "empty", message: "Pick a name to finish." };
+  }
+  if (label.length > MAX_HANDLE) {
+    return {
+      ok: false,
+      problem: "tooLong",
+      message: `Keep it to ${MAX_HANDLE} characters or fewer.`,
+    };
+  }
+  if (!HANDLE_OK.test(label)) {
+    return {
+      ok: false,
+      problem: "badChars",
+      message: "Lowercase letters, numbers, and hyphens only.",
+    };
+  }
+  return { ok: true, label };
+}


### PR DESCRIPTION
## The gap

With `REGENOS_LOGIN_ENABLED` on, any email regenOS doesn't already know (i.e. **most RegenHub members**) goes: login panel → `beginSignup` → prod regenOS (email mode) mails a link at **`https://regenhub.xyz/login?token=…`** — and this app served no `/login`, so every new member's link 404'd.

We proved the link shape live today: a real `beginSignup` round trip with the regenhub Origin produced an email titled "Your regenhub.xyz sign-in link" pointing exactly there (Lucian's `ALLOWED_APP_ORIGINS` entry on the appview is confirmed working — the origin part is right, the path just didn't exist on our side).

Root cause on our side: `RegenosLoginPanel` was written against the appview's **beta-mode** response (`chooseHandle` → "no account, use the classic lane"), but prod runs **email mode**, which returns `checkEmail` and mails the wizard link regardless.

## The fix

`/login?token=…` is now the second half of that same wizard, mirroring regenOS's own scenius-web flow byte-for-byte:

- **`app/login/page.tsx`** — flag off or no token → redirect to `/auth/login` (it's a URL people type; a redirect beats a 404). `force-dynamic`, noindex.
- **`components/auth/MagicLinkWizard.tsx`** — `verifySignup` on mount (ref-guarded for React double-mount), then the handle step: lowercase-filtered input (18 chars, `[a-z0-9-]`, never pre-filled from the email — upstream's own rule), a 400 ms-debounced `checkHandle` availability note (stale-answer-proof via request ids; a probe failure is neutral and never blocks), then `setSignupProfile` → `createCustodialAccount` (lands the real `__Host-rs_session` via our proxy) → the **same** `POST /api/auth/regenos/session` handoff both existing doors finish through. The 409 `HandleTaken` race keeps you on the handle step with the server's `<label>2` suggestion.
- **`lib/regenos/signupWizard.ts`** — the wire contract + validation as a pure, fetch-injectable module (vitest here is node-env, no jsdom), verified against the appview source (`onboarding.rs`, `change_handle.rs`).
- **`/xrpc` proxy** — `social.scenius.checkHandle` added to the allowlist (read-only, pre-auth, public probe). Nothing else widened.
- `RegenosLoginPanel` — comment-only clarification of the beta-vs-email-mode split. No behavior change.
- CLAUDE.md — the `/login` surface documented under one-login.

A link opened on a **different device** than the one that started the signup can't resume (the token binds to the `__Host-rs_pending` cookie) — the failure copy says so plainly, with a "Start again" back to `/auth/login`.

## Verification

- `pnpm --filter web lint` — 0 errors (1 pre-existing warning, untouched)
- `pnpm --filter web test` — **111/111** (20 new tests: call ordering, failure mapping, HandleTaken, neutral probe failures, handle boundaries)
- `pnpm --filter web build` — compiles, `ƒ /login` in the route table

Not exercised against a live appview end-to-end (the flag is off in prod) — the wire contract is proven by unit tests + the appview/scenius-web source. After merge + redeploy, flipping `REGENOS_LOGIN_ENABLED` makes the full path testable for real; a narrated demo of the UI flow (mocked backend) follows in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
