### PR TITLE
fix(bot): match Telegram usernames regardless of stored @ prefix

### DIFF
--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "node --import tsx --test src/**/*.test.ts"
   },
   "dependencies": {
     "@regenhub/shared": "workspace:*",

--- a/apps/bot/src/db/supabase.ts
+++ b/apps/bot/src/db/supabase.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
+import { telegramIlikePatterns } from "./telegram.js";
 
 if (!process.env.SUPABASE_URL) throw new Error("SUPABASE_URL is required");
 if (!process.env.SUPABASE_SERVICE_ROLE_KEY) throw new Error("SUPABASE_SERVICE_ROLE_KEY is required");
@@ -26,8 +27,14 @@ export type MemberRow = {
 };
 
 export async function findMemberByTelegram(username: string): Promise<MemberRow | null> {
-  const handle = username.startsWith("@") ? username : `@${username}`;
-  const { data } = await db.from("members").select("*").ilike("telegram_username", handle).single();
+  const p = telegramIlikePatterns(username);
+  if (!p) return null;
+  const { data } = await db
+    .from("members")
+    .select("*")
+    .or(`telegram_username.ilike.${p.bare},telegram_username.ilike.${p.withAt}`)
+    .limit(1)
+    .maybeSingle();
   return data ?? null;
 }
 

--- a/apps/bot/src/db/telegram.test.ts
+++ b/apps/bot/src/db/telegram.test.ts
@@ -1,0 +1,32 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { telegramIlikePatterns } from "./telegram.js";
+
+test("strips a leading @ from the Telegram input", () => {
+  assert.deepEqual(telegramIlikePatterns("@owocki"), { bare: "owocki", withAt: "@owocki" });
+});
+
+test("bare input yields both stored forms so a row without @ still matches", () => {
+  // michaelgreen06 is stored WITHOUT a leading @ — this is the case that
+  // locked admins out of /quickcode.
+  assert.deepEqual(telegramIlikePatterns("michaelgreen06"), {
+    bare: "michaelgreen06",
+    withAt: "@michaelgreen06",
+  });
+});
+
+test("escapes LIKE metacharacters so _ is literal, not a wildcard", () => {
+  const p = telegramIlikePatterns("vibe_temple");
+  assert.equal(p?.bare, "vibe\\_temple");
+  assert.equal(p?.withAt, "@vibe\\_temple");
+});
+
+test("escapes % and backslash too", () => {
+  assert.equal(telegramIlikePatterns("a%b\\c")?.bare, "a\\%b\\\\c");
+});
+
+test("empty or @-only input returns null (no match attempted)", () => {
+  assert.equal(telegramIlikePatterns(""), null);
+  assert.equal(telegramIlikePatterns("@"), null);
+  assert.equal(telegramIlikePatterns("   "), null);
+});

--- a/apps/bot/src/db/telegram.ts
+++ b/apps/bot/src/db/telegram.ts
@@ -1,0 +1,13 @@
+// Telegram usernames arrive from the API without a leading "@", but stored
+// `telegram_username` values are inconsistent — most carry a "@", some don't
+// (a data-entry drift). Matching must therefore ignore the "@" entirely, or a
+// member whose row happens to lack it silently fails every admin/member gate
+// (this locked admins out of /quickcode). Returns two ilike patterns matching
+// either stored form; LIKE metacharacters are escaped because Telegram handles
+// legally contain "_" (an unescaped "_" is a single-char wildcard).
+export function telegramIlikePatterns(username: string): { bare: string; withAt: string } | null {
+  const bare = username.replace(/^@+/, "").trim();
+  if (!bare) return null;
+  const esc = bare.replace(/([\\%_])/g, "\\$1");
+  return { bare: esc, withAt: `@${esc}` };
+}


### PR DESCRIPTION
## Bug

Both admins reported "Admins only" when running `/quickcode` in Telegram (blocks door-code creation).

## Root cause

The bot looks up members by their Telegram username in `findMemberByTelegram` (`apps/bot/src/db/supabase.ts`), which gates every admin and member command. It force-added a leading `@` and matched with `.ilike(...).single()`:

```ts
const handle = username.startsWith("@") ? username : `@${username}`;
const { data } = await db.from("members").select("*").ilike("telegram_username", handle).single();
```

But stored `telegram_username` values are inconsistent — **12 member rows (including admin Michael Green) have no leading `@`** (e.g. `michaelgreen06`), while most have one (`@UnforcedAG`). The Telegram API never sends `@`, so the code always searched for `@handle` — and those 12 rows could never match, silently failing every gated command. Verified against prod: `ilike '@michaelgreen06'` → 0 rows, `ilike 'michaelgreen06'` → 1.

Two smaller latent issues fixed along the way: `.single()` throws on 0 rows (swallowed, but noisy), and `.ilike` treated `_` as a wildcard — and Telegram handles legally contain `_` (e.g. `vibe_temple`).

## Fix

`findMemberByTelegram` now strips the `@` from the input and matches **either** stored form, case-insensitively, escaping LIKE metacharacters, via `maybeSingle`:

```ts
const p = telegramIlikePatterns(username);   // strips @, escapes \ % _
if (!p) return null;
const { data } = await db.from("members").select("*")
  .or(`telegram_username.ilike.${p.bare},telegram_username.ilike.${p.withAt}`)
  .limit(1).maybeSingle();
```

The pure pattern builder is extracted to `apps/bot/src/db/telegram.ts` with unit tests. Fixes the reported admins plus the other 10 non-`@` members who'd have hit the same wall on member commands.

## Tests / gates

- New `apps/bot/src/db/telegram.test.ts` (5 tests, `node --test` via the existing `tsx` — no new deps): `pnpm --filter bot test` → 5/5.
- `pnpm --filter bot build` (tsc) → clean.
- Query shape validated against the live prod DB (both stored forms + underscore-handle escaping).

## Note

I already applied an immediate data stopgap on prod — normalized Michael Green's row to `@michaelgreen06` — so he's unblocked now on the current build. This PR is the durable fix so a missing `@` can never lock anyone out again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
