### PR TITLE
fix(auth): sign-out also ends the regenOS session

### DIFF
--- a/apps/web/src/app/auth/signout/route.test.ts
+++ b/apps/web/src/app/auth/signout/route.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeSupabaseMock } from "../../../../test/mockSupabase";
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("@/lib/regenos/config", () => ({
+  isRegenosLoginEnabled: vi.fn(() => false),
+}));
+
+vi.mock("@/lib/regenos/auth", () => ({
+  REGENOS_SESSION_COOKIE: "__Host-rs_session",
+  REGENOS_PENDING_COOKIE: "__Host-rs_pending",
+  revokeRegenosSession: vi.fn(async () => undefined),
+}));
+
+// next/navigation's real redirect() throws to halt the handler — mirror that
+// here (message carries the URL) rather than letting a bare "not implemented"
+// stub mask a code path that never reaches the redirect at all.
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
+}));
+
+/** Every `.delete(...)` call any test's cookie store received, across the whole run. */
+const cookieDeletes: { name: string; path?: string; secure?: boolean }[] = [];
+const cookiesFn = vi.fn(async () => ({
+  delete: vi.fn((opts: { name: string; path?: string; secure?: boolean }) => {
+    cookieDeletes.push(opts);
+  }),
+}));
+vi.mock("next/headers", () => ({
+  cookies: () => cookiesFn(),
+}));
+
+import { POST } from "./route";
+import { createClient } from "@/lib/supabase/server";
+import { isRegenosLoginEnabled } from "@/lib/regenos/config";
+import { revokeRegenosSession } from "@/lib/regenos/auth";
+
+/** A signed-in Supabase client whose `auth.signOut()` we can assert on. */
+function makeServerMock() {
+  const base = makeSupabaseMock();
+  const signOut = vi.fn(async () => ({ error: null }));
+  return { ...base, auth: { ...base.auth, signOut }, __signOut: signOut };
+}
+
+function req(cookie?: string) {
+  return new Request("http://localhost:3000/auth/signout", {
+    method: "POST",
+    headers: cookie ? { cookie } : {},
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cookieDeletes.length = 0;
+  vi.mocked(isRegenosLoginEnabled).mockReturnValue(false);
+});
+
+describe("POST /auth/signout", () => {
+  it("signs out of Supabase and redirects to /auth/login when no regenOS cookie is present", async () => {
+    vi.mocked(isRegenosLoginEnabled).mockReturnValue(true);
+    const server = makeServerMock();
+    vi.mocked(createClient).mockResolvedValue(server as never);
+
+    await expect(POST(req())).rejects.toThrow("REDIRECT:/auth/login");
+
+    expect(server.__signOut).toHaveBeenCalled();
+    expect(revokeRegenosSession).not.toHaveBeenCalled();
+  });
+
+  it("revokes the regenOS session and expires both __Host- cookies when the cookie is present and the flag is on", async () => {
+    vi.mocked(isRegenosLoginEnabled).mockReturnValue(true);
+    const server = makeServerMock();
+    vi.mocked(createClient).mockResolvedValue(server as never);
+    const cookieHeader = "__Host-rs_session=opaque; other=1";
+
+    await expect(POST(req(cookieHeader))).rejects.toThrow("REDIRECT:/auth/login");
+
+    expect(server.__signOut).toHaveBeenCalled();
+    expect(revokeRegenosSession).toHaveBeenCalledWith(cookieHeader);
+
+    expect(cookieDeletes).toEqual(
+      expect.arrayContaining([
+        { name: "__Host-rs_session", path: "/", secure: true },
+        { name: "__Host-rs_pending", path: "/", secure: true },
+      ]),
+    );
+    // Every deletion must itself satisfy the `__Host-` prefix contract, or the
+    // browser refuses to apply it and the stale cookie survives sign-out.
+    for (const del of cookieDeletes) {
+      expect(del.path).toBe("/");
+      expect(del.secure).toBe(true);
+    }
+  });
+
+  it("still completes sign-out and expires cookies when the AppView revoke call fails", async () => {
+    vi.mocked(isRegenosLoginEnabled).mockReturnValue(true);
+    vi.mocked(revokeRegenosSession).mockRejectedValueOnce(new Error("network error"));
+    const server = makeServerMock();
+    vi.mocked(createClient).mockResolvedValue(server as never);
+    const cookieHeader = "__Host-rs_session=opaque";
+
+    await expect(POST(req(cookieHeader))).rejects.toThrow("REDIRECT:/auth/login");
+
+    expect(server.__signOut).toHaveBeenCalled();
+    expect(revokeRegenosSession).toHaveBeenCalledWith(cookieHeader);
+    expect(cookieDeletes.map((d) => d.name)).toEqual(
+      expect.arrayContaining(["__Host-rs_session", "__Host-rs_pending"]),
+    );
+  });
+
+  it("expires the local cookies even when the flag is off, so a stale cookie doesn't survive a flag flip", async () => {
+    vi.mocked(isRegenosLoginEnabled).mockReturnValue(false);
+    const server = makeServerMock();
+    vi.mocked(createClient).mockResolvedValue(server as never);
+    const cookieHeader = "__Host-rs_session=opaque";
+
+    await expect(POST(req(cookieHeader))).rejects.toThrow("REDIRECT:/auth/login");
+
+    expect(server.__signOut).toHaveBeenCalled();
+    expect(revokeRegenosSession).not.toHaveBeenCalled();
+    expect(cookieDeletes.map((d) => d.name)).toEqual(
+      expect.arrayContaining(["__Host-rs_session", "__Host-rs_pending"]),
+    );
+  });
+});

--- a/apps/web/src/app/auth/signout/route.ts
+++ b/apps/web/src/app/auth/signout/route.ts
@@ -1,8 +1,46 @@
 import { redirect } from "next/navigation";
+import { cookies } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
+import { isRegenosLoginEnabled } from "@/lib/regenos/config";
+import { REGENOS_PENDING_COOKIE, REGENOS_SESSION_COOKIE, revokeRegenosSession } from "@/lib/regenos/auth";
 
-export async function POST() {
+/**
+ * Sign-out ends BOTH sessions this origin can hold.
+ *
+ * regenOS one-login (Phase 2) can leave its own `__Host-rs_session` cookie
+ * alive here (set by the /xrpc proxy — app/xrpc/[...nsid]/route.ts). If we
+ * only cleared the Supabase side, RegenosLoginPanel's `getSession` probe on
+ * /auth/login would still find a live regenOS session on mount and silently
+ * re-run the handoff (POST /api/auth/regenos/session) — the user is signed
+ * back in before they can switch accounts.
+ *
+ * The local `__Host-` cookies are expired unconditionally, even when the
+ * flag is off or the AppView revoke call fails: a stale cookie must not
+ * survive sign-out just because REGENOS_LOGIN_ENABLED flipped, and a slow or
+ * down AppView must never block sign-out.
+ */
+export async function POST(request: Request) {
   const supabase = await createClient();
   await supabase.auth.signOut();
+
+  const cookieHeader = request.headers.get("cookie") ?? "";
+  if (isRegenosLoginEnabled() && cookieHeader.includes(REGENOS_SESSION_COOKIE)) {
+    // Belt-and-suspenders on top of revokeRegenosSession's own swallowing: no
+    // matter how it fails, this route still finishes signing the caller out.
+    try {
+      await revokeRegenosSession(cookieHeader);
+    } catch (err) {
+      console.warn("[regenOS] revoke on sign-out failed:", err);
+    }
+  }
+
+  // A replacement Set-Cookie for a `__Host-` cookie must itself satisfy the
+  // `__Host-` requirements (Secure, Path=/, no Domain) or the browser rejects
+  // it outright, so the bare defaults `.delete(name)` would use aren't enough.
+  const cookieStore = await cookies();
+  for (const name of [REGENOS_SESSION_COOKIE, REGENOS_PENDING_COOKIE]) {
+    cookieStore.delete({ name, path: "/", secure: true });
+  }
+
   redirect("/auth/login");
 }

--- a/apps/web/src/lib/regenos/auth.ts
+++ b/apps/web/src/lib/regenos/auth.ts
@@ -31,6 +31,9 @@ import { REGENOS_TIMEOUT_MS, regenosBaseUrl } from "./config";
 /** The regenOS session cookie the AppView sets. `__Host-` ⇒ host-scoped, no Domain. */
 export const REGENOS_SESSION_COOKIE = "__Host-rs_session";
 
+/** The signup wizard's in-progress cookie (`beginSignup` → `verifySignup`), same `__Host-` scoping. */
+export const REGENOS_PENDING_COOKIE = "__Host-rs_pending";
+
 export interface RegenosIdentity {
   did: string;
   handle: string | null;
@@ -97,6 +100,36 @@ export async function fetchRegenosIdentity(cookieHeader: string): Promise<Regeno
     handle: session.handle ?? null,
     email: verifiedEmail?.address?.trim().toLowerCase() ?? null,
   };
+}
+
+/**
+ * Best-effort server-side logout — tells the AppView to revoke the session
+ * behind a `__Host-rs_session` cookie, so RegenHub sign-out (app/auth/signout/route.ts)
+ * ends the regenOS side too, not just the local cookie. Without this, the
+ * AppView still considers the session live even after we've stopped sending
+ * the cookie back — a low-severity gap (whoever holds the browser is gone
+ * either way), but "sign out" should mean it everywhere.
+ *
+ * Same posture as `xrpcGet`: a timeout, a non-2xx, or a network error is
+ * swallowed and warned, never thrown. Sign-out must never fail because
+ * regenOS is slow or down.
+ */
+export async function revokeRegenosSession(cookieHeader: string): Promise<void> {
+  const base = regenosBaseUrl();
+  if (!base) return;
+  try {
+    const res = await fetch(`${base}/xrpc/social.scenius.logout`, {
+      method: "POST",
+      headers: { cookie: cookieHeader },
+      signal: AbortSignal.timeout(REGENOS_TIMEOUT_MS),
+      cache: "no-store",
+    });
+    if (!res.ok) {
+      console.warn(`[regenOS] logout returned ${res.status}`);
+    }
+  } catch (err) {
+    console.warn("[regenOS] logout failed:", err);
+  }
 }
 
 /** The scene roles that may write events, mirroring the AppView's `owner_or_builder` gate. */


### PR DESCRIPTION
## Bug

Sign-out doesn't stick when regenOS one-login is on. Reported by Aaron on prod today: once authed via regenOS you can't sign out and sign in as another account.

**Cause:** `/auth/signout` only clears the Supabase session. The regenOS `__Host-rs_session` cookie (landed on this origin by the `/xrpc` proxy) survives, and `RegenosLoginPanel` probes `getSession` on `/auth/login` mount — it finds the live regenOS session and silently re-runs the handoff (`POST /api/auth/regenos/session`), signing the user straight back in.

## Fix

Sign-out now ends both sessions:

1. **Server-side revoke** — new `revokeRegenosSession(cookieHeader)` in `lib/regenos/auth.ts` POSTs `social.scenius.logout` to the AppView with the forwarded cookie, so the regenOS session dies server-side too. Same posture as the existing `xrpcGet`: timeout (`REGENOS_TIMEOUT_MS`), swallow-and-warn on any failure — a slow or down AppView never blocks sign-out.
2. **Local cookie expiry** — `__Host-rs_session` and `__Host-rs_pending` are expired **unconditionally** (even flag-off, even if the revoke fails): a stale cookie must not survive sign-out just because `REGENOS_LOGIN_ENABLED` flipped. Deletion satisfies the `__Host-` prefix contract (Secure, Path=/, no Domain) — the bare `.delete(name)` defaults wouldn't.

No changes to the proxy, the login panel, or the handoff route.

## Tests

4 new tests in `app/auth/signout/route.test.ts` (existing suite's mocking style): no-cookie path untouched; cookie + flag on → revoke called with forwarded header + both cookies expired with `__Host-`-valid attributes; AppView failure → sign-out still completes; flag off + cookie present → no AppView call but cookies still expired.

## Gates

- lint: clean (one pre-existing unrelated warning)
- tests: 115/115 (111 before, 4 new)
- build: green

## After merge

Redeploy web (no env changes needed). I'll verify live in-thread: sign out with a real regenOS session and confirm `/auth/login` no longer auto-reauths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
