### PR TITLE
feat(mcp): database migrations over MCP — ledger, list_migrations, run_migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ The `.dockerignore` has an exception (`!**/.env.production`) so the file is avai
 | `HA_LOCK_ENTITIES` | Web + Bot (runtime) | Comma-separated Z-Wave entity IDs, e.g. `lock.front_door_lock,lock.back_door_lock` |
 | `SUPABASE_URL` | Bot (runtime) | |
 | `SUPABASE_SERVICE_ROLE_KEY` | Bot (runtime) | Bypasses RLS |
+| `SUPABASE_DB_URL` | Web (runtime) | Full `postgres://` connection string (supabase_admin role, host-exposed Postgres port on compute-1). **Only** used by the MCP's `list_migrations`/`run_migration`. Unset = those two tools report "not configured" and everything else is unaffected. |
+| `MIGRATIONS_DIR` | Web (runtime) | Optional override for where `supabase/migrations/` lives. The Dockerfile copies it into the image and `lib/migrations.ts` finds it from either possible cwd — you shouldn't need this. |
 | `TELEGRAM_BOT_TOKEN` | Bot (runtime) | |
 | `REGENOS_BASE_URL` | Web (runtime) | regenOS AppView base URL, no trailing slash. Unset = events fall back to the Luma embed and one-login stays off. |
 | `REGENOS_COLLECTIVE_DID` | Web (runtime) | The RegenHub collective's `did:plc:…`. Required alongside the base URL for the events swap. |
@@ -112,7 +114,13 @@ curl "http://192.168.1.200:8000/api/v1/deployments/<dep-uuid>" \
 ```
 
 ### Run a DB migration
-Connect via postgres Docker container on compute-1 (see DEPLOYMENT.md).
+**Primary path is the MCP** — no SSH, no psql. Merge the new `NNN_name.sql`, redeploy web
+(the file has to be *in the image*), then from an MCP client:
+`list_migrations()` to see what's pending → `run_migration("NNN_name.sql")` for the
+lowest-numbered pending one. Each apply is one transaction and writes a `schema_migrations`
+row (migration 043), so there's finally a record of what ran, when, and who ran it.
+Fallback (MCP down, or the migration itself broke): psql against the container on compute-1 —
+see DEPLOYMENT.md "Run migrations".
 
 ### Membership application flow (approve + notify)
 `/apply` (sign-in required) → `/api/portal/application` upserts the application, emails the
@@ -262,11 +270,25 @@ MCP changes, just redeploy the web app.
 - **Code:** OAuth core in `apps/web/src/lib/mcp/oauth.ts`, metadata in `metadata.ts`, tool surface +
   transport in `server.ts`; routes under `apps/web/src/app/{mcp,oauth,.well-known}`. Scopes
   (`read/deploy/locks/migrate`) are wired for the planned per-tier surface (members → day codes,
-  admins → events/members, ops → dangerous tools).
+  admins → events/members, ops → dangerous tools). MCP clients aren't required to *request* a
+  scope and ours don't, so `createAuthorizationCode` expands an empty request to the full set,
+  and `hasScope()` (metadata.ts) treats an empty scope list as a full grant — entry is already
+  `is_ops_admin`-only, so an unscoped token is an ops token, and tokens minted before scopes were
+  enforced keep working.
 - **Tools:** `ping`; `save_newsletter_draft(issue_key, subject, markdown_body)` (upserts a
   `newsletter_issues` draft via the server-side service client — the whole point: no secrets on the
-  caller's machine). To add a tool: register it in `server.ts` (zod input shape), redeploy web; the
-  client auto-reconnects and picks up the new tool (bump `SERVER_VERSION` to confirm the rollout).
+  caller's machine); `audit_approvals` / `send_checkout_email`; `list_migrations` and
+  `run_migration(filename)` (scope `migrate`, see below). To add a tool: register it in `server.ts`
+  (zod input shape), redeploy web; the client auto-reconnects and picks up the new tool (bump
+  `SERVER_VERSION` to confirm the rollout).
+- **Migrations over MCP** (`lib/migrations.ts` + `lib/mcp/migrationTools.ts`): `list_migrations` is
+  read-only (applied rows, pending files, checksum drift, whether `SUPABASE_DB_URL` is set);
+  `run_migration("NNN_name.sql")` applies exactly the named file in one transaction and writes the
+  `schema_migrations` ledger row. Deliberate constraints: the filename is explicit (no "run all"),
+  only the **lowest-numbered pending** file may run, applied migrations never re-run, and if the
+  ledger table doesn't exist yet the only permitted file is `043_schema_migrations.sql` — the
+  bootstrap. Drift (a file edited after it was applied) is reported loudly and never auto-fixed.
+  The SQL ships in the Docker image, so **deploy first, then run the migration.**
 
 ## Important Notes
 - **NEVER restart Supabase via Coolify.** Coolify regenerates ALL `SERVICE_PASSWORD_*` values on restart — but the DB volume retains the old passwords. This breaks every service. If it happens, see the password fix procedure in DEPLOYMENT.md.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -62,7 +62,43 @@ ssh steward@regenhub-compute-1.lan \
 ```
 
 ### Run migrations
-Migrations live in `supabase/migrations/`. To apply:
+
+Migrations live in `supabase/migrations/` as `NNN_name.sql`. **The primary path is now the
+MCP** (`https://regenhub.xyz/mcp`) — no SSH, no LAN, no psql. Migration `043_schema_migrations.sql`
+added a `schema_migrations` ledger, so what has and hasn't been applied is a fact you can read
+instead of a thing you remember. (Before it, there was no record at all — which is how 042 got
+merged, deployed, and never applied.)
+
+**Normal flow**
+
+1. Merge the migration and **redeploy the web app**. The SQL ships inside the image
+   (`apps/web/Dockerfile` copies `supabase/migrations/`), so a file that isn't deployed can't be run.
+2. `list_migrations()` — shows applied rows (filename / when / who), pending files, and any
+   checksum drift.
+3. `run_migration("044_whatever.sql")` — applies exactly that file, in one transaction, and writes
+   the ledger row with your email as `applied_by`.
+
+The rules it enforces, deliberately: the filename is explicit (there is no "run all"); only the
+**lowest-numbered pending** migration may run; an applied migration never re-runs; and a file
+edited after it was applied is reported as drift and never silently reconciled.
+
+**One-time setup (do this once, in this order)**
+
+1. In Coolify → web app → Environment Variables, set `SUPABASE_DB_URL` to a full connection
+   string for the host-exposed Postgres port on compute-1, using the `supabase_admin` role
+   (it needs DDL rights that `postgres` via PgBouncer may not have):
+   `postgres://supabase_admin:<password>@192.168.1.200:<exposed-port>/postgres`.
+   Get the password with the "Get credentials from running container" snippet below.
+2. Redeploy web. Until then `list_migrations` will honestly report *"migrations are not configured
+   on this deployment"* — it never crashes and never blocks the rest of the MCP.
+3. `run_migration("043_schema_migrations.sql")` — the bootstrap. Before the ledger table exists
+   this is the *only* file `run_migration` will accept. It creates `schema_migrations` and seeds
+   001–043 as already-applied (checksum `NULL` = baseline, applied before there was a ledger),
+   including itself.
+4. `list_migrations()` again to confirm: 43 applied, 0 pending.
+
+**Fallback (MCP is down, or a migration failed mid-way)**
+
 ```bash
 # From compute-2 (has LAN access)
 PGPASSWORD=<db-password> psql \
@@ -72,6 +108,12 @@ PGPASSWORD=<db-password> psql \
 ```
 
 Or via the Supabase Studio UI at `https://supabase-studio-w8gw0wc80o80c0c8g88kk8og.regenhub.build`.
+
+If you apply one by hand, **record it** so the ledger stays true:
+```sql
+insert into schema_migrations (filename, checksum, applied_by)
+values ('044_whatever.sql', null, 'manual');
+```
 
 ### Get credentials from running container
 ```bash
@@ -184,6 +226,7 @@ If a migration was pending when the outage hit, apply it directly with `psql` (S
 sudo docker exec supabase-db-w8gw0wc80o80c0c8g88kk8og \
   psql -U supabase_admin -d postgres -f - < supabase/migrations/0XX_whatever.sql
 ```
+Then record it in the ledger (see "Run migrations") so `list_migrations` doesn't report it as pending.
 
 ### Recovery: Kong consumer keys stale (`Invalid authentication credentials`)
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -46,6 +46,13 @@ COPY --from=builder /app/apps/web/.next/standalone ./
 COPY --from=builder /app/apps/web/.next/static     ./apps/web/.next/static
 COPY --from=builder /app/apps/web/public           ./apps/web/public
 
+# The SQL migrations ship with the app so the MCP's run_migration tool can apply
+# them (lib/migrations.ts). Lands at /app/apps/web/supabase/migrations — the
+# standalone server.js chdir()s into the double-nested /app/apps/web/apps/web,
+# so resolveMigrationsDir() tries both cwd/supabase/migrations and
+# cwd/../../supabase/migrations and finds it either way. MIGRATIONS_DIR overrides.
+COPY supabase/migrations ./supabase/migrations
+
 USER nextjs
 EXPOSE 3000
 ENV PORT=3000

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "embla-carousel-react": "^8.6.0",
     "lucide-react": "^0.575.0",
     "next": "16.1.6",
+    "pg": "^8.23.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "resend": "^6.12.4",
@@ -35,6 +36,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
+    "@types/pg": "^8.23.1",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/apps/web/src/lib/mcp/metadata.ts
+++ b/apps/web/src/lib/mcp/metadata.ts
@@ -3,6 +3,24 @@
 
 export const MCP_SCOPES = ["read", "deploy", "locks", "migrate"] as const;
 
+export type McpScope = (typeof MCP_SCOPES)[number];
+
+/**
+ * Does this token carry `scope`?
+ *
+ * An EMPTY scope list means "everything". MCP clients aren't required to send a
+ * `scope` parameter and the ones we use don't — `/oauth/authorize` passes
+ * through whatever arrived, so every token issued before scopes were enforced
+ * has `scopes: []`. Entry to the MCP is already gated on `is_ops_admin`
+ * (re-checked live), so an unscoped token is a full ops grant, not a
+ * privilege-free one. `createAuthorizationCode` now expands an empty request to
+ * the full set so new tokens say so explicitly; this keeps the old ones working.
+ */
+export function hasScope(scopes: string[] | undefined, scope: McpScope): boolean {
+  if (!scopes || scopes.length === 0) return true;
+  return scopes.includes(scope);
+}
+
 export function siteOrigin(): string {
   return (process.env.NEXT_PUBLIC_SITE_URL ?? "https://regenhub.xyz").replace(/\/$/, "");
 }

--- a/apps/web/src/lib/mcp/migrationTools.test.ts
+++ b/apps/web/src/lib/mcp/migrationTools.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/migrations", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/migrations")>();
+  return {
+    ...actual,
+    getMigrationStatus: vi.fn(),
+    applyMigration: vi.fn(),
+  };
+});
+
+import { listMigrationsHandler, runMigrationHandler } from "./migrationTools";
+import {
+  applyMigration,
+  getMigrationStatus,
+  LEDGER_MIGRATION,
+  type MigrationStatus,
+} from "@/lib/migrations";
+import type { McpAuthInfo } from "./oauth";
+
+const auth = (scopes: string[]): McpAuthInfo => ({
+  token: "t",
+  clientId: "c",
+  scopes,
+  extra: { memberId: 7, email: "ops@regenhub.xyz", isAdmin: true, isOpsAdmin: true },
+});
+
+const status = (over: Partial<MigrationStatus> = {}): MigrationStatus => ({
+  configured: true,
+  dir: "/app/apps/web/supabase/migrations",
+  files: [],
+  ignored: [],
+  ledgerExists: true,
+  applied: [],
+  pending: [],
+  drift: [],
+  orphans: [],
+  ...over,
+});
+
+const body = (r: { content: { text: string }[] }) => r.content.map((c) => c.text).join("\n");
+
+const OLD_ENV = { ...process.env };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.SUPABASE_DB_URL;
+});
+
+afterEach(() => {
+  process.env = { ...OLD_ENV };
+});
+
+describe("scope gating", () => {
+  it("denies both tools when the token has scopes but not `migrate`", async () => {
+    const a = auth(["read", "locks"]);
+
+    const list = await listMigrationsHandler(a);
+    expect(list.isError).toBe(true);
+    expect(body(list)).toMatch(/requires the "migrate" scope/);
+    expect(getMigrationStatus).not.toHaveBeenCalled();
+
+    const run = await runMigrationHandler(a, "044_x.sql");
+    expect(run.isError).toBe(true);
+    expect(body(run)).toMatch(/requires the "migrate" scope/);
+    expect(applyMigration).not.toHaveBeenCalled();
+  });
+
+  it("allows a token that carries `migrate`", async () => {
+    vi.mocked(getMigrationStatus).mockResolvedValue(status());
+    const list = await listMigrationsHandler(auth(["read", "migrate"]));
+    expect(list.isError).toBeUndefined();
+    expect(getMigrationStatus).toHaveBeenCalled();
+  });
+
+  it("allows a legacy token with NO scopes at all — an unscoped grant is a full one", async () => {
+    // Every token minted before scopes were enforced has scopes: []. Entry is
+    // already is_ops_admin-gated, so those must keep working.
+    vi.mocked(getMigrationStatus).mockResolvedValue(status());
+    const list = await listMigrationsHandler(auth([]));
+    expect(list.isError).toBeUndefined();
+  });
+});
+
+describe("list_migrations", () => {
+  it("says so, plainly, when SUPABASE_DB_URL is unset — and still lists the files", async () => {
+    vi.mocked(getMigrationStatus).mockResolvedValue(
+      status({
+        configured: false,
+        ledgerExists: false,
+        files: [{ filename: "001_a.sql", number: 1, checksum: "abc" }],
+      }),
+    );
+    const res = await listMigrationsHandler(auth(["migrate"]));
+    expect(res.isError).toBeUndefined(); // not configured is a state, not a failure
+    expect(body(res)).toMatch(/NOT CONFIGURED/);
+    expect(body(res)).toMatch(/SUPABASE_DB_URL is unset/);
+    expect(body(res)).toMatch(/001_a\.sql/);
+  });
+
+  it("points at the bootstrap when the ledger table doesn't exist", async () => {
+    vi.mocked(getMigrationStatus).mockResolvedValue(
+      status({ ledgerExists: false, pending: [{ filename: LEDGER_MIGRATION, number: 43, checksum: "x" }] }),
+    );
+    const res = await listMigrationsHandler(auth(["migrate"]));
+    expect(body(res)).toMatch(/ledger.* does not exist yet/);
+    expect(body(res)).toContain(`run_migration("${LEDGER_MIGRATION}")`);
+  });
+
+  it("tables the applied rows, marks the next pending one, and shouts about drift", async () => {
+    vi.mocked(getMigrationStatus).mockResolvedValue(
+      status({
+        applied: [
+          { filename: "001_a.sql", checksum: null, applied_at: "2026-01-01T00:00:00Z", applied_by: "baseline" },
+          { filename: "002_b.sql", checksum: "0123456789abcdef", applied_at: "2026-02-02T00:00:00Z", applied_by: "ops@regenhub.xyz" },
+        ],
+        pending: [
+          { filename: "044_c.sql", number: 44, checksum: "y" },
+          { filename: "045_d.sql", number: 45, checksum: "z" },
+        ],
+        drift: [{ filename: "002_b.sql", stored: "0123456789abcdef", current: "fedcba9876543210" }],
+        orphans: [{ filename: "099_gone.sql", checksum: null, applied_at: "2026-03-03T00:00:00Z", applied_by: "manual" }],
+      }),
+    );
+    const out = body(await listMigrationsHandler(auth(["migrate"])));
+    expect(out).toMatch(/### Applied \(2\)/);
+    expect(out).toMatch(/\| 001_a\.sql \| 2026-01-01T00:00:00Z \| baseline \|/);
+    expect(out).toMatch(/### Pending \(2\)/);
+    expect(out).toMatch(/- 044_c\.sql {2}← next; only this one may run/);
+    expect(out).not.toMatch(/045_d\.sql {2}←/);
+    expect(out).toMatch(/DRIFT: 002_b\.sql/);
+    expect(out).toMatch(/ORPHAN: the ledger says 099_gone\.sql/);
+  });
+
+  it("turns an unexpected failure into an error result, not a crash", async () => {
+    vi.mocked(getMigrationStatus).mockRejectedValue(new Error("ECONNREFUSED 127.0.0.1:5432"));
+    const res = await listMigrationsHandler(auth(["migrate"]));
+    expect(res.isError).toBe(true);
+    expect(body(res)).toMatch(/ECONNREFUSED/);
+  });
+});
+
+describe("run_migration", () => {
+  it("refuses without touching the database when SUPABASE_DB_URL is unset", async () => {
+    const res = await runMigrationHandler(auth(["migrate"]), "044_c.sql");
+    expect(res.isError).toBe(true);
+    expect(body(res)).toMatch(/SUPABASE_DB_URL is unset/);
+    expect(applyMigration).not.toHaveBeenCalled();
+  });
+
+  it("records the caller's email as applied_by", async () => {
+    process.env.SUPABASE_DB_URL = "postgres://x";
+    vi.mocked(applyMigration).mockResolvedValue({
+      ok: true, filename: "044_c.sql", checksum: "deadbeef", bootstrap: false,
+      status: status({ applied: [{ filename: "044_c.sql", checksum: "deadbeef", applied_at: "now", applied_by: "ops@regenhub.xyz" }] }),
+    });
+    const res = await runMigrationHandler(auth(["migrate"]), "044_c.sql");
+    expect(applyMigration).toHaveBeenCalledWith("044_c.sql", "ops@regenhub.xyz");
+    expect(res.isError).toBeUndefined();
+    expect(body(res)).toMatch(/Applied \*\*044_c\.sql\*\* as ops@regenhub\.xyz/);
+    expect(body(res)).toMatch(/deadbeef/);
+  });
+
+  it("falls back to the member id when the token carries no email", async () => {
+    process.env.SUPABASE_DB_URL = "postgres://x";
+    vi.mocked(applyMigration).mockResolvedValue({ ok: false, error: "nope" });
+    const a = { ...auth(["migrate"]), extra: { memberId: 7, email: "", isAdmin: true, isOpsAdmin: true } };
+    await runMigrationHandler(a, "044_c.sql");
+    expect(applyMigration).toHaveBeenCalledWith("044_c.sql", "member 7");
+  });
+
+  it("surfaces the library's refusal verbatim", async () => {
+    process.env.SUPABASE_DB_URL = "postgres://x";
+    vi.mocked(applyMigration).mockResolvedValue({ ok: false, error: "Out of order: 043_schema_migrations.sql is pending and comes first." });
+    const res = await runMigrationHandler(auth(["migrate"]), "044_c.sql");
+    expect(res.isError).toBe(true);
+    expect(body(res)).toMatch(/Out of order/);
+  });
+
+  it("names the bootstrap for what it is", async () => {
+    process.env.SUPABASE_DB_URL = "postgres://x";
+    vi.mocked(applyMigration).mockResolvedValue({
+      ok: true, filename: LEDGER_MIGRATION, checksum: "c0ffee", bootstrap: true, status: status(),
+    });
+    const res = await runMigrationHandler(auth(["migrate"]), LEDGER_MIGRATION);
+    expect(body(res)).toMatch(/Bootstrapped the ledger/);
+  });
+
+  it("turns a thrown driver error into an error result", async () => {
+    process.env.SUPABASE_DB_URL = "postgres://x";
+    vi.mocked(applyMigration).mockRejectedValue(new Error("password authentication failed"));
+    const res = await runMigrationHandler(auth(["migrate"]), "044_c.sql");
+    expect(res.isError).toBe(true);
+    expect(body(res)).toMatch(/password authentication failed/);
+  });
+});

--- a/apps/web/src/lib/mcp/migrationTools.ts
+++ b/apps/web/src/lib/mcp/migrationTools.ts
@@ -1,0 +1,149 @@
+import type { McpAuthInfo } from "./oauth";
+import { hasScope } from "./metadata";
+import {
+  applyMigration,
+  getMigrationStatus,
+  isMigrationsConfigured,
+  LEDGER_MIGRATION,
+  NOT_CONFIGURED,
+  type MigrationStatus,
+} from "@/lib/migrations";
+
+/**
+ * The `list_migrations` / `run_migration` MCP tools.
+ *
+ * Kept out of server.ts so the handlers can be unit-tested directly — server.ts
+ * just registers them. Both are gated on the `migrate` scope; both report
+ * "not configured" rather than throwing when SUPABASE_DB_URL is unset, so a
+ * deployment without database access still serves the rest of the MCP.
+ */
+
+type ToolResult = { content: { type: "text"; text: string }[]; isError?: boolean };
+
+const text = (s: string): ToolResult => ({ content: [{ type: "text", text: s }] });
+const fail = (s: string): ToolResult => ({ isError: true, content: [{ type: "text", text: s }] });
+
+const denied = (tool: string) =>
+  fail(`Denied: ${tool} requires the "migrate" scope, which this token doesn't carry. Reconnect the MCP to re-consent.`);
+
+/** Render the drift + orphan warnings that must never be quiet. */
+function warnings(status: MigrationStatus): string[] {
+  const lines: string[] = [];
+  for (const d of status.drift) {
+    lines.push(
+      `⚠️  DRIFT: ${d.filename} was applied as ${d.stored.slice(0, 12)}… but the file on disk now hashes to ${d.current.slice(0, 12)}…. ` +
+        `Someone edited a migration after it ran. Nothing here will fix that automatically — reconcile by hand.`,
+    );
+  }
+  for (const o of status.orphans) {
+    lines.push(`⚠️  ORPHAN: the ledger says ${o.filename} was applied (${o.applied_at}) but there is no such file on disk.`);
+  }
+  for (const i of status.ignored) {
+    lines.push(`ℹ️  Ignored (doesn't match NNN_name.sql): ${i}`);
+  }
+  return lines;
+}
+
+function renderStatus(status: MigrationStatus): string {
+  const lines: string[] = [];
+
+  if (!status.configured) {
+    lines.push(`## Migrations: NOT CONFIGURED`);
+    lines.push(NOT_CONFIGURED);
+    lines.push("");
+    lines.push(`Files on disk (${status.files.length}) — applied state unknown:`);
+    for (const f of status.files) lines.push(`- ${f.filename}`);
+    return lines.join("\n");
+  }
+
+  lines.push(`## Migrations (SUPABASE_DB_URL configured · dir: ${status.dir ?? "NOT FOUND"})`);
+
+  if (!status.dir) {
+    lines.push("");
+    lines.push("No supabase/migrations directory was found on this deployment — is the image built from a Dockerfile that copies it? Set MIGRATIONS_DIR to override.");
+  }
+
+  if (!status.ledgerExists) {
+    lines.push("");
+    lines.push(
+      `**The \`schema_migrations\` ledger does not exist yet.** Nothing has been recorded. ` +
+        `Bootstrap it with \`run_migration("${LEDGER_MIGRATION}")\` — that file creates the ledger and seeds every migration through 043 as already-applied.`,
+    );
+  }
+
+  lines.push("");
+  lines.push(`### Applied (${status.applied.length})`);
+  if (status.applied.length === 0) {
+    lines.push("_(none recorded)_");
+  } else {
+    lines.push("| filename | applied_at | applied_by |");
+    lines.push("|---|---|---|");
+    for (const r of status.applied) {
+      lines.push(`| ${r.filename} | ${r.applied_at} | ${r.applied_by ?? "—"} |`);
+    }
+  }
+
+  lines.push("");
+  lines.push(`### Pending (${status.pending.length})`);
+  if (status.pending.length === 0) {
+    lines.push("_(none — the database is up to date with this deployment's files)_");
+  } else {
+    status.pending.forEach((f, i) => {
+      lines.push(`- ${f.filename}${i === 0 ? "  ← next; only this one may run" : ""}`);
+    });
+  }
+
+  const w = warnings(status);
+  if (w.length > 0) {
+    lines.push("");
+    lines.push("### Warnings");
+    lines.push(...w);
+  }
+
+  return lines.join("\n");
+}
+
+/** `list_migrations` — read-only, always safe to call. */
+export async function listMigrationsHandler(auth: McpAuthInfo): Promise<ToolResult> {
+  if (!hasScope(auth.scopes, "migrate")) return denied("list_migrations");
+  try {
+    return text(renderStatus(await getMigrationStatus()));
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return fail(`Could not read migration state: ${msg}`);
+  }
+}
+
+/** `run_migration` — applies exactly the named file, if it's the one that's allowed to run. */
+export async function runMigrationHandler(auth: McpAuthInfo, filename: string): Promise<ToolResult> {
+  if (!hasScope(auth.scopes, "migrate")) return denied("run_migration");
+  if (!isMigrationsConfigured()) return fail(NOT_CONFIGURED);
+
+  const appliedBy = auth.extra.email || `member ${auth.extra.memberId}`;
+  let result;
+  try {
+    result = await applyMigration(filename, appliedBy);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return fail(`Could not apply ${filename}: ${msg}`);
+  }
+  if (!result.ok) return fail(result.error);
+
+  const head = result.bootstrap
+    ? `Bootstrapped the ledger: applied **${result.filename}** as ${appliedBy}.`
+    : `Applied **${result.filename}** as ${appliedBy}.`;
+  return text(`${head}\nchecksum ${result.checksum}\n\n${renderStatus(result.status)}`);
+}
+
+export const LIST_MIGRATIONS_DESCRIPTION =
+  "Read-only status of the database migrations in supabase/migrations/ against the schema_migrations ledger on the " +
+  "production database. Shows what's applied (filename, when, by whom), what's pending, any checksum drift " +
+  "(a migration file edited after it ran), and whether SUPABASE_DB_URL is configured on this deployment. " +
+  "Always safe to call — it never writes. Call it before and after run_migration.";
+
+export const RUN_MIGRATION_DESCRIPTION =
+  "APPLIES A SQL MIGRATION to the production database, inside a single transaction, and records it in the " +
+  "schema_migrations ledger. You must name the exact file (e.g. '044_add_thing.sql') — there is deliberately no " +
+  "'run all'. It will only run the LOWEST-numbered pending migration; anything else is refused. If the ledger " +
+  `table doesn't exist yet, the only permitted file is '${LEDGER_MIGRATION}', which creates and seeds it. ` +
+  "The migration must be present in the deployed image, so ship the code first, then run this. Use list_migrations to see what's pending.";

--- a/apps/web/src/lib/mcp/oauth.ts
+++ b/apps/web/src/lib/mcp/oauth.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes } from "node:crypto";
 import { createServiceClient } from "@/lib/supabase/admin";
+import { MCP_SCOPES } from "./metadata";
 
 /**
  * OAuth 2.1 server logic for the RegenHub MCP, served in-app at regenhub.xyz.
@@ -78,9 +79,14 @@ export async function createAuthorizationCode(p: {
   const m = await getMember(p.memberId);
   if (!m?.is_ops_admin) throw new OAuthError("access_denied", "not a RegenHub ops-admin", 403);
   const code = randToken();
+  // MCP clients aren't required to ask for scopes, and ours don't — an empty
+  // request would otherwise mint a token that no scope-gated tool accepts.
+  // Entry is already is_ops_admin-only, so consent here IS the full ops grant;
+  // record it explicitly rather than leaving the list blank.
+  const scopes = p.scopes.length > 0 ? p.scopes : [...MCP_SCOPES];
   const { error } = await sb().from("mcp_oauth_codes").insert({
     code_hash: sha256(code), client_id: p.clientId, member_id: p.memberId,
-    code_challenge: p.codeChallenge, redirect_uri: p.redirectUri, scopes: p.scopes,
+    code_challenge: p.codeChallenge, redirect_uri: p.redirectUri, scopes,
     resource: p.resource ?? null, expires_at: new Date(Date.now() + CODE_TTL_SEC * 1000).toISOString(),
   });
   if (error) throw new OAuthError("server_error", "could not persist authorization code", 500);

--- a/apps/web/src/lib/mcp/server.ts
+++ b/apps/web/src/lib/mcp/server.ts
@@ -9,9 +9,15 @@ import { createServiceClient } from "@/lib/supabase/admin";
 import { getStripe, isStripeConfigured } from "@/lib/stripe";
 import { sendApplicationCheckoutEmail } from "@/lib/applicationCheckout";
 import { siteOrigin } from "./metadata";
+import {
+  listMigrationsHandler,
+  runMigrationHandler,
+  LIST_MIGRATIONS_DESCRIPTION,
+  RUN_MIGRATION_DESCRIPTION,
+} from "./migrationTools";
 
 const SERVER_NAME = "regenhub";
-const SERVER_VERSION = "0.4.0";
+const SERVER_VERSION = "0.5.0";
 
 /**
  * Build the MCP tool surface. Phase 1 = `ping`. Future tools gate on the caller's
@@ -186,6 +192,21 @@ function buildServer(auth: McpAuthInfo): McpServer {
         }],
       };
     },
+  );
+
+  // ── database migrations (scope: migrate) ──────────────────
+  server.tool("list_migrations", LIST_MIGRATIONS_DESCRIPTION, async () => listMigrationsHandler(auth));
+
+  server.tool(
+    "run_migration",
+    RUN_MIGRATION_DESCRIPTION,
+    {
+      filename: z
+        .string()
+        .regex(/^\d{3}_[a-z0-9_]+\.sql$/, "exact migration filename, e.g. 044_add_thing.sql")
+        .describe("Exact migration filename from supabase/migrations/, e.g. '044_add_thing.sql'"),
+    },
+    async ({ filename }) => runMigrationHandler(auth, filename),
   );
 
   return server;

--- a/apps/web/src/lib/migrations.test.ts
+++ b/apps/web/src/lib/migrations.test.ts
@@ -1,0 +1,433 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// fs is mocked so these tests describe a migrations directory rather than the
+// real one — the repo's own files keep changing and shouldn't fail the suite.
+vi.mock("node:fs", () => ({ existsSync: vi.fn(() => false) }));
+vi.mock("node:fs/promises", () => ({ readdir: vi.fn(), readFile: vi.fn() }));
+vi.mock("pg", () => ({ Client: vi.fn() }));
+
+import { existsSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import { Client } from "pg";
+import {
+  applyMigration,
+  checkApplyAllowed,
+  computePending,
+  detectDrift,
+  detectOrphans,
+  getMigrationStatus,
+  isMigrationsConfigured,
+  LEDGER_MIGRATION,
+  migrationNumber,
+  migrationsDirCandidates,
+  readMigrationFiles,
+  resolveMigrationsDir,
+  sha256Hex,
+  sortMigrationFilenames,
+  type LedgerRow,
+  type MigrationFile,
+} from "./migrations";
+
+const DIR = "/repo/supabase/migrations";
+
+/** A migration file with a stable, made-up checksum. */
+const f = (filename: string, checksum = `sum-${filename}`): MigrationFile => ({
+  filename,
+  number: migrationNumber(filename)!,
+  checksum,
+});
+
+const row = (filename: string, checksum: string | null = null, applied_by = "baseline"): LedgerRow => ({
+  filename,
+  checksum,
+  applied_at: "2026-08-24T00:00:00.000Z",
+  applied_by,
+});
+
+/**
+ * Point the resolver at DIR and serve `contents` from it. Uses the
+ * MIGRATIONS_DIR override so these tests don't depend on the real cwd —
+ * resolution from cwd gets its own tests below.
+ */
+function mockDir(contents: Record<string, string>) {
+  process.env.MIGRATIONS_DIR = DIR;
+  vi.mocked(existsSync).mockImplementation((p) => String(p) === DIR);
+  vi.mocked(readdir).mockResolvedValue(Object.keys(contents) as never);
+  vi.mocked(readFile).mockImplementation(async (p) => {
+    const name = String(p).split("/").pop()!;
+    if (!(name in contents)) throw new Error(`ENOENT ${name}`);
+    return contents[name];
+  });
+}
+
+type QueryCall = { sql: string; values?: unknown[] };
+
+/**
+ * A stand-in for `pg.Client`. `ledger` = null means the schema_migrations table
+ * doesn't exist (the pre-bootstrap state); `failOn` makes one statement throw so
+ * the rollback path can be exercised.
+ */
+function mockPg(opts: { ledger: LedgerRow[] | null; failOn?: RegExp }) {
+  const calls: QueryCall[] = [];
+  let ledger = opts.ledger;
+  const query = vi.fn(async (sql: string, values?: unknown[]) => {
+    calls.push({ sql, values });
+    if (opts.failOn?.test(sql)) throw new Error("syntax error at or near \"oops\"");
+    if (/to_regclass/.test(sql)) return { rows: [{ reg: ledger === null ? null : "schema_migrations" }] };
+    if (/^select filename/.test(sql)) return { rows: (ledger ?? []) as unknown as Record<string, unknown>[] };
+    if (/^insert into schema_migrations/.test(sql)) {
+      const [filename, checksum, applied_by] = (values ?? []) as [string, string, string];
+      ledger = [
+        ...(ledger ?? []).filter((r) => r.filename !== filename),
+        { filename, checksum, applied_at: "2026-08-24T12:00:00.000Z", applied_by },
+      ].sort((a, b) => a.filename.localeCompare(b.filename));
+      return { rows: [] };
+    }
+    // The migration body itself (bootstrap) brings the table into existence.
+    if (ledger === null && !/^(begin|commit|rollback)$/.test(sql)) ledger = [];
+    return { rows: [] };
+  });
+  const client = { connect: vi.fn(async () => {}), query, end: vi.fn(async () => {}) };
+  // Must be a `function`, not an arrow — the code under test calls `new Client(...)`.
+  vi.mocked(Client).mockImplementation(function () {
+    return client;
+  } as never);
+  return { client, calls, sqlOf: () => calls.map((c) => c.sql) };
+}
+
+const OLD_ENV = { ...process.env };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(existsSync).mockReturnValue(false);
+  delete process.env.SUPABASE_DB_URL;
+  delete process.env.MIGRATIONS_DIR;
+});
+
+afterEach(() => {
+  process.env = { ...OLD_ENV };
+});
+
+// ── pure helpers ────────────────────────────────────────────
+
+describe("filename validation + ordering", () => {
+  it("accepts NNN_lower_snake.sql and reads the number", () => {
+    expect(migrationNumber("001_initial_schema.sql")).toBe(1);
+    expect(migrationNumber("043_schema_migrations.sql")).toBe(43);
+  });
+
+  it("rejects anything that isn't a migration filename", () => {
+    for (const bad of [
+      "1_initial.sql",            // not three digits
+      "0043_thing.sql",           // four digits
+      "043-schema-migrations.sql", // dashes
+      "043_Schema_Migrations.sql", // uppercase
+      "043_schema_migrations.txt", // wrong extension
+      "043_.sql",                  // empty name
+      "README.md",
+      ".DS_Store",
+    ]) {
+      expect(migrationNumber(bad), bad).toBeNull();
+    }
+  });
+
+  it("orders numerically, not lexicographically, and quarantines the rest", () => {
+    const { valid, ignored } = sortMigrationFilenames([
+      "010_ten.sql",
+      "README.md",
+      "002_two.sql",
+      "1000_thousand.sql", // four digits — not a migration by our rule
+      "009_nine.sql",
+    ]);
+    expect(valid).toEqual(["002_two.sql", "009_nine.sql", "010_ten.sql"]);
+    expect(ignored).toEqual(["1000_thousand.sql", "README.md"]);
+  });
+
+  it("hashes file contents with sha256", () => {
+    // Known vector: sha256("") — proves we're hashing the bytes, not the name.
+    expect(sha256Hex("")).toBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    expect(sha256Hex("a")).not.toBe(sha256Hex("b"));
+  });
+});
+
+describe("pending / drift / orphans", () => {
+  const files = [f("001_a.sql"), f("002_b.sql"), f("003_c.sql")];
+
+  it("pending is files minus ledger rows, in order", () => {
+    expect(computePending(files, [row("001_a.sql")]).map((x) => x.filename)).toEqual([
+      "002_b.sql",
+      "003_c.sql",
+    ]);
+  });
+
+  it("pending is empty when everything is recorded", () => {
+    expect(computePending(files, files.map((x) => row(x.filename)))).toEqual([]);
+  });
+
+  it("flags a ledger row whose stored checksum no longer matches the file", () => {
+    const drift = detectDrift(files, [row("002_b.sql", "an-old-hash", "ops@regenhub.xyz")]);
+    expect(drift).toEqual([{ filename: "002_b.sql", stored: "an-old-hash", current: "sum-002_b.sql" }]);
+  });
+
+  it("does NOT flag baseline rows, whose checksum is null by design", () => {
+    expect(detectDrift(files, [row("002_b.sql", null)])).toEqual([]);
+  });
+
+  it("does not flag a matching checksum", () => {
+    expect(detectDrift(files, [row("002_b.sql", "sum-002_b.sql")])).toEqual([]);
+  });
+
+  it("reports ledger rows with no file on disk", () => {
+    expect(detectOrphans(files, [row("001_a.sql"), row("099_gone.sql")]).map((r) => r.filename)).toEqual([
+      "099_gone.sql",
+    ]);
+  });
+});
+
+describe("checkApplyAllowed", () => {
+  const files = [f("001_a.sql"), f("042_b.sql"), f(LEDGER_MIGRATION), f("044_d.sql")];
+  const allButLast = files.slice(0, 3).map((x) => row(x.filename));
+
+  it("allows the lowest-numbered pending migration", () => {
+    expect(checkApplyAllowed({ filename: "044_d.sql", files, applied: allButLast, ledgerExists: true }))
+      .toEqual({ ok: true, bootstrap: false });
+  });
+
+  it("refuses a higher-numbered migration while a lower one is pending", () => {
+    const applied = [row("001_a.sql")];
+    const res = checkApplyAllowed({ filename: "044_d.sql", files, applied, ledgerExists: true });
+    expect(res.ok).toBe(false);
+    expect(res.ok === false && res.reason).toMatch(/Out of order: 042_b\.sql is pending/);
+  });
+
+  it("refuses a migration that was already applied", () => {
+    const res = checkApplyAllowed({ filename: "001_a.sql", files, applied: allButLast, ledgerExists: true });
+    expect(res.ok).toBe(false);
+    expect(res.ok === false && res.reason).toMatch(/already applied/);
+  });
+
+  it("refuses a file that isn't in this deployment's directory", () => {
+    const res = checkApplyAllowed({ filename: "099_future.sql", files, applied: allButLast, ledgerExists: true });
+    expect(res.ok).toBe(false);
+    expect(res.ok === false && res.reason).toMatch(/not in the migrations directory/);
+  });
+
+  it("refuses a string that isn't a migration filename at all", () => {
+    const res = checkApplyAllowed({ filename: "drop table members", files, applied: [], ledgerExists: true });
+    expect(res.ok).toBe(false);
+    expect(res.ok === false && res.reason).toMatch(/not a migration filename/);
+  });
+
+  describe("bootstrap (no ledger table)", () => {
+    it("permits 043 and marks it as the bootstrap", () => {
+      expect(checkApplyAllowed({ filename: LEDGER_MIGRATION, files, applied: [], ledgerExists: false }))
+        .toEqual({ ok: true, bootstrap: true });
+    });
+
+    it("refuses every other file — including 001, which would otherwise be 'lowest pending'", () => {
+      for (const name of ["001_a.sql", "042_b.sql", "044_d.sql"]) {
+        const res = checkApplyAllowed({ filename: name, files, applied: [], ledgerExists: false });
+        expect(res.ok, name).toBe(false);
+        expect(res.ok === false && res.reason).toMatch(/ledger doesn't exist yet/);
+      }
+    });
+  });
+});
+
+// ── directory resolution ────────────────────────────────────
+
+describe("resolveMigrationsDir", () => {
+  it("prefers MIGRATIONS_DIR over everything else", () => {
+    process.env.MIGRATIONS_DIR = "/custom/migrations";
+    expect(migrationsDirCandidates("/app/apps/web")[0]).toBe("/custom/migrations");
+  });
+
+  it("covers both the container cwd and the double-nested standalone cwd", () => {
+    // Dockerfile copies to /app/apps/web/supabase/migrations; server.js may chdir
+    // into /app/apps/web/apps/web. One list has to find it from either.
+    expect(migrationsDirCandidates("/app/apps/web")).toContain("/app/apps/web/supabase/migrations");
+    expect(migrationsDirCandidates("/app/apps/web/apps/web")).toContain("/app/apps/web/supabase/migrations");
+  });
+
+  it("finds the repo root from a dev cwd of apps/web", () => {
+    expect(migrationsDirCandidates("/repo/apps/web")).toContain("/repo/supabase/migrations");
+  });
+
+  it("returns the first candidate that exists", () => {
+    vi.mocked(existsSync).mockImplementation((p) => String(p) === "/repo/supabase/migrations");
+    expect(resolveMigrationsDir("/repo/apps/web")).toBe("/repo/supabase/migrations");
+  });
+
+  it("returns null when nothing exists", () => {
+    expect(resolveMigrationsDir("/nowhere")).toBeNull();
+  });
+});
+
+describe("readMigrationFiles", () => {
+  it("hashes each file and returns them in numeric order", async () => {
+    mockDir({ "002_b.sql": "select 2;", "001_a.sql": "select 1;", "notes.md": "hi" });
+    const { files, ignored } = await readMigrationFiles(DIR);
+    expect(files.map((x) => x.filename)).toEqual(["001_a.sql", "002_b.sql"]);
+    expect(files[0].checksum).toBe(sha256Hex("select 1;"));
+    expect(files[0].number).toBe(1);
+    expect(ignored).toEqual(["notes.md"]);
+  });
+});
+
+// ── configuration + status ──────────────────────────────────
+
+describe("isMigrationsConfigured", () => {
+  it("is false without SUPABASE_DB_URL and true with it", () => {
+    expect(isMigrationsConfigured()).toBe(false);
+    process.env.SUPABASE_DB_URL = "postgres://u:p@h:5432/postgres";
+    expect(isMigrationsConfigured()).toBe(true);
+  });
+});
+
+describe("getMigrationStatus", () => {
+  it("still lists files, and never touches pg, when SUPABASE_DB_URL is unset", async () => {
+    mockDir({ "001_a.sql": "select 1;" });
+    const status = await getMigrationStatus();
+    expect(status.configured).toBe(false);
+    expect(status.files.map((x) => x.filename)).toEqual(["001_a.sql"]);
+    expect(status.applied).toEqual([]);
+    expect(Client).not.toHaveBeenCalled();
+  });
+
+  it("reports every file as pending when the ledger table doesn't exist", async () => {
+    process.env.SUPABASE_DB_URL = "postgres://x";
+    mockDir({ "001_a.sql": "select 1;", [LEDGER_MIGRATION]: "create table schema_migrations();" });
+    mockPg({ ledger: null });
+
+    const status = await getMigrationStatus();
+    expect(status.ledgerExists).toBe(false);
+    expect(status.pending.map((x) => x.filename)).toEqual(["001_a.sql", LEDGER_MIGRATION]);
+  });
+
+  it("splits applied vs pending and surfaces drift", async () => {
+    process.env.SUPABASE_DB_URL = "postgres://x";
+    mockDir({ "001_a.sql": "select 1;", "002_b.sql": "select 2;", "003_c.sql": "select 3;" });
+    const pg = mockPg({
+      ledger: [row("001_a.sql", null), row("002_b.sql", "stale-hash", "ops@regenhub.xyz")],
+    });
+
+    const status = await getMigrationStatus();
+    expect(status.applied.map((r) => r.filename)).toEqual(["001_a.sql", "002_b.sql"]);
+    expect(status.pending.map((x) => x.filename)).toEqual(["003_c.sql"]);
+    expect(status.drift).toEqual([
+      { filename: "002_b.sql", stored: "stale-hash", current: sha256Hex("select 2;") },
+    ]);
+    expect(pg.client.end).toHaveBeenCalled();
+  });
+});
+
+// ── applying ────────────────────────────────────────────────
+
+describe("applyMigration", () => {
+  it("refuses immediately when SUPABASE_DB_URL is unset", async () => {
+    const res = await applyMigration("001_a.sql", "ops@regenhub.xyz");
+    expect(res).toEqual({ ok: false, error: expect.stringMatching(/SUPABASE_DB_URL is unset/) });
+    expect(Client).not.toHaveBeenCalled();
+  });
+
+  it("runs the file and the ledger insert in one transaction", async () => {
+    process.env.SUPABASE_DB_URL = "postgres://x";
+    mockDir({ "001_a.sql": "select 1;", "002_b.sql": "alter table members add column x text;" });
+    const pg = mockPg({ ledger: [row("001_a.sql", null)] });
+
+    const res = await applyMigration("002_b.sql", "ops@regenhub.xyz");
+    expect(res.ok).toBe(true);
+
+    const sql = pg.sqlOf();
+    const begin = sql.indexOf("begin");
+    const body = sql.indexOf("alter table members add column x text;");
+    const insert = sql.findIndex((s) => s.startsWith("insert into schema_migrations"));
+    const commit = sql.indexOf("commit");
+    expect(begin).toBeGreaterThanOrEqual(0);
+    expect(body).toBeGreaterThan(begin);
+    expect(insert).toBeGreaterThan(body);
+    expect(commit).toBeGreaterThan(insert);
+    expect(sql).not.toContain("rollback");
+  });
+
+  it("records the caller's email and the real checksum", async () => {
+    process.env.SUPABASE_DB_URL = "postgres://x";
+    mockDir({ "001_a.sql": "select 1;" });
+    const pg = mockPg({ ledger: [] });
+
+    const res = await applyMigration("001_a.sql", "ops@regenhub.xyz");
+    expect(res.ok && res.checksum).toBe(sha256Hex("select 1;"));
+    const insert = pg.calls.find((c) => c.sql.startsWith("insert into schema_migrations"))!;
+    expect(insert.values).toEqual(["001_a.sql", sha256Hex("select 1;"), "ops@regenhub.xyz"]);
+    expect(res.ok && res.status.pending).toEqual([]);
+    expect(res.ok && res.status.applied.map((r) => r.applied_by)).toEqual(["ops@regenhub.xyz"]);
+  });
+
+  it("rolls back and applies nothing when the SQL fails", async () => {
+    process.env.SUPABASE_DB_URL = "postgres://x";
+    mockDir({ "001_a.sql": "oops not sql;" });
+    const pg = mockPg({ ledger: [], failOn: /oops/ });
+
+    const res = await applyMigration("001_a.sql", "ops@regenhub.xyz");
+    expect(res.ok).toBe(false);
+    expect(res.ok === false && res.error).toMatch(/rolled back — nothing was applied/);
+    expect(pg.sqlOf()).toContain("rollback");
+    expect(pg.sqlOf().some((s) => s.startsWith("insert into schema_migrations"))).toBe(false);
+  });
+
+  it("refuses out-of-order without opening a transaction", async () => {
+    process.env.SUPABASE_DB_URL = "postgres://x";
+    mockDir({ "001_a.sql": "select 1;", "002_b.sql": "select 2;" });
+    const pg = mockPg({ ledger: [] });
+
+    const res = await applyMigration("002_b.sql", "ops@regenhub.xyz");
+    expect(res.ok).toBe(false);
+    expect(res.ok === false && res.error).toMatch(/Out of order: 001_a\.sql/);
+    expect(pg.sqlOf()).not.toContain("begin");
+  });
+
+  it("bootstraps: with no ledger table, 043 runs and only 043", async () => {
+    process.env.SUPABASE_DB_URL = "postgres://x";
+    mockDir({
+      "001_a.sql": "select 1;",
+      "042_b.sql": "select 42;",
+      [LEDGER_MIGRATION]: "create table schema_migrations (filename text primary key);",
+    });
+    mockPg({ ledger: null });
+
+    const blocked = await applyMigration("001_a.sql", "ops@regenhub.xyz");
+    expect(blocked.ok).toBe(false);
+    expect(blocked.ok === false && blocked.error).toMatch(/ledger doesn't exist yet/);
+
+    mockPg({ ledger: null });
+    const res = await applyMigration(LEDGER_MIGRATION, "ops@regenhub.xyz");
+    expect(res.ok).toBe(true);
+    expect(res.ok && res.bootstrap).toBe(true);
+    // The ledger now exists and knows about itself.
+    expect(res.ok && res.status.applied.map((r) => r.filename)).toEqual([LEDGER_MIGRATION]);
+  });
+
+  it("refuses a filename that isn't in the deployed directory", async () => {
+    process.env.SUPABASE_DB_URL = "postgres://x";
+    mockDir({ "001_a.sql": "select 1;" });
+    const pg = mockPg({ ledger: [] });
+
+    const res = await applyMigration("099_not_shipped.sql", "ops@regenhub.xyz");
+    expect(res.ok).toBe(false);
+    expect(res.ok === false && res.error).toMatch(/not in the migrations directory/);
+    expect(pg.sqlOf()).not.toContain("begin");
+  });
+
+  it("aborts if the file changes between hashing and reading", async () => {
+    process.env.SUPABASE_DB_URL = "postgres://x";
+    mockDir({ "001_a.sql": "select 1;" });
+    mockPg({ ledger: [] });
+    // First read (hashing) sees one thing, the apply-time read sees another.
+    let n = 0;
+    vi.mocked(readFile).mockImplementation(async () => (n++ === 0 ? "select 1;" : "select 2;"));
+
+    const res = await applyMigration("001_a.sql", "ops@regenhub.xyz");
+    expect(res.ok).toBe(false);
+    expect(res.ok === false && res.error).toMatch(/changed on disk/);
+  });
+});

--- a/apps/web/src/lib/migrations.ts
+++ b/apps/web/src/lib/migrations.ts
@@ -1,0 +1,391 @@
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Database migrations, applied from inside the app.
+ *
+ * Migrations live in `supabase/migrations/` as `NNN_name.sql` and used to be
+ * applied by hand (psql / Studio) with no record kept — which is how 042 got
+ * merged and never applied. Migration 043 adds a `schema_migrations` ledger;
+ * this module is everything the MCP needs to read that ledger and add to it.
+ *
+ * Two hard rules, both here rather than in the tool layer:
+ *   1. Only the LOWEST-numbered pending migration may run. No "run all", no
+ *      skipping ahead, no re-running.
+ *   2. If the ledger table doesn't exist yet, the ONLY file permitted is
+ *      043 itself — the bootstrap. That's what lets the whole thing come up
+ *      without anyone SSHing anywhere.
+ *
+ * Everything degrades when `SUPABASE_DB_URL` is unset: the tools report
+ * "not configured on this deployment" and the rest of the MCP is unaffected.
+ */
+
+/** `NNN_lower_snake.sql` — the shape every file in supabase/migrations/ has. */
+export const MIGRATION_FILENAME_RE = /^(\d{3})_[a-z0-9]+(?:_[a-z0-9]+)*\.sql$/;
+
+/** The migration that creates the ledger. The one file allowed to bootstrap. */
+export const LEDGER_MIGRATION = "043_schema_migrations.sql";
+
+export const LEDGER_TABLE = "schema_migrations";
+
+export interface MigrationFile {
+  filename: string;
+  /** The numeric prefix, e.g. 43 for `043_schema_migrations.sql`. */
+  number: number;
+  /** sha256 hex of the file contents. */
+  checksum: string;
+}
+
+export interface LedgerRow {
+  filename: string;
+  checksum: string | null;
+  applied_at: string;
+  applied_by: string | null;
+}
+
+export interface Drift {
+  filename: string;
+  stored: string;
+  current: string;
+}
+
+export interface MigrationStatus {
+  /** Is SUPABASE_DB_URL set? When false, everything below the file list is unknown. */
+  configured: boolean;
+  /** Resolved migrations directory, or null if none of the candidates exist. */
+  dir: string | null;
+  /** Files on disk, numerically ordered. */
+  files: MigrationFile[];
+  /** Filenames in the directory that don't match `NNN_name.sql` (ignored, but reported). */
+  ignored: string[];
+  /** False when the `schema_migrations` table doesn't exist yet (pre-bootstrap). */
+  ledgerExists: boolean;
+  applied: LedgerRow[];
+  pending: MigrationFile[];
+  /** Ledger rows with a stored checksum that no longer matches the file. */
+  drift: Drift[];
+  /** Ledger rows with no corresponding file on disk (renamed or deleted). */
+  orphans: LedgerRow[];
+}
+
+// ── pure helpers ────────────────────────────────────────────
+
+export function sha256Hex(contents: string): string {
+  return createHash("sha256").update(contents, "utf8").digest("hex");
+}
+
+/** The numeric prefix of a valid migration filename, or null if it isn't one. */
+export function migrationNumber(filename: string): number | null {
+  const m = MIGRATION_FILENAME_RE.exec(filename);
+  return m ? Number(m[1]) : null;
+}
+
+/**
+ * Split a directory listing into valid migration filenames (numerically ordered)
+ * and everything else. Ordering is by the numeric prefix, not lexicographic —
+ * they agree today at three digits but won't at 1000, and the sort is the thing
+ * "apply in order" rests on.
+ */
+export function sortMigrationFilenames(names: string[]): { valid: string[]; ignored: string[] } {
+  const valid: { name: string; n: number }[] = [];
+  const ignored: string[] = [];
+  for (const name of names) {
+    const n = migrationNumber(name);
+    if (n === null) ignored.push(name);
+    else valid.push({ name, n });
+  }
+  valid.sort((a, b) => a.n - b.n || a.name.localeCompare(b.name));
+  return { valid: valid.map((v) => v.name), ignored: ignored.sort() };
+}
+
+/** Files with no ledger row, in order. */
+export function computePending(files: MigrationFile[], applied: LedgerRow[]): MigrationFile[] {
+  const seen = new Set(applied.map((r) => r.filename));
+  return files.filter((f) => !seen.has(f.filename));
+}
+
+/**
+ * Ledger rows whose stored checksum disagrees with the file on disk. NULL
+ * checksums are baseline rows (applied before the ledger existed) and are
+ * skipped — there's nothing to compare against, and inventing a comparison
+ * would turn a known unknown into a false alarm.
+ */
+export function detectDrift(files: MigrationFile[], applied: LedgerRow[]): Drift[] {
+  const byName = new Map(files.map((f) => [f.filename, f]));
+  const out: Drift[] = [];
+  for (const row of applied) {
+    if (!row.checksum) continue;
+    const file = byName.get(row.filename);
+    if (file && file.checksum !== row.checksum) {
+      out.push({ filename: row.filename, stored: row.checksum, current: file.checksum });
+    }
+  }
+  return out;
+}
+
+/** Ledger rows with no file on disk — a migration was renamed or deleted after it ran. */
+export function detectOrphans(files: MigrationFile[], applied: LedgerRow[]): LedgerRow[] {
+  const onDisk = new Set(files.map((f) => f.filename));
+  return applied.filter((r) => !onDisk.has(r.filename));
+}
+
+export type ApplyCheck = { ok: true; bootstrap: boolean } | { ok: false; reason: string };
+
+/**
+ * May `filename` be applied right now? The whole safety story lives here so it
+ * can be tested without a database.
+ */
+export function checkApplyAllowed(p: {
+  filename: string;
+  files: MigrationFile[];
+  applied: LedgerRow[];
+  ledgerExists: boolean;
+}): ApplyCheck {
+  const { filename, files, applied, ledgerExists } = p;
+
+  if (migrationNumber(filename) === null) {
+    return { ok: false, reason: `"${filename}" is not a migration filename — expected NNN_name.sql (e.g. 044_add_thing.sql).` };
+  }
+  const file = files.find((f) => f.filename === filename);
+  if (!file) {
+    return { ok: false, reason: `"${filename}" is not in the migrations directory of this deployment. Has the code that adds it been deployed?` };
+  }
+
+  if (!ledgerExists) {
+    if (filename !== LEDGER_MIGRATION) {
+      return {
+        ok: false,
+        reason:
+          `The ${LEDGER_TABLE} ledger doesn't exist yet, so the only migration that can run is ${LEDGER_MIGRATION} ` +
+          `(it creates the ledger and seeds it with everything already applied). Run that first, then retry "${filename}".`,
+      };
+    }
+    return { ok: true, bootstrap: true };
+  }
+
+  const pending = computePending(files, applied);
+  if (!pending.some((f) => f.filename === filename)) {
+    const row = applied.find((r) => r.filename === filename);
+    return {
+      ok: false,
+      reason: row
+        ? `${filename} was already applied at ${row.applied_at} by ${row.applied_by ?? "unknown"}. Migrations never re-run.`
+        : `${filename} is not pending.`,
+    };
+  }
+  const lowest = pending[0];
+  if (lowest.filename !== filename) {
+    return {
+      ok: false,
+      reason:
+        `Out of order: ${lowest.filename} is pending and comes first. ` +
+        `Apply migrations lowest-number-first — run ${lowest.filename}, then ${filename}.`,
+    };
+  }
+  return { ok: true, bootstrap: false };
+}
+
+// ── filesystem ──────────────────────────────────────────────
+
+/**
+ * Where `supabase/migrations/` might be, most-specific first.
+ *
+ * Three shapes matter:
+ *   - `MIGRATIONS_DIR` env override — always wins.
+ *   - The container. The Dockerfile copies the directory to `/app/apps/web/supabase/migrations`
+ *     (WORKDIR of the runner stage). Next's standalone `server.js` chdir()s to its own
+ *     directory, which is double-nested for a pnpm monorepo (`/app/apps/web/apps/web` —
+ *     see CLAUDE.md), so BOTH `cwd/supabase/migrations` and `cwd/../../supabase/migrations`
+ *     are tried and one of them hits regardless of which cwd we actually get.
+ *   - Local dev / vitest, where cwd is `apps/web` and the repo root is two up — which is
+ *     the same `../../` candidate. One list covers all of it.
+ */
+export function migrationsDirCandidates(cwd: string = process.cwd()): string[] {
+  const override = process.env.MIGRATIONS_DIR;
+  return [
+    ...(override ? [override] : []),
+    path.join(cwd, "supabase", "migrations"),
+    path.resolve(cwd, "..", "..", "supabase", "migrations"),
+    path.resolve(cwd, "..", "supabase", "migrations"),
+  ];
+}
+
+/** First candidate directory that exists, or null. */
+export function resolveMigrationsDir(cwd: string = process.cwd()): string | null {
+  return migrationsDirCandidates(cwd).find((d) => existsSync(d)) ?? null;
+}
+
+/** Read + hash every migration file on disk, numerically ordered. */
+export async function readMigrationFiles(
+  dir: string,
+): Promise<{ files: MigrationFile[]; ignored: string[] }> {
+  const entries = await readdir(dir);
+  const { valid, ignored } = sortMigrationFilenames(entries);
+  const files: MigrationFile[] = [];
+  for (const filename of valid) {
+    const contents = await readFile(path.join(dir, filename), "utf8");
+    files.push({ filename, number: migrationNumber(filename)!, checksum: sha256Hex(contents) });
+  }
+  return { files, ignored };
+}
+
+// ── database ────────────────────────────────────────────────
+
+export function isMigrationsConfigured(): boolean {
+  return Boolean(process.env.SUPABASE_DB_URL);
+}
+
+export const NOT_CONFIGURED =
+  "Migrations are not configured on this deployment: SUPABASE_DB_URL is unset. " +
+  "Set it in Coolify on the web app (a postgres:// URL for the supabase_admin role) and redeploy.";
+
+/**
+ * A minimal `pg.Client`. Typed structurally so tests can hand us a fake and so
+ * the `pg` import stays dynamic — nothing loads the driver until a migration
+ * tool is actually called.
+ */
+interface PgLike {
+  connect(): Promise<void>;
+  query(sql: string, values?: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
+  end(): Promise<void>;
+}
+
+async function withClient<T>(fn: (client: PgLike) => Promise<T>): Promise<T> {
+  const { Client } = await import("pg");
+  const client = new Client({ connectionString: process.env.SUPABASE_DB_URL }) as unknown as PgLike;
+  await client.connect();
+  try {
+    return await fn(client);
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+/** Does `public.schema_migrations` exist? Cheap, and the bootstrap hinges on it. */
+async function ledgerExists(client: PgLike): Promise<boolean> {
+  const res = await client.query(`select to_regclass('public.${LEDGER_TABLE}') as reg`);
+  return Boolean(res.rows[0]?.reg);
+}
+
+async function readLedger(client: PgLike): Promise<LedgerRow[]> {
+  const res = await client.query(
+    `select filename, checksum, applied_at, applied_by from ${LEDGER_TABLE} order by filename`,
+  );
+  return res.rows.map((r) => ({
+    filename: String(r.filename),
+    checksum: r.checksum == null ? null : String(r.checksum),
+    applied_at:
+      r.applied_at instanceof Date ? r.applied_at.toISOString() : String(r.applied_at ?? ""),
+    applied_by: r.applied_by == null ? null : String(r.applied_by),
+  }));
+}
+
+/** Everything list_migrations needs. Never throws for "unconfigured" — that's a state, not an error. */
+export async function getMigrationStatus(): Promise<MigrationStatus> {
+  const dir = resolveMigrationsDir();
+  const { files, ignored } = dir ? await readMigrationFiles(dir) : { files: [], ignored: [] };
+
+  const base: MigrationStatus = {
+    configured: isMigrationsConfigured(),
+    dir,
+    files,
+    ignored,
+    ledgerExists: false,
+    applied: [],
+    pending: [],
+    drift: [],
+    orphans: [],
+  };
+  if (!base.configured) return base;
+
+  return withClient(async (client) => {
+    const exists = await ledgerExists(client);
+    const applied = exists ? await readLedger(client) : [];
+    return {
+      ...base,
+      ledgerExists: exists,
+      applied,
+      pending: exists ? computePending(files, applied) : files,
+      drift: detectDrift(files, applied),
+      orphans: detectOrphans(files, applied),
+    };
+  });
+}
+
+export type ApplyResult =
+  | { ok: true; filename: string; checksum: string; bootstrap: boolean; status: MigrationStatus }
+  | { ok: false; error: string };
+
+/**
+ * Apply exactly one migration, in one transaction: BEGIN, the file's SQL, the
+ * ledger row, COMMIT. Any failure rolls the whole thing back, so a half-applied
+ * migration can't exist and the ledger can't claim something that didn't land.
+ */
+export async function applyMigration(filename: string, appliedBy: string): Promise<ApplyResult> {
+  if (!isMigrationsConfigured()) return { ok: false, error: NOT_CONFIGURED };
+
+  const dir = resolveMigrationsDir();
+  if (!dir) {
+    return {
+      ok: false,
+      error: "Could not find a supabase/migrations directory on this deployment. Set MIGRATIONS_DIR if it lives somewhere unusual.",
+    };
+  }
+
+  const { files } = await readMigrationFiles(dir);
+
+  return withClient(async (client) => {
+    const exists = await ledgerExists(client);
+    const applied = exists ? await readLedger(client) : [];
+
+    const check = checkApplyAllowed({ filename, files, applied, ledgerExists: exists });
+    if (!check.ok) return { ok: false as const, error: check.reason };
+
+    const file = files.find((f) => f.filename === filename)!;
+    const sql = await readFile(path.join(dir, filename), "utf8");
+
+    // Guard against an edit landing between hashing and reading.
+    if (sha256Hex(sql) !== file.checksum) {
+      return { ok: false as const, error: `${filename} changed on disk while it was being read — nothing was applied.` };
+    }
+
+    try {
+      await client.query("begin");
+      await client.query(sql);
+      await client.query(
+        `insert into ${LEDGER_TABLE} (filename, checksum, applied_by) values ($1, $2, $3)
+         on conflict (filename) do update
+           set checksum = excluded.checksum,
+               applied_at = now(),
+               applied_by = excluded.applied_by`,
+        [filename, file.checksum, appliedBy],
+      );
+      await client.query("commit");
+    } catch (e) {
+      await client.query("rollback").catch(() => {});
+      const msg = e instanceof Error ? e.message : String(e);
+      return { ok: false as const, error: `${filename} failed and was rolled back — nothing was applied. Postgres said: ${msg}` };
+    }
+
+    const nowApplied = await readLedger(client);
+    return {
+      ok: true as const,
+      filename,
+      checksum: file.checksum,
+      bootstrap: check.bootstrap,
+      status: {
+        configured: true,
+        dir,
+        files,
+        ignored: [],
+        ledgerExists: true,
+        applied: nowApplied,
+        pending: computePending(files, nowApplied),
+        drift: detectDrift(files, nowApplied),
+        orphans: detectOrphans(files, nowApplied),
+      },
+    };
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      pg:
+        specifier: ^8.23.0
+        version: 8.23.0
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -111,6 +114,9 @@ importers:
       '@types/node':
         specifier: ^20
         version: 20.19.35
+      '@types/pg':
+        specifier: ^8.23.1
+        version: 8.23.1
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -1041,6 +1047,9 @@ packages:
 
   '@types/node@22.19.13':
     resolution: {integrity: sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==}
+
+  '@types/pg@8.23.1':
+    resolution: {integrity: sha512-fKVHpikPdg4GKks3JuLEhvwSyvwzF23hnabPy6DD8ljVbC7+6J5dQzdv4arV6jqq57djnMgs1HKBxX4P8aBI3A==}
 
   '@types/phoenix@1.6.7':
     resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
@@ -2650,6 +2659,40 @@ packages:
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.16.0:
+    resolution: {integrity: sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.23.0:
+    resolution: {integrity: sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2687,6 +2730,22 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2911,6 +2970,10 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   sshpk@1.18.0:
     resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
@@ -3298,6 +3361,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -4071,6 +4138,12 @@ snapshots:
   '@types/node@22.19.13':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/pg@8.23.1':
+    dependencies:
+      '@types/node': 22.19.13
+      pg-protocol: 1.16.0
+      pg-types: 2.2.0
 
   '@types/phoenix@1.6.7': {}
 
@@ -5835,6 +5908,41 @@ snapshots:
 
   performance-now@2.1.0: {}
 
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.23.0):
+    dependencies:
+      pg: 8.23.0
+
+  pg-protocol@1.16.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.23.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.23.0)
+      pg-protocol: 1.16.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -5866,6 +5974,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prelude-ls@1.2.1: {}
 
@@ -6197,6 +6315,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
 
   sshpk@1.18.0:
     dependencies:
@@ -6599,6 +6719,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.19.0: {}
+
+  xtend@4.0.2: {}
 
   yallist@3.1.1: {}
 

--- a/supabase/migrations/043_schema_migrations.sql
+++ b/supabase/migrations/043_schema_migrations.sql
@@ -1,0 +1,92 @@
+-- Migration 043: schema_migrations — a ledger, so "is it applied?" stops being a guess.
+--
+-- Until now this repo had migrations but no record of them. Files landed in
+-- supabase/migrations/, someone pasted them into psql or Studio, and the only
+-- evidence they ran was the schema itself. That failed exactly the way you'd
+-- expect: 042 (members.did) was merged, deployed, and never applied — the
+-- column simply wasn't there, and nothing anywhere could have told us.
+--
+-- The table is deliberately dumb: one row per file, keyed by the filename we
+-- already order by. No version numbers, no "dirty" flag, no framework. The
+-- interesting column is `checksum` — sha256 of the file *as applied* — which
+-- turns "someone edited a migration after it ran" from an invisible fact into
+-- a loud one.
+--
+-- BASELINE. Everything from 001 through 043 is already true of production
+-- (042 went in by hand the day this was written), so we seed those rows here
+-- rather than pretend they're pending. Their checksum is NULL, and NULL means
+-- exactly one thing: applied before the ledger existed, so there is nothing
+-- honest to compare the file against. Drift detection skips them by design —
+-- a fake checksum would be worse than none.
+--
+-- 043 seeds *itself* as applied, because applying this file IS applying it.
+-- That's what lets the MCP's run_migration("043_schema_migrations.sql")
+-- bootstrap the whole system with zero manual SQL: the tool sees no ledger
+-- table, permits this one file and nothing else, runs it in a transaction, and
+-- from the next migration on the record keeps itself.
+--
+-- RLS on, no policies: this is ops metadata. It is written by the MCP over a
+-- direct supabase_admin Postgres connection (SUPABASE_DB_URL), which is not
+-- PostgREST and not subject to RLS. Nothing anon or authenticated should read it.
+
+create table schema_migrations (
+  filename   text primary key,
+  checksum   text,
+  applied_at timestamptz not null default now(),
+  applied_by text
+);
+
+comment on table schema_migrations is
+  'Ledger of applied SQL migrations from supabase/migrations/. One row per file. Written by the RegenHub MCP run_migration tool (or by hand); read by list_migrations.';
+comment on column schema_migrations.checksum is
+  'sha256 hex of the migration file as applied. NULL = baseline row seeded by 043 (applied before this ledger existed) — drift detection deliberately skips NULLs.';
+comment on column schema_migrations.applied_by is
+  'Email of the MCP caller who applied it, or ''manual'' / ''baseline'' when it went in outside the tool.';
+
+alter table schema_migrations enable row level security;
+
+insert into schema_migrations (filename, checksum, applied_by) values
+  ('001_initial_schema.sql',                         null, 'baseline'),
+  ('002_fix_rls_admin_recursion.sql',                null, 'baseline'),
+  ('003_members_update_own.sql',                     null, 'baseline'),
+  ('004_link_member_on_auth.sql',                    null, 'baseline'),
+  ('005_applications.sql',                           null, 'baseline'),
+  ('006_pin_slot_ranges.sql',                        null, 'baseline'),
+  ('007_nullable_expires_at.sql',                    null, 'baseline'),
+  ('008_membership_model.sql',                       null, 'baseline'),
+  ('009_day_passes_balance.sql',                     null, 'baseline'),
+  ('010_fix_member_types.sql',                       null, 'baseline'),
+  ('011_hub_friend.sql',                             null, 'baseline'),
+  ('012_atomic_day_pass_balance.sql',                null, 'baseline'),
+  ('013_link_member_to_auth_reverse.sql',            null, 'baseline'),
+  ('014_free_day_claims.sql',                        null, 'baseline'),
+  ('015_free_day_promo_and_approval.sql',            null, 'baseline'),
+  ('016_invite_links_and_auto_member.sql',           null, 'baseline'),
+  ('017_application_telegram.sql',                   null, 'baseline'),
+  ('018_atomic_slot_allocation.sql',                 null, 'baseline'),
+  ('019_interests.sql',                              null, 'baseline'),
+  ('020_interests_link_to_members.sql',              null, 'baseline'),
+  ('021_stripe_memberships.sql',                     null, 'baseline'),
+  ('022_free_day_know_at_hub.sql',                   null, 'baseline'),
+  ('023_application_audit_trail.sql',                null, 'baseline'),
+  ('024_webhook_events.sql',                         null, 'baseline'),
+  ('025_lock_sync_runs.sql',                         null, 'baseline'),
+  ('026_free_day_no_date.sql',                       null, 'baseline'),
+  ('027_member_membership_approval.sql',             null, 'baseline'),
+  ('028_refine_membership_approval_grandfather.sql', null, 'baseline'),
+  ('029_approved_for_desk.sql',                      null, 'baseline'),
+  ('030_rename_approval_flags_daily_full.sql',       null, 'baseline'),
+  ('031_members_update_lockdown.sql',                null, 'baseline'),
+  ('032_free_day_grants_day_pass.sql',               null, 'baseline'),
+  ('033_admin_actions.sql',                          null, 'baseline'),
+  ('034_digest_notes.sql',                           null, 'baseline'),
+  ('035_newsletter.sql',                             null, 'baseline'),
+  ('036_telegram_at_signup.sql',                     null, 'baseline'),
+  ('037_door_holds.sql',                             null, 'baseline'),
+  ('038_door_hold_notify_chat.sql',                  null, 'baseline'),
+  ('039_newsletter_drafts_and_sends.sql',            null, 'baseline'),
+  ('040_ops_mcp_oauth.sql',                          null, 'baseline'),
+  ('041_ops_admin_tier.sql',                         null, 'baseline'),
+  ('042_members_did.sql',                            null, 'baseline'),
+  ('043_schema_migrations.sql',                      null, 'baseline')
+on conflict (filename) do nothing;


### PR DESCRIPTION
## Why

Migrations on prod are applied by hand and nothing records what ran. That failed exactly the way you'd expect this week: 042 (`members.did`) was merged and deployed but never applied, and the one-login handoff 500'd on prod until it went in over SSH. Aaron's ask: apply migrations without SSH-ing into compute-1, via the MCP.

## What this adds

**A ledger** — `supabase/migrations/043_schema_migrations.sql` creates `schema_migrations` (filename PK, sha256 checksum *as applied*, applied_at, applied_by) and seeds 001–043 as baseline rows (they're already true of prod; checksum NULL = "applied before the ledger existed", deliberately skipped by drift detection). 043 seeds itself, which is what makes the zero-SQL bootstrap below work.

**Two MCP tools** (in-app server at `regenhub.xyz/mcp`, entry already gated on `members.is_ops_admin`, live-checked per token verification; these additionally carry the `migrate` scope):

- `list_migrations` — read-only: applied rows, pending files, checksum drift, orphaned ledger rows, and whether the DB connection is configured.
- `run_migration(filename)` — applies exactly the named file in one transaction and writes the ledger row (`applied_by` = the caller's email). Deliberate constraints: explicit filename only (no "run all"), only the **lowest-numbered pending** file may run, applied files never re-run, files are re-hashed at apply time, and if the ledger table doesn't exist the only permitted file is 043 itself — the bootstrap.

**Plumbing** — `pg` (dynamic import, only loads when a migration tool is called), new runtime env `SUPABASE_DB_URL` (unset ⇒ tools report "not configured", nothing else affected), Dockerfile ships `supabase/migrations/` in the image (so: **deploy first, then run the migration** — the image is the source of truth for what can be applied).

**Scope fix discovered en route** — the `migrate` scope existed but was never granted: MCP clients don't send a `scope` param, so every token had `scopes: []` and a strict check would have locked out all existing connections. `createAuthorizationCode` now expands an empty request to the full scope set, and `hasScope()` treats an empty list as a full grant (defensible: entry is already ops-admin-only, so an unscoped token was always an ops token). Both commented and tested.

## One-time setup after merge

1. Coolify (web app): set `SUPABASE_DB_URL` = the supabase_admin `postgres://` connection string (host-exposed Postgres port on compute-1, credentials per DEPLOYMENT.md "Get credentials from running container"), then redeploy.
2. Become an MCP user if you aren't yet: `update members set is_ops_admin = true where email = '<your member email>';` (one Studio query — this is the "superadmin in the DB" bit; it's also what gates the whole MCP).
3. Connect: `claude mcp add --transport http regenhub-ops https://regenhub.xyz/mcp` (browser OAuth as your RegenHub account).
4. Bootstrap the ledger: `run_migration("043_schema_migrations.sql")`. From then on it keeps itself.

Docs updated in CLAUDE.md + DEPLOYMENT.md (MCP is the primary migration path; psql/Studio documented as fallback).

## Gates

- lint: clean (one pre-existing unrelated warning)
- tests: 159/159 (111 before; +48 across `lib/migrations.test.ts` and `lib/mcp/migrationTools.test.ts`)
- build: green (`pg` verified present in the standalone output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
