### PR TITLE
fix: normalize telegram_username to one canonical form (bare)

### DIFF
--- a/apps/web/src/app/api/admin/members/[id]/route.ts
+++ b/apps/web/src/app/api/admin/members/[id]/route.ts
@@ -62,6 +62,12 @@ export async function PATCH(
     if (key in body) update[key] = body[key];
   }
 
+  // Canonical Telegram handle: bare, no "@" (migration 044); display adds it back.
+  if ("telegram_username" in update) {
+    update.telegram_username =
+      String(update.telegram_username ?? "").trim().replace(/^@+/, "") || null;
+  }
+
   // Auto-assign slot + code when upgrading from day_pass to a permanent type
   const newType = update.member_type as string | undefined;
   const isUpgrade =

--- a/apps/web/src/app/api/admin/members/route.ts
+++ b/apps/web/src/app/api/admin/members/route.ts
@@ -33,7 +33,8 @@ export async function POST(request: Request) {
     is_coop_member: is_coop_member ?? false,
     is_admin: is_admin ?? false,
     day_passes_balance: Math.max(0, parseInt(initial_day_passes) || 0),
-    telegram_username: telegram_username || null,
+    // Canonical form is bare (no "@") — see migration 044; display adds it back.
+    telegram_username: String(telegram_username ?? "").trim().replace(/^@+/, "") || null,
     pin_code: assignedPin,
     supabase_user_id: supabase_user_id || null,
     disabled: false,

--- a/supabase/migrations/044_normalize_telegram_usernames.sql
+++ b/supabase/migrations/044_normalize_telegram_usernames.sql
@@ -1,0 +1,20 @@
+-- Migration 044: one canonical form for members.telegram_username — bare, no "@".
+--
+-- The column drifted into two shapes. The write paths that matter already agree
+-- on bare: application approval (api/admin/applications/[id]/approve) and the
+-- member profile route both `.replace(/^@+/, "")` before storing, and every
+-- display site adds the "@" back for presentation (lifecycle-nudges, freeday,
+-- the MCP audit). But two admin routes stored whatever they were handed, so ~37
+-- rows accumulated a leading "@". The Telegram API never sends "@", so bare is
+-- the true canonical form; the "@"-prefixed rows are the anomaly.
+--
+-- That drift is what silently broke the bot's /quickcode gate for the bare
+-- rows before the matcher was taught to ignore "@" (PR #65). With the matcher
+-- now tolerant of both, this migration removes the ambiguity at the source:
+-- strip any leading "@", trim, and null out anything left empty. Idempotent —
+-- the WHERE clause only touches rows that actually change.
+
+update members
+set telegram_username = nullif(btrim(regexp_replace(telegram_username, '^@+', '')), '')
+where telegram_username is not null
+  and telegram_username is distinct from nullif(btrim(regexp_replace(telegram_username, '^@+', '')), '');


### PR DESCRIPTION
Follow-up to #65, addressing Aaron's "might be better to store telegram handles consistently."

## The drift

`members.telegram_username` exists in two shapes — ~37 rows carry a leading `@`, the rest are bare. The **canonical form is bare** (no `@`): the two write paths that matter already strip it — application approval (`api/admin/applications/[id]/approve`) and the member profile route both `.replace(/^@+/, "")` — and every display site adds the `@` back (lifecycle-nudges, freeday, the MCP audit). The Telegram API never sends `@`, so the bare rows are correct; the `@`-prefixed ones are the anomaly.

That drift is exactly what silently broke `/quickcode` for the bare rows until #65 taught the matcher to ignore `@`.

## Fix

- **migration 044** — strip any leading `@`, trim, null-out-empty across `members`. Idempotent (the `WHERE` only touches rows that change).
- **two admin write routes** (`api/admin/members` POST + `[id]` PATCH) now normalize on write, matching what the approval/profile routes already do — so the drift can't re-accumulate.

## Gates

`pnpm --filter web lint` clean (1 pre-existing warning), `pnpm --filter web build` green.

## Deploy (after merge)

Standard migration flow, now that the MCP tool exists: merge → redeploy web (ships the 044 file) → `run_migration("044_normalize_telegram_usernames.sql")`. First real use of the migration system end to end. I'll drive it and confirm 0 `@`-rows remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
