### PR TITLE
fix: drop no-email 403; participant session + DID linking card

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,10 +224,14 @@ Both doors land the AppView's session cookie on this origin then call the one sh
   `beginOAuth`/`oauthCallback`) plus the three event writes** (`createEvent`/`updateEvent`/
   `deleteEvent`) — nothing else; 404s when the flag is off.
 - `POST /api/auth/regenos/session` — the handoff, shared by both doors. Reads the regenOS session cookie → `getSession`
-  (DID) + `getMyContactPref` (the **verified** login-anchor email) → matches `members` by email →
-  writes `members.did` → mints a Supabase session via `generateLink` + `verifyOtp` (the admin API,
-  no second email). **No member match is not an error**: that's a *participant* — a real session with
-  public features only, sent to `/membership`.
+  (DID) + `getMyContactPref` (the **verified** login-anchor email, if any) → matches `members` by that
+  email, or by `members.did` if there is no email → writes `members.did` → mints a Supabase session via
+  `generateLink` + `verifyOtp` (the admin API, no second email). **No member match is not an error**:
+  that's a *participant* — a real session with public features only, sent to `/membership`.
+  **No verified email is also not an error**: BYOD/passkey accounts mint a participant session against
+  a synthetic `@did.regenhub.invalid` address, or a member session if `members.did` already matches.
+  Unverified email and handle never claim a member row. Linking a DID onto an existing member (already
+  signed in on RegenHub) is `POST /api/auth/regenos/link`, surfaced as a card on `/portal`.
 - The verified email is trustworthy because regenOS seeds it server-side from `email_identities` and
   `saveContactPref` refuses any email that isn't the account's login anchor. We require
   `verified === true` and ignore every other channel.

--- a/apps/web/src/app/api/auth/regenos/link/route.test.ts
+++ b/apps/web/src/app/api/auth/regenos/link/route.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeSupabaseMock } from "../../../../../../test/mockSupabase";
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createServiceClient: vi.fn(),
+}));
+
+vi.mock("@/lib/regenos/config", () => ({
+  isRegenosLoginEnabled: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/regenos/auth", () => ({
+  fetchRegenosIdentity: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/admin";
+import { isRegenosLoginEnabled } from "@/lib/regenos/config";
+import { fetchRegenosIdentity } from "@/lib/regenos/auth";
+
+const DID = "did:plc:byodaccount";
+const USER = { id: "user-1", email: "member@example.com" };
+
+function req() {
+  return new Request("http://localhost:3000/api/auth/regenos/link", {
+    method: "POST",
+    headers: { cookie: "__Host-rs_session=opaque" },
+  });
+}
+
+function makeAdmin(opts: {
+  member?: Record<string, unknown> | null;
+  updateError?: { code?: string; message: string } | null;
+} = {}) {
+  const updates: { table: string; payload: unknown }[] = [];
+  const base = makeSupabaseMock({
+    selects: { members: { data: opts.member ?? null } },
+    mutations: { error: opts.updateError ?? null },
+  });
+  const updateResult = { data: null, error: opts.updateError ?? null };
+  const innerFrom = base.from;
+  const from = vi.fn((table: string) => {
+    const builder = innerFrom(table) as Record<string, unknown>;
+    builder.update = vi.fn((payload: unknown) => {
+      updates.push({ table, payload });
+      const chain: Record<string, unknown> = {
+        eq: vi.fn(() => chain),
+        then: (onfulfilled?: (v: typeof updateResult) => unknown) =>
+          Promise.resolve(updateResult).then(onfulfilled),
+      };
+      return chain;
+    });
+    return builder;
+  });
+  return { ...base, from, __updates: updates };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(isRegenosLoginEnabled).mockReturnValue(true);
+  vi.mocked(fetchRegenosIdentity).mockResolvedValue({
+    did: DID,
+    handle: "byod.test",
+    email: null,
+  });
+  vi.mocked(createClient).mockResolvedValue(
+    makeSupabaseMock({ auth: { user: USER } }) as never,
+  );
+});
+
+describe("POST /api/auth/regenos/link", () => {
+  it("404s when the feature flag is off", async () => {
+    vi.mocked(isRegenosLoginEnabled).mockReturnValue(false);
+    const res = await POST(req());
+    expect(res.status).toBe(404);
+  });
+
+  it("401s when there is no RegenHub session", async () => {
+    vi.mocked(createClient).mockResolvedValue(
+      makeSupabaseMock({ auth: { user: null } }) as never,
+    );
+    const res = await POST(req());
+    expect(res.status).toBe(401);
+  });
+
+  it("401s when there is no regenOS session", async () => {
+    vi.mocked(fetchRegenosIdentity).mockResolvedValue(null);
+    const res = await POST(req());
+    const json = await res.json();
+    expect(res.status).toBe(401);
+    expect(json.error).toMatch(/No regenOS session/);
+  });
+
+  it("403s when the caller is not a member", async () => {
+    vi.mocked(createServiceClient).mockReturnValue(makeAdmin({ member: null }) as never);
+    const res = await POST(req());
+    expect(res.status).toBe(403);
+  });
+
+  it("writes members.did for a logged-in member with a live regenOS session and no prior DID", async () => {
+    const admin = makeAdmin({ member: { id: 42, email: USER.email, did: null } });
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+
+    const res = await POST(req());
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toMatchObject({ ok: true, did: DID, already: false });
+    expect(admin.__updates).toEqual([{ table: "members", payload: { did: DID } }]);
+  });
+
+  it("is a no-op when the DID is already linked to this member", async () => {
+    const admin = makeAdmin({ member: { id: 42, email: USER.email, did: DID } });
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+
+    const res = await POST(req());
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.already).toBe(true);
+    expect(admin.__updates).toEqual([]);
+  });
+
+  it("409s when this membership is already linked to a different DID", async () => {
+    const admin = makeAdmin({
+      member: { id: 42, email: USER.email, did: "did:plc:someoneelse" },
+    });
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+
+    const res = await POST(req());
+    expect(res.status).toBe(409);
+    expect(admin.__updates).toEqual([]);
+  });
+
+  it("409s when another member already holds this DID", async () => {
+    const admin = makeAdmin({
+      member: { id: 42, email: USER.email, did: null },
+      updateError: { code: "23505", message: "duplicate key" },
+    });
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+
+    const res = await POST(req());
+    const json = await res.json();
+    expect(res.status).toBe(409);
+    expect(json.error).toMatch(/already linked to another member/);
+  });
+});

--- a/apps/web/src/app/api/auth/regenos/link/route.ts
+++ b/apps/web/src/app/api/auth/regenos/link/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/admin";
+import { isRegenosLoginEnabled } from "@/lib/regenos/config";
+import { fetchRegenosIdentity } from "@/lib/regenos/auth";
+import { writeDid } from "@/lib/regenos/writeDid";
+
+/**
+ * POST /api/auth/regenos/link — attach a regenOS DID to the logged-in member.
+ *
+ * Possession proof is both sessions at once: a live RegenHub (Supabase) session
+ * AND a live regenOS cookie. Email is not required. This is the BYOD path:
+ * you're already a member (magic-link / existing account), you sign into
+ * regenOS on this origin, we write `members.did`. Unverified email still never
+ * claims anyone else's row — we bind to the caller’s member row only.
+ *
+ * Flag off ⇒ 404.
+ */
+export async function POST(request: Request) {
+  if (!isRegenosLoginEnabled()) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Sign in first." }, { status: 401 });
+  }
+
+  const cookieHeader = request.headers.get("cookie") ?? "";
+  const identity = await fetchRegenosIdentity(cookieHeader);
+  if (!identity) {
+    return NextResponse.json(
+      { error: "No regenOS session. Sign in with regenOS first, then try linking again." },
+      { status: 401 },
+    );
+  }
+
+  const admin = createServiceClient();
+  const { data: member, error: memberError } = await admin
+    .from("members")
+    .select("id, email, did")
+    .eq("supabase_user_id", user.id)
+    .maybeSingle();
+
+  if (memberError) {
+    console.error("[regenOS] link member lookup failed:", memberError);
+    return NextResponse.json({ error: "Couldn't look up your membership." }, { status: 500 });
+  }
+  if (!member) {
+    return NextResponse.json(
+      { error: "Linking is for existing members. Apply to join, or sign in with a membership email." },
+      { status: 403 },
+    );
+  }
+
+  if (member.did && member.did !== identity.did) {
+    return NextResponse.json(
+      {
+        error:
+          "This membership is already linked to a different regenOS identity. Email us and we'll sort it out.",
+      },
+      { status: 409 },
+    );
+  }
+
+  if (member.did === identity.did) {
+    return NextResponse.json({ ok: true, did: identity.did, already: true });
+  }
+
+  const linked = await writeDid(admin, member.id, identity.did);
+  if (!linked.ok) return linked.response;
+
+  return NextResponse.json({ ok: true, did: identity.did, already: false });
+}

--- a/apps/web/src/app/api/auth/regenos/session/route.test.ts
+++ b/apps/web/src/app/api/auth/regenos/session/route.test.ts
@@ -22,6 +22,7 @@ import { createClient } from "@/lib/supabase/server";
 import { createServiceClient } from "@/lib/supabase/admin";
 import { isRegenosLoginEnabled } from "@/lib/regenos/config";
 import { fetchRegenosIdentity } from "@/lib/regenos/auth";
+import { syntheticEmailForDid } from "@/lib/regenos/syntheticEmail";
 
 const DID = "did:plc:regenhubmember";
 const EMAIL = "member@example.com";
@@ -146,15 +147,42 @@ describe("POST /api/auth/regenos/session", () => {
     expect(json.error).toMatch(/No regenOS session/);
   });
 
-  it("403s when the regenOS account has no verified email", async () => {
+  it("mints a participant session when the regenOS account has no verified email", async () => {
     vi.mocked(fetchRegenosIdentity).mockResolvedValue({ did: DID, handle: null, email: null });
-    vi.mocked(createServiceClient).mockReturnValue(makeAdminMock() as never);
+    const admin = makeAdminMock({ member: null });
+    const server = makeServerMock();
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+    vi.mocked(createClient).mockResolvedValue(server as never);
 
     const res = await POST(req());
     const json = await res.json();
 
-    expect(res.status).toBe(403);
-    expect(json.error).toMatch(/no verified email/);
+    expect(res.status).toBe(200);
+    expect(json).toMatchObject({ ok: true, member: false, did: DID, redirect: "/membership" });
+    expect(admin.__updates).toEqual([]);
+    expect(admin.__generateLink).toHaveBeenCalledWith({
+      type: "magiclink",
+      email: syntheticEmailForDid(DID),
+    });
+    expect(server.__verifyOtp).toHaveBeenCalled();
+  });
+
+  it("mints a member session by DID when there is no email but members.did already matches", async () => {
+    vi.mocked(fetchRegenosIdentity).mockResolvedValue({ did: DID, handle: "byod.test", email: null });
+    const admin = makeAdminMock({
+      member: { id: 42, email: EMAIL, did: DID, disabled: false },
+    });
+    const server = makeServerMock();
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+    vi.mocked(createClient).mockResolvedValue(server as never);
+
+    const res = await POST(req());
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toMatchObject({ ok: true, member: true, did: DID, redirect: "/portal" });
+    expect(admin.__updates).toEqual([]);
+    expect(admin.__generateLink).toHaveBeenCalledWith({ type: "magiclink", email: EMAIL });
   });
 
   it("links the DID and mints a Supabase session for a matched member", async () => {

--- a/apps/web/src/app/api/auth/regenos/session/route.ts
+++ b/apps/web/src/app/api/auth/regenos/session/route.ts
@@ -2,7 +2,9 @@ import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { createServiceClient } from "@/lib/supabase/admin";
 import { isRegenosLoginEnabled } from "@/lib/regenos/config";
-import { fetchRegenosIdentity } from "@/lib/regenos/auth";
+import { fetchRegenosIdentity, type RegenosIdentity } from "@/lib/regenos/auth";
+import { syntheticEmailForDid } from "@/lib/regenos/syntheticEmail";
+import { writeDid } from "@/lib/regenos/writeDid";
 
 /**
  * POST /api/auth/regenos/session — the one-login handoff.
@@ -10,11 +12,10 @@ import { fetchRegenosIdentity } from "@/lib/regenos/auth";
  * The caller already holds a live regenOS session cookie on this origin (set
  * by the /xrpc proxy). This route turns that into a RegenHub session:
  *
- *   1. ask regenOS who the caller is (DID + the VERIFIED login-anchor email —
- *      see lib/regenos/auth.ts for why that email is trustworthy);
- *   2. match that email to a `members` row — the SAME email join the four
- *      existing stitching mechanisms already use (triggers 004/013/020 and the
- *      portal's runtime repair, CLAUDE.md "Identity linkage");
+ *   1. ask regenOS who the caller is (DID + optional VERIFIED login-anchor
+ *      email — see lib/regenos/auth.ts for why that email is trustworthy);
+ *   2. match a `members` row by that verified email, or (if none) by
+ *      `members.did`. Unverified email and handle never claim a row;
  *   3. write `members.did` — server-side only. This is deliberately NOT the
  *      profile whitelist (api/portal/profile/route.ts:63-65 says not to add
  *      columns unless they're safe for self-edit; a custodial DID isn't);
@@ -27,6 +28,14 @@ import { fetchRegenosIdentity } from "@/lib/regenos/auth";
  * row, and send them to /membership. That is Aaron's participants tier, and
  * handling it explicitly is the point.
  *
+ * NO VERIFIED EMAIL IS ALSO NOT AN ERROR. A BYOD / passkey regenOS account
+ * has no login-anchor email. Possession proof is the session cookie. If
+ * `members.did` already points at them, they get a member session (minted
+ * against the member's RegenHub email). Otherwise they get a participant
+ * session minted against a synthetic `@did.regenhub.invalid` address. Linking
+ * a DID onto an existing member is POST /api/auth/regenos/link — both
+ * sessions at once, from the portal card.
+ *
  * ── On minting the Supabase session ──────────────────────────────────────────
  * The repo's precedent for server-side identity provisioning is
  * `admin.auth.signInWithOtp({ shouldCreateUser: true })` (api/freeday/route.ts:248,
@@ -36,10 +45,13 @@ import { fetchRegenosIdentity } from "@/lib/regenos/auth";
  * `generateLink` (admin API, sends nothing, returns the hashed token) redeemed
  * immediately by `verifyOtp`, which writes the `sb-regenhub` cookies through
  * the server client's cookie adapter. Provisioning via `createUser` with
- * `email_confirm: true` is honest here: regenOS just proved the address.
+ * `email_confirm: true` is honest here: regenOS just proved possession.
  *
  * Flag off ⇒ 404. The Supabase OTP door is untouched either way.
  */
+
+type MemberHit = { id: number; email: string | null; did: string | null; disabled: boolean };
+
 export async function POST(request: Request) {
   if (!isRegenosLoginEnabled()) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -54,39 +66,17 @@ export async function POST(request: Request) {
     );
   }
 
-  if (!identity.email) {
-    // A BYOD / passkey regenOS account has no email anchor at all. There is
-    // nothing to match on and nothing to prove, so we refuse rather than guess.
-    return NextResponse.json(
-      {
-        error:
-          "That regenOS account has no verified email, so we can't match it to a RegenHub membership.",
-      },
-      { status: 403 },
-    );
-  }
-
-  const email = identity.email;
   const admin = createServiceClient();
 
-  // ── 2. match the membership by verified email ──────────────────────────────
-  const { data: member, error: memberError } = await admin
-    .from("members")
-    .select("id, email, did, disabled")
-    .eq("email", email)
-    .maybeSingle();
-
-  if (memberError) {
-    console.error("[regenOS] member lookup failed:", memberError);
-    return NextResponse.json({ error: "Couldn't look up your membership." }, { status: 500 });
-  }
+  const found = await findMember(admin, identity);
+  if (!found.ok) return found.response;
+  const member = found.member;
 
   // ── 3. write members.did ───────────────────────────────────────────────────
   if (member) {
     if (member.did && member.did !== identity.did) {
-      // One member row, two regenOS identities. regenOS's own email→DID map is
-      // a bijection, so this only happens if the member's email was changed
-      // after a previous link. A human has to decide which one is real.
+      // One member row, two regenOS identities. A human has to decide which
+      // one is real — email match and a prior DID-link disagree.
       console.warn(
         `[regenOS] member ${member.id} already linked to ${member.did}, refusing to relink to ${identity.did}`,
       );
@@ -100,51 +90,36 @@ export async function POST(request: Request) {
     }
 
     if (!member.did) {
-      const { error: linkError } = await admin
-        .from("members")
-        .update({ did: identity.did })
-        .eq("id", member.id);
-
-      if (linkError) {
-        // 23505 = the unique index caught another member already holding this
-        // DID. Same friendly-409 posture as the telegram handle
-        // (api/portal/profile/route.ts:78-86).
-        if ((linkError as { code?: string }).code === "23505") {
-          return NextResponse.json(
-            {
-              error:
-                "That regenOS identity is already linked to another member. Email us and we'll sort it out.",
-            },
-            { status: 409 },
-          );
-        }
-        console.error("[regenOS] did link failed:", linkError);
-        return NextResponse.json({ error: "Couldn't link your regenOS identity." }, { status: 500 });
-      }
+      const linked = await writeDid(admin, member.id, identity.did);
+      if (!linked.ok) return linked.response;
     }
   }
 
   // ── 4. mint the Supabase session ───────────────────────────────────────────
+  // Member email wins (that's the RegenHub account). Verified regenOS email
+  // next. Synthetic DID address last — participants with no email at all.
+  const mintEmail = member?.email ?? identity.email ?? syntheticEmailForDid(identity.did);
+
   // When no auth.users row exists yet, current GoTrue does NOT error here — it
   // auto-creates an unconfirmed user and mints a `signup`-type token (older
   // GoTrue 404s instead, which the branch below handles). Either way trigger
   // 004 links the new auth user to the member row by email on insert, so
-  // supabase_user_id lands for free. The redeem must use the
-  // `verification_type` GoTrue says it minted: redeeming a signup token as
+  // supabase_user_id lands for free when the emails match. The redeem must use
+  // the `verification_type` GoTrue says it minted: redeeming a signup token as
   // "magiclink" fails with "Email link is invalid or has expired", which used
   // to break exactly the first sign-in of every newly provisioned member.
-  let link = await admin.auth.admin.generateLink({ type: "magiclink", email });
+  let link = await admin.auth.admin.generateLink({ type: "magiclink", email: mintEmail });
 
   if (link.error) {
     const { error: createError } = await admin.auth.admin.createUser({
-      email,
+      email: mintEmail,
       email_confirm: true,
     });
     if (createError) {
       console.error("[regenOS] auth user provisioning failed:", createError);
       return NextResponse.json({ error: "Couldn't create your sign-in." }, { status: 500 });
     }
-    link = await admin.auth.admin.generateLink({ type: "magiclink", email });
+    link = await admin.auth.admin.generateLink({ type: "magiclink", email: mintEmail });
   }
 
   const tokenHash = link.data?.properties?.hashed_token;
@@ -171,4 +146,39 @@ export async function POST(request: Request) {
     did: identity.did,
     redirect: member ? "/portal" : "/membership",
   });
+}
+
+async function findMember(
+  admin: ReturnType<typeof createServiceClient>,
+  identity: RegenosIdentity,
+): Promise<{ ok: true; member: MemberHit | null } | { ok: false; response: NextResponse }> {
+  if (identity.email) {
+    const { data, error } = await admin
+      .from("members")
+      .select("id, email, did, disabled")
+      .eq("email", identity.email)
+      .maybeSingle();
+    if (error) {
+      console.error("[regenOS] member lookup failed:", error);
+      return {
+        ok: false,
+        response: NextResponse.json({ error: "Couldn't look up your membership." }, { status: 500 }),
+      };
+    }
+    if (data) return { ok: true, member: data as MemberHit };
+  }
+
+  const { data, error } = await admin
+    .from("members")
+    .select("id, email, did, disabled")
+    .eq("did", identity.did)
+    .maybeSingle();
+  if (error) {
+    console.error("[regenOS] member did lookup failed:", error);
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Couldn't look up your membership." }, { status: 500 }),
+    };
+  }
+  return { ok: true, member: (data as MemberHit | null) ?? null };
 }

--- a/apps/web/src/app/api/portal/application/route.ts
+++ b/apps/web/src/app/api/portal/application/route.ts
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { notifyNewApplication, interestLabel } from "@/lib/applicationNotify";
 import { sendEmail, applicationReceivedEmail } from "@/lib/email";
 import type { MembershipInterest } from "@/lib/supabase/types";
+import { isSyntheticEmail } from "@/lib/regenos/syntheticEmail";
 
 export async function GET() {
   const supabase = await createClient();
@@ -26,16 +27,28 @@ export async function POST(req: Request) {
   const body = await req.json().catch(() => null);
   if (!body) return NextResponse.json({ error: "Invalid request" }, { status: 400 });
 
-  const { name, telegram, about, why_join, membership_interest } = body as {
+  const { name, telegram, about, why_join, membership_interest, email: bodyEmail } = body as {
     name?: string;
     telegram?: string;
     about?: string;
     why_join?: string;
     membership_interest?: MembershipInterest;
+    email?: string;
   };
 
   if (!name?.trim()) {
     return NextResponse.json({ error: "Name is required" }, { status: 400 });
+  }
+
+  let email = user.email ?? "";
+  if (isSyntheticEmail(email)) {
+    email = (bodyEmail ?? "").trim().toLowerCase();
+    if (!email || !email.includes("@") || isSyntheticEmail(email)) {
+      return NextResponse.json({ error: "A real email is required to apply." }, { status: 400 });
+    }
+  }
+  if (!email) {
+    return NextResponse.json({ error: "Email is required" }, { status: 400 });
   }
 
   const telegramHandle = telegram?.trim().replace(/^@+/, "") || null;
@@ -46,7 +59,7 @@ export async function POST(req: Request) {
     .upsert(
       {
         supabase_user_id: user.id,
-        email: user.email!,
+        email,
         name: name.trim(),
         telegram: telegramHandle,
         about: about?.trim() || null,
@@ -70,7 +83,7 @@ export async function POST(req: Request) {
   notifyNewApplication({
     id: data.id,
     name: name.trim(),
-    email: user.email!,
+    email,
     telegram: telegramHandle,
     about: about?.trim() || null,
     why_join: why_join?.trim() || null,
@@ -85,7 +98,7 @@ export async function POST(req: Request) {
     interestLabel: interestLabel(membership_interest ?? "member_basic"),
     siteUrl,
   });
-  sendEmail({ to: user.email!, subject: ackTpl.subject, html: ackTpl.html, text: ackTpl.text })
+  sendEmail({ to: email, subject: ackTpl.subject, html: ackTpl.html, text: ackTpl.text })
     .catch((err) => console.error("[PortalApplication] Ack email failed:", err));
 
   return NextResponse.json({ application: data });

--- a/apps/web/src/app/apply/ApplyForm.tsx
+++ b/apps/web/src/app/apply/ApplyForm.tsx
@@ -23,7 +23,7 @@ const ACCESS_OPTIONS = [
 type MembershipInterest = "daypass_5pack" | "daypass_single" | "hot_desk" | "reserved_desk" | "member_basic" | "member_2day" | "member_5day";
 
 type Props = {
-  /** The signed-in user's email — locked in the form; the application links to their account. */
+  /** The signed-in user's email — locked when real; empty for BYOD/synthetic so they type one. */
   authenticatedEmail: string;
   /** Prefill from the applicant's account / prior application. */
   initial?: {
@@ -41,6 +41,7 @@ const VALID_INTERESTS = new Set<string>(ACCESS_OPTIONS.map((o) => o.value));
 
 export default function ApplyForm({ authenticatedEmail, initial }: Props) {
   const router = useRouter();
+  const emailLocked = Boolean(authenticatedEmail);
   const [form, setForm] = useState({
     name: initial?.name ?? "",
     email: authenticatedEmail,
@@ -73,6 +74,7 @@ export default function ApplyForm({ authenticatedEmail, initial }: Props) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: form.name,
+          ...(emailLocked ? {} : { email: form.email }),
           telegram: form.telegram,
           about: form.about,
           why_join: form.why_join,
@@ -123,13 +125,18 @@ export default function ApplyForm({ authenticatedEmail, initial }: Props) {
                     id="email"
                     type="email"
                     value={form.email}
+                    onChange={emailLocked ? undefined : set("email")}
                     required
                     placeholder="you@example.com"
                     className="glass-input"
-                    readOnly
-                    disabled
+                    readOnly={emailLocked}
+                    disabled={emailLocked}
                   />
-                  <p className="text-xs text-muted">Linked to your signed-in account.</p>
+                  <p className="text-xs text-muted">
+                    {emailLocked
+                      ? "Linked to your signed-in account."
+                      : "Your regenOS account has no email — this is how we'll reach you."}
+                  </p>
                 </div>
               </div>
 

--- a/apps/web/src/app/apply/page.tsx
+++ b/apps/web/src/app/apply/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { LoginForm } from "@/components/auth/LoginForm";
 import ApplyForm from "./ApplyForm";
 import regenHubFull from "@/assets/regenhub-full.svg";
+import { isSyntheticEmail } from "@/lib/regenos/syntheticEmail";
 
 export const metadata: Metadata = {
   title: "Apply for Membership — RegenHub",
@@ -75,7 +76,10 @@ export default async function ApplyPage() {
 
   return (
     <>
-      <ApplyForm authenticatedEmail={user.email!} initial={initial} />
+      <ApplyForm
+        authenticatedEmail={user.email && !isSyntheticEmail(user.email) ? user.email : ""}
+        initial={initial}
+      />
       <div className="px-6 pb-12 -mt-4">
         <p className="text-center text-xs text-muted max-w-md mx-auto">
           Want to try it first?{" "}

--- a/apps/web/src/app/portal/page.tsx
+++ b/apps/web/src/app/portal/page.tsx
@@ -16,6 +16,8 @@ import { MembershipStatusCard } from "@/components/portal/MembershipStatusCard";
 import { InstallPrompt } from "@/components/pwa/InstallPrompt";
 import { planLabel, getPlan } from "@/lib/plans";
 import { isRegenosLoginEnabled } from "@/lib/regenos/config";
+import { isSyntheticEmail } from "@/lib/regenos/syntheticEmail";
+import { LinkRegenOSCard } from "@/components/portal/LinkRegenOSCard";
 
 export default async function PortalPage() {
   const supabase = await createClient();
@@ -32,7 +34,7 @@ export default async function PortalPage() {
   // Auto-link: if no member found by supabase_user_id, try matching by verified email.
   // This handles the case where a member was created via Telegram bot (no supabase_user_id)
   // and then signs in on the web with the same email.
-  if (!member && user.email) {
+  if (!member && user.email && !isSyntheticEmail(user.email)) {
     const admin = createServiceClient();
     const { data: matched } = await admin
       .from("members")
@@ -230,7 +232,9 @@ export default async function PortalPage() {
           <ClipboardList className="w-10 h-10 text-sage mx-auto mb-4" />
           <h2 className="text-xl font-semibold mb-3">Welcome — let&apos;s get you set up</h2>
           <p className="text-muted text-sm mb-6">
-            You&apos;re signed in as <strong className="text-foreground">{user.email}</strong>, but you&apos;re
+            You&apos;re signed in{user.email && !isSyntheticEmail(user.email) ? (
+              <> as <strong className="text-foreground">{user.email}</strong></>
+            ) : null}, but you&apos;re
             not a member yet. Apply to join the cooperative, or try a free day first to feel out the space.
           </p>
           <div className="flex gap-2 flex-wrap justify-center">
@@ -246,6 +250,7 @@ export default async function PortalPage() {
           </div>
         </div>
 
+        {user.email && !isSyntheticEmail(user.email) && (
         <div className="glass-panel p-6">
           <div className="flex items-start gap-3">
             <MessageCircle className="w-5 h-5 text-sage mt-0.5 shrink-0" />
@@ -259,6 +264,7 @@ export default async function PortalPage() {
             </div>
           </div>
         </div>
+        )}
       </div>
     );
   }
@@ -317,6 +323,8 @@ export default async function PortalPage() {
         applicationInterest={application?.membership_interest}
         hasActiveSubscription={!!activeSubscription}
       />
+
+      {isRegenosLoginEnabled() && !member.did && <LinkRegenOSCard />}
 
       <DayPassRedemptionHero member={member} />
 

--- a/apps/web/src/components/portal/LinkRegenOSCard.tsx
+++ b/apps/web/src/components/portal/LinkRegenOSCard.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Link2, Loader2, CheckCircle } from "lucide-react";
+
+/**
+ * BYOD path: a logged-in member with no `members.did` yet. If this browser
+ * already holds a regenOS session, one click writes the DID. Otherwise we
+ * point them at /auth/login to pick up a regenOS session, then they come back.
+ */
+export function LinkRegenOSCard() {
+  const [busy, setBusy] = useState(false);
+  const [handle, setHandle] = useState<string | null | undefined>(undefined);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [linked, setLinked] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/xrpc/social.scenius.getSession", { cache: "no-store" });
+        if (!res.ok) {
+          if (!cancelled) setHandle(null);
+          return;
+        }
+        const data = (await res.json()) as { did?: string; handle?: string };
+        if (cancelled) return;
+        setHandle(data.did ? (data.handle ?? data.did) : null);
+      } catch {
+        if (!cancelled) setHandle(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function link() {
+    setBusy(true);
+    setErr(null);
+    setMsg(null);
+    try {
+      const res = await fetch("/api/auth/regenos/link", { method: "POST" });
+      const json = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        did?: string;
+        already?: boolean;
+        error?: string;
+      };
+      if (!res.ok || !json.ok) {
+        setErr(json.error ?? `Couldn't link (${res.status})`);
+        return;
+      }
+      setLinked(true);
+      setMsg(json.already ? "Already linked." : "Linked this regenOS identity to your membership.");
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (linked) {
+    return (
+      <Card className="glass-panel border border-sage/30">
+        <CardContent className="p-6 flex items-start gap-4">
+          <CheckCircle className="w-7 h-7 text-sage shrink-0 mt-0.5" />
+          <div>
+            <h3 className="font-semibold mb-1">regenOS identity linked</h3>
+            <p className="text-sm text-muted">{msg}</p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const waiting = handle === undefined;
+
+  return (
+    <Card className="glass-panel">
+      <CardContent className="p-6 flex items-start gap-4">
+        <Link2 className="w-7 h-7 text-sage shrink-0 mt-0.5" />
+        <div className="flex-1">
+          <h3 className="font-semibold mb-1">Link your regenOS identity</h3>
+          <p className="text-sm text-muted mb-3">
+            Attach the atproto account you sign in with, even if it has no email.
+            After this, that identity opens your membership without a magic link.
+          </p>
+          {waiting ? (
+            <p className="text-xs text-muted">Checking for a regenOS session…</p>
+          ) : handle ? (
+            <div className="flex items-center gap-3 flex-wrap">
+              <Button
+                type="button"
+                size="sm"
+                className="btn-primary-glass"
+                onClick={link}
+                disabled={busy}
+              >
+                {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Link2 className="w-3.5 h-3.5" />}
+                Link {handle}
+              </Button>
+              {err && <p className="text-xs text-red-400">{err}</p>}
+            </div>
+          ) : (
+            <Link href="/auth/login">
+              <Button type="button" size="sm" className="btn-glass">
+                Sign in with regenOS to link
+              </Button>
+            </Link>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/lib/regenos/signupWizard.test.ts
+++ b/apps/web/src/lib/regenos/signupWizard.test.ts
@@ -144,12 +144,14 @@ describe("finishSession", () => {
   });
 
   it("surfaces the handoff's own error, and never redirects on ok:false", async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(json({ ok: false, error: "No verified email on that account." }, 400));
+    const fetchImpl = vi.fn().mockResolvedValue(
+      json({ ok: false, error: "This membership is already linked to a different regenOS identity." }, 409),
+    );
 
     await expect(finishSession(fetchImpl)).resolves.toEqual({
       ok: false,
       reason: "rejected",
-      message: "No verified email on that account.",
+      message: "This membership is already linked to a different regenOS identity.",
     });
   });
 });

--- a/apps/web/src/lib/regenos/signupWizard.ts
+++ b/apps/web/src/lib/regenos/signupWizard.ts
@@ -205,9 +205,10 @@ interface SessionResponse {
 
 /**
  * `POST /api/auth/regenos/session` — the SAME handoff both existing regenOS doors run
- * (`RegenosLoginPanel.finish()`, `OAuthCallback`): match the verified email to a membership, link
- * the DID, mint the Supabase session. No member match is not an error — that's a participant, and
- * the route says where to send them.
+ * (`RegenosLoginPanel.finish()`, `OAuthCallback`): match verified email (or existing
+ * `members.did`) to a membership, link the DID, mint the Supabase session. No member
+ * match is not an error — that's a participant, and the route says where to send them.
+ * No verified email is also not an error (BYOD / passkey → participant, or member via DID).
  */
 export async function finishSession(
   fetchImpl: typeof fetch = fetch,

--- a/apps/web/src/lib/regenos/syntheticEmail.test.ts
+++ b/apps/web/src/lib/regenos/syntheticEmail.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { isSyntheticEmail, syntheticEmailForDid, SYNTHETIC_EMAIL_DOMAIN } from "./syntheticEmail";
+
+describe("syntheticEmailForDid", () => {
+  it("is stable for a plc did and uses the reserved domain", () => {
+    const did = "did:plc:dl3lexgjfg2euvkqvao4wsgs";
+    const a = syntheticEmailForDid(did);
+    expect(a).toBe(`did-plc-dl3lexgjfg2euvkqvao4wsgs@${SYNTHETIC_EMAIL_DOMAIN}`);
+    expect(syntheticEmailForDid(did)).toBe(a);
+    expect(isSyntheticEmail(a)).toBe(true);
+  });
+
+  it("does not claim a real address", () => {
+    expect(isSyntheticEmail("member@example.com")).toBe(false);
+    expect(isSyntheticEmail(null)).toBe(false);
+  });
+
+  it("hashes instead of truncating a long did", () => {
+    const did = `did:web:${"a".repeat(80)}.example`;
+    const email = syntheticEmailForDid(did);
+    expect(email.startsWith("did-")).toBe(true);
+    expect(email.endsWith(`@${SYNTHETIC_EMAIL_DOMAIN}`)).toBe(true);
+    expect(email.split("@")[0]!.length).toBeLessThanOrEqual(64);
+    expect(syntheticEmailForDid(did)).toBe(email);
+  });
+});

--- a/apps/web/src/lib/regenos/syntheticEmail.ts
+++ b/apps/web/src/lib/regenos/syntheticEmail.ts
@@ -1,0 +1,29 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Auth.users needs an email. A BYOD / passkey regenOS account has none, so we
+ * mint a stable, non-deliverable address derived from the DID. `.invalid` is
+ * RFC 2606 reserved — nothing will ever accept mail there, and it cannot
+ * collide with a real member email.
+ *
+ * Same DID ⇒ same address, so a returning participant gets the same auth row.
+ */
+export const SYNTHETIC_EMAIL_DOMAIN = "did.regenhub.invalid";
+
+const SUFFIX = `@${SYNTHETIC_EMAIL_DOMAIN}`;
+
+export function syntheticEmailForDid(did: string): string {
+  const local = did
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  // Local-part max 64. Long did:web:… hashes rather than truncating (truncation collides).
+  if (local.length > 0 && local.length <= 64) return `${local}${SUFFIX}`;
+  const h = createHash("sha256").update(did).digest("hex").slice(0, 32);
+  return `did-${h}${SUFFIX}`;
+}
+
+export function isSyntheticEmail(email: string | null | undefined): boolean {
+  if (!email) return false;
+  return email.toLowerCase().endsWith(SUFFIX);
+}

--- a/apps/web/src/lib/regenos/writeDid.ts
+++ b/apps/web/src/lib/regenos/writeDid.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import type { createServiceClient } from "@/lib/supabase/admin";
+
+/**
+ * Server-side `members.did` write. Not on the profile whitelist — a custodial
+ * DID isn't self-editable. 23505 → friendly 409, same as telegram handle.
+ */
+export async function writeDid(
+  admin: ReturnType<typeof createServiceClient>,
+  memberId: number,
+  did: string,
+): Promise<{ ok: true } | { ok: false; response: NextResponse }> {
+  const { error } = await admin.from("members").update({ did }).eq("id", memberId);
+  if (!error) return { ok: true };
+  if ((error as { code?: string }).code === "23505") {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        {
+          error:
+            "That regenOS identity is already linked to another member. Email us and we'll sort it out.",
+        },
+        { status: 409 },
+      ),
+    };
+  }
+  console.error("[regenOS] did link failed:", error);
+  return {
+    ok: false,
+    response: NextResponse.json({ error: "Couldn't link your regenOS identity." }, { status: 500 }),
+  };
+}


### PR DESCRIPTION
fix: drop no-email 403; participant session + DID linking card

A BYOD/passkey regenOS account has no verified email. The handoff 403'd instead of minting a participant session.

- Possession proof is the regenOS session cookie, not an email.
- Verified-email match still auto-joins. Else `members.did`. Handle / unverified email never claim a row.
- No member → participant on a synthetic `@did.regenhub.invalid` auth user (RFC 2606 reserved, stable per DID).
- `/portal` linking card → `POST /api/auth/regenos/link` (logged-in member + live regenOS cookie).
- Apply form unlocks email when the session address is synthetic.

186/186 web tests at `b5ea865`. No DB migration.

## Staging demo

Local Next `:3002` + local Supabase + a **stub AppView** that answers `getSession` / `getMyContactPref` with a passkey DID and no email — same contract as production, not a mocked screenshot. Narration says so.

https://github.com/user-attachments/assets/1a79845f-1c7b-41d9-afbe-2f2b2f69fded
