### PR TITLE
feat: Luma paste-import and regenOS membership-claim sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,7 +222,9 @@ Both doors land the AppView's session cookie on this origin then call the one sh
   liminal-web). Needed because the AppView's `__Host-rs_session` cookie forbids a `Domain` attribute
   and can only land on the origin that emitted it. **Allowlisted to the login NSIDs (incl.
   `beginOAuth`/`oauthCallback`) plus the three event writes** (`createEvent`/`updateEvent`/
-  `deleteEvent`) — nothing else; 404s when the flag is off.
+  `deleteEvent`) — nothing else; 404s when the flag is off. Membership-claim sync
+  (`setMembership`/`revokeMembership`) is the admin API talking to the AppView
+  server-to-server, not this proxy.
 - `POST /api/auth/regenos/session` — the handoff, shared by both doors. Reads the regenOS session cookie → `getSession`
   (DID) + `getMyContactPref` (the **verified** login-anchor email, if any) → matches `members` by that
   email, or by `members.did` if there is no email → writes `members.did` → mints a Supabase session via
@@ -238,6 +240,9 @@ Both doors land the AppView's session cookie on this origin then call the one sh
 - `members.did` (migration `042`) is **server-written only** and deliberately absent from the profile
   self-edit whitelist (`api/portal/profile/route.ts:63-65`).
 - `/portal/events` — **Manage Events**, the stewards' in-portal calendar (no link-out to scenius).
+  **Import from Luma** pastes public luma.com / lu.ma URLs/HTML, parses JSON-LD (no Pro API), then
+  `createEvent`s the selected rows. `/admin/members` **Sync claims to regenOS** maps member axes
+  onto `social.scenius.setMembership` (`member|builder|facilitator|steward`) for rows with a DID.
   Server component: Supabase session, then `fetchRegenosIdentity` + `fetchRegenosSceneStanding`
   (`getSceneMembers`, whose `steward` flag is computed for the *caller* through the trust resolver;
   we OR it with a direct Builder+ roster row to mirror the AppView's own `owner_or_builder` write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,8 +241,9 @@ Both doors land the AppView's session cookie on this origin then call the one sh
   self-edit whitelist (`api/portal/profile/route.ts:63-65`).
 - `/portal/events` — **Manage Events**, the stewards' in-portal calendar (no link-out to scenius).
   **Import from Luma** pastes public luma.com / lu.ma URLs/HTML, parses JSON-LD (no Pro API), then
-  `createEvent`s the selected rows. `/admin/members` **Sync claims to regenOS** maps member axes
-  onto `social.scenius.setMembership` (`member|builder|facilitator|steward`) for rows with a DID.
+  `createEvent`s the selected rows. `/admin/members` **Sync claims to regenOS** admits DID-holders
+  as `member` and admins/ops as `steward`. Desk/co-op do **not** map to builder/facilitator
+  (those roles can write events). Builder grants stay explicit on regenOS.
   Server component: Supabase session, then `fetchRegenosIdentity` + `fetchRegenosSceneStanding`
   (`getSceneMembers`, whose `steward` flag is computed for the *caller* through the trust resolver;
   we OR it with a direct Builder+ roster row to mirror the AppView's own `owner_or_builder` write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,9 +242,9 @@ Both doors land the AppView's session cookie on this origin then call the one sh
 - `/portal/events` — **Manage Events**, the stewards' in-portal calendar (no link-out to scenius).
   **Import from Luma** pastes public luma.com / lu.ma URLs/HTML, parses JSON-LD (no Pro API), then
   `createEvent`s the selected rows. `/admin/members` **Sync claims to regenOS** admits paid desk
-  and hub friends (`cold_desk` / `hot_desk` / `hub_friend`) with a DID as scene `member`,
-  admins/ops as `steward`. Day-pass is revoked (404 already-absent is success). Builder grants
-  stay explicit on regenOS — those roles can write events.
+  and hub friends, plus `day_pass` rows with a live subscription (`active`/`trialing`/`past_due`
+  — the $30/$50/$100 ladder). One-off day-pass checkouts (no sub) are revoked. Admins/ops as
+  `steward`. Builder grants stay explicit on regenOS — those roles can write events.
   Server component: Supabase session, then `fetchRegenosIdentity` + `fetchRegenosSceneStanding`
   (`getSceneMembers`, whose `steward` flag is computed for the *caller* through the trust resolver;
   we OR it with a direct Builder+ roster row to mirror the AppView's own `owner_or_builder` write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,9 +241,10 @@ Both doors land the AppView's session cookie on this origin then call the one sh
   self-edit whitelist (`api/portal/profile/route.ts:63-65`).
 - `/portal/events` — **Manage Events**, the stewards' in-portal calendar (no link-out to scenius).
   **Import from Luma** pastes public luma.com / lu.ma URLs/HTML, parses JSON-LD (no Pro API), then
-  `createEvent`s the selected rows. `/admin/members` **Sync claims to regenOS** admits DID-holders
-  as `member` and admins/ops as `steward`. Desk/co-op do **not** map to builder/facilitator
-  (those roles can write events). Builder grants stay explicit on regenOS.
+  `createEvent`s the selected rows. `/admin/members` **Sync claims to regenOS** admits paid desk
+  and hub friends (`cold_desk` / `hot_desk` / `hub_friend`) with a DID as scene `member`,
+  admins/ops as `steward`. Day-pass is revoked (404 already-absent is success). Builder grants
+  stay explicit on regenOS — those roles can write events.
   Server component: Supabase session, then `fetchRegenosIdentity` + `fetchRegenosSceneStanding`
   (`getSceneMembers`, whose `steward` flag is computed for the *caller* through the trust resolver;
   we OR it with a direct Builder+ roster row to mirror the AppView's own `owner_or_builder` write

--- a/apps/web/src/app/admin/members/page.tsx
+++ b/apps/web/src/app/admin/members/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import Link from "next/link";
 import { Search, X } from "lucide-react";
+import { MembershipSyncButton } from "@/components/admin/MembershipSyncButton";
 import type { AdminUsersResponse, AdminUser, AdminUserSubscription } from "@/app/api/admin/users/route";
 import type { Member } from "@/lib/supabase/types";
 import { effectiveMonthlyCents } from "@/lib/stripeNet";
@@ -339,9 +340,12 @@ export default function UsersPage() {
             </p>
           )}
         </div>
-        <Link href="/admin/members/new">
-          <Button className="btn-primary-glass">Add Member</Button>
-        </Link>
+        <div className="flex items-center gap-3 flex-wrap">
+          <MembershipSyncButton />
+          <Link href="/admin/members/new">
+            <Button className="btn-primary-glass">Add Member</Button>
+          </Link>
+        </div>
       </div>
 
       {/* Search + filters */}

--- a/apps/web/src/app/api/admin/membership-sync/route.ts
+++ b/apps/web/src/app/api/admin/membership-sync/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { requireAdmin } from "@/lib/admin";
+import { createServiceClient } from "@/lib/supabase/admin";
+import { fetchRegenosIdentity, fetchRegenosSceneStanding } from "@/lib/regenos/auth";
+import { isRegenosLoginEnabled, regenosCollectiveDid, regenosBaseUrl } from "@/lib/regenos/config";
+import { planMembership } from "@/lib/regenos/membershipRole";
+
+/**
+ * POST /api/admin/membership-sync
+ *
+ * Push RegenHub member axes onto the collective as `coop.lexicon.membership`
+ * claims via `social.scenius.setMembership` / `revokeMembership`. The caller
+ * must be a RegenHub admin AND a regenOS steward of the collective — the
+ * AppView writes the claim AS the scene, using the steward's session.
+ *
+ * Rows with no DID are skipped. Disabled members are revoked.
+ */
+export async function POST() {
+  if (!isRegenosLoginEnabled() || !regenosBaseUrl() || !regenosCollectiveDid()) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  if (!(await requireAdmin())) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const scene = regenosCollectiveDid()!;
+  const cookieHeader = (await cookies()).toString();
+  const identity = await fetchRegenosIdentity(cookieHeader);
+  if (!identity) {
+    return NextResponse.json({ error: "Sign in with regenOS as a steward first." }, { status: 401 });
+  }
+  const standing = await fetchRegenosSceneStanding(cookieHeader, scene, identity.did);
+  if (!standing.steward) {
+    return NextResponse.json({ error: "Only a collective steward can sync membership claims." }, { status: 403 });
+  }
+
+  const admin = createServiceClient();
+  const { data: rows, error } = await admin
+    .from("members")
+    .select("id, name, did, disabled, is_admin, is_ops_admin, is_coop_member, member_type");
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const base = regenosBaseUrl()!;
+  const results: Array<{
+    id: number;
+    name: string;
+    action: string;
+    role?: string;
+    ok: boolean;
+    error?: string;
+  }> = [];
+
+  for (const row of rows ?? []) {
+    const plan = planMembership(row);
+    if (plan.action === "skip") {
+      results.push({ id: row.id, name: row.name, action: "skip", ok: true, error: plan.reason });
+      continue;
+    }
+    const nsid = plan.action === "revoke" ? "social.scenius.revokeMembership" : "social.scenius.setMembership";
+    const body =
+      plan.action === "revoke"
+        ? { scene, member: plan.did }
+        : { scene, member: plan.did, role: plan.role };
+    try {
+      const res = await fetch(`${base}/xrpc/${nsid}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          cookie: cookieHeader,
+        },
+        signal: AbortSignal.timeout(15_000),
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const json = (await res.json().catch(() => null)) as { message?: string; error?: string } | null;
+        results.push({
+          id: row.id,
+          name: row.name,
+          action: plan.action,
+          role: plan.action === "set" ? plan.role : undefined,
+          ok: false,
+          error: json?.message ?? json?.error ?? `HTTP ${res.status}`,
+        });
+        continue;
+      }
+      results.push({
+        id: row.id,
+        name: row.name,
+        action: plan.action,
+        role: plan.action === "set" ? plan.role : undefined,
+        ok: true,
+      });
+    } catch (err) {
+      results.push({
+        id: row.id,
+        name: row.name,
+        action: plan.action,
+        role: plan.action === "set" ? plan.role : undefined,
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const synced = results.filter((r) => r.ok && r.action !== "skip").length;
+  const skipped = results.filter((r) => r.action === "skip").length;
+  const failed = results.filter((r) => !r.ok).length;
+  return NextResponse.json({ scanned: results.length, synced, skipped, failed, results });
+}

--- a/apps/web/src/app/api/admin/membership-sync/route.ts
+++ b/apps/web/src/app/api/admin/membership-sync/route.ts
@@ -14,8 +14,9 @@ import { planMembership } from "@/lib/regenos/membershipRole";
  * must be a RegenHub admin AND a regenOS steward of the collective — the
  * AppView writes the claim AS the scene, using the steward's session.
  *
- * Rows with no DID are skipped. Disabled members are revoked. Desk/co-op
- * do not grant builder/facilitator — those are calendar-write roles.
+ * Scene member = cold_desk / hot_desk / hub_friend with a DID. Day-pass is
+ * revoked (404 already-absent is success). Disabled is revoked. Admins/ops
+ * are steward. Builder/facilitator are not inferred.
  */
 export async function POST() {
   if (!isRegenosLoginEnabled() || !regenosBaseUrl() || !regenosCollectiveDid()) {
@@ -39,7 +40,7 @@ export async function POST() {
   const admin = createServiceClient();
   const { data: rows, error } = await admin
     .from("members")
-    .select("id, name, did, disabled, is_admin, is_ops_admin");
+    .select("id, name, did, disabled, is_admin, is_ops_admin, member_type");
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
@@ -77,6 +78,17 @@ export async function POST() {
       });
       if (!res.ok) {
         const json = (await res.json().catch(() => null)) as { message?: string; error?: string } | null;
+        // revokeMembership 404s when there was nothing to delete — already not a scene member.
+        if (plan.action === "revoke" && res.status === 404) {
+          results.push({
+            id: row.id,
+            name: row.name,
+            action: "revoke",
+            ok: true,
+            error: "already absent",
+          });
+          continue;
+        }
         results.push({
           id: row.id,
           name: row.name,

--- a/apps/web/src/app/api/admin/membership-sync/route.ts
+++ b/apps/web/src/app/api/admin/membership-sync/route.ts
@@ -14,9 +14,9 @@ import { planMembership } from "@/lib/regenos/membershipRole";
  * must be a RegenHub admin AND a regenOS steward of the collective — the
  * AppView writes the claim AS the scene, using the steward's session.
  *
- * Scene member = cold_desk / hot_desk / hub_friend with a DID. Day-pass is
- * revoked (404 already-absent is success). Disabled is revoked. Admins/ops
- * are steward. Builder/facilitator are not inferred.
+ * Scene member = cold_desk / hot_desk / hub_friend, or day_pass with a live
+ * recurring subscription. One-off day-pass checkouts (no sub) are revoked.
+ * 404 already-absent is success. Disabled is revoked. Admins/ops are steward.
  */
 export async function POST() {
   if (!isRegenosLoginEnabled() || !regenosBaseUrl() || !regenosCollectiveDid()) {
@@ -45,6 +45,15 @@ export async function POST() {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
+  const { data: subs, error: subErr } = await admin
+    .from("subscriptions")
+    .select("member_id")
+    .in("status", ["active", "trialing", "past_due"]);
+  if (subErr) {
+    return NextResponse.json({ error: subErr.message }, { status: 500 });
+  }
+  const liveSub = new Set((subs ?? []).map((s) => s.member_id));
+
   const base = regenosBaseUrl()!;
   const results: Array<{
     id: number;
@@ -56,7 +65,10 @@ export async function POST() {
   }> = [];
 
   for (const row of rows ?? []) {
-    const plan = planMembership(row);
+    const plan = planMembership({
+      ...row,
+      hasLiveSubscription: liveSub.has(row.id),
+    });
     if (plan.action === "skip") {
       results.push({ id: row.id, name: row.name, action: "skip", ok: true, error: plan.reason });
       continue;

--- a/apps/web/src/app/api/admin/membership-sync/route.ts
+++ b/apps/web/src/app/api/admin/membership-sync/route.ts
@@ -14,7 +14,8 @@ import { planMembership } from "@/lib/regenos/membershipRole";
  * must be a RegenHub admin AND a regenOS steward of the collective — the
  * AppView writes the claim AS the scene, using the steward's session.
  *
- * Rows with no DID are skipped. Disabled members are revoked.
+ * Rows with no DID are skipped. Disabled members are revoked. Desk/co-op
+ * do not grant builder/facilitator — those are calendar-write roles.
  */
 export async function POST() {
   if (!isRegenosLoginEnabled() || !regenosBaseUrl() || !regenosCollectiveDid()) {
@@ -38,7 +39,7 @@ export async function POST() {
   const admin = createServiceClient();
   const { data: rows, error } = await admin
     .from("members")
-    .select("id, name, did, disabled, is_admin, is_ops_admin, is_coop_member, member_type");
+    .select("id, name, did, disabled, is_admin, is_ops_admin");
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }

--- a/apps/web/src/app/api/portal/events/import-luma/route.ts
+++ b/apps/web/src/app/api/portal/events/import-luma/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createClient } from "@/lib/supabase/server";
+import {
+  extractLumaUrls,
+  fetchLumaHtml,
+  parseLumaHtml,
+  type ParsedLumaEvent,
+} from "@/lib/lumaImport";
+import { fetchRegenosIdentity, fetchRegenosSceneStanding } from "@/lib/regenos/auth";
+import { isRegenosEventsConfigured, isRegenosLoginEnabled, regenosCollectiveDid } from "@/lib/regenos/config";
+
+/**
+ * POST /api/portal/events/import-luma
+ *
+ * Body: `{ text: string }` — pasted luma.com URLs and/or a Luma page's HTML.
+ * Fetches allowed URLs server-side (luma.com only), parses JSON-LD, returns
+ * candidates. Does not write events; the steward confirms and createEvent
+ * runs from the browser with their regenOS cookie.
+ */
+export async function POST(request: Request) {
+  if (!isRegenosLoginEnabled() || !isRegenosEventsConfigured()) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Sign in first." }, { status: 401 });
+
+  const collective = regenosCollectiveDid();
+  if (!collective) return NextResponse.json({ error: "Collective isn't configured." }, { status: 503 });
+
+  const cookieHeader = (await cookies()).toString();
+  const identity = await fetchRegenosIdentity(cookieHeader);
+  if (!identity) {
+    return NextResponse.json({ error: "Sign in with regenOS to import events." }, { status: 401 });
+  }
+  const standing = await fetchRegenosSceneStanding(cookieHeader, collective, identity.did);
+  if (!standing.canManageEvents) {
+    return NextResponse.json({ error: "Only stewards can import events." }, { status: 403 });
+  }
+
+  const body = (await request.json().catch(() => null)) as { text?: string } | null;
+  const text = body?.text?.trim() ?? "";
+  if (!text) return NextResponse.json({ error: "Paste a luma.com URL or page HTML." }, { status: 400 });
+
+  const events: ParsedLumaEvent[] = [];
+  const errors: string[] = [];
+
+  const fromPaste = parseLumaHtml(text);
+  events.push(...fromPaste);
+
+  const have = new Set(events.map((e) => e.url.replace(/\/+$/, "")));
+  const urls = extractLumaUrls(text);
+  for (const url of urls) {
+    if (have.has(url)) continue;
+    try {
+      const { html } = await fetchLumaHtml(url);
+      const parsed = parseLumaHtml(html);
+      if (parsed.length === 0) errors.push(`${url}: no JSON-LD events found`);
+      events.push(...parsed);
+    } catch (err) {
+      errors.push(`${url}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  const seen = new Set<string>();
+  const unique: ParsedLumaEvent[] = [];
+  for (const e of events) {
+    const key = e.url || `${e.name}|${e.startAt}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(e);
+  }
+
+  return NextResponse.json({ events: unique, errors });
+}

--- a/apps/web/src/app/xrpc/[...nsid]/route.test.ts
+++ b/apps/web/src/app/xrpc/[...nsid]/route.test.ts
@@ -107,11 +107,13 @@ describe("xrpc proxy allowlist", () => {
 
   it.each([
     // Neighbours of the allowed writes — near-misses are the ones that matter.
-    "social.scenius.setMembership",
     "social.scenius.adoptEvent",
     "social.scenius.rsvp",
     "social.scenius.inviteToEvent",
     "social.scenius.createScene",
+    // Membership sync is the admin API, not this proxy.
+    "social.scenius.setMembership",
+    "social.scenius.revokeMembership",
   ])("404s the unlisted %s without touching the AppView", async (nsid) => {
     const res = await POST(req(nsid), ctx(nsid));
     expect(res.status).toBe(404);

--- a/apps/web/src/app/xrpc/[...nsid]/route.ts
+++ b/apps/web/src/app/xrpc/[...nsid]/route.ts
@@ -43,9 +43,11 @@ export const runtime = "nodejs";
  *   pre-auth, PUBLIC AppView method (it answers anonymous callers by design)
  * - getSession / getMyContactPref — whoami, read by the browser for UI state
  * - createEvent / updateEvent / deleteEvent — /portal/events, the stewards'
- *   in-portal calendar. These are the only WRITES on the list; each one is
- *   gated server-side by the AppView on Builder+ of the event's authority
+ *   in-portal calendar. Each write is gated server-side by the AppView
  *   (`require_owner_or_builder`), so the proxy widens reach, never authority.
+ * Membership-claim sync does NOT go through this proxy: the admin route talks
+ * to the AppView server-to-server with the steward cookie, and also requires
+ * RegenHub `requireAdmin`.
  */
 const ALLOWED_NSIDS = new Set([
   "social.scenius.beginSignup",

--- a/apps/web/src/components/admin/MembershipSyncButton.tsx
+++ b/apps/web/src/components/admin/MembershipSyncButton.tsx
@@ -12,7 +12,7 @@ export function MembershipSyncButton() {
   async function run() {
     if (
       !window.confirm(
-        "Admit every member with a DID as member, admins/ops as steward? Desk and co-op do not grant calendar write. Disabled members are revoked.",
+        "Admit paid desk and hub friends with a DID as scene members, admins/ops as steward? Day-pass is not a scene member. Disabled members are revoked.",
       )
     ) {
       return;

--- a/apps/web/src/components/admin/MembershipSyncButton.tsx
+++ b/apps/web/src/components/admin/MembershipSyncButton.tsx
@@ -12,7 +12,7 @@ export function MembershipSyncButton() {
   async function run() {
     if (
       !window.confirm(
-        "Admit paid desk and hub friends with a DID as scene members, admins/ops as steward? Day-pass is not a scene member. Disabled members are revoked.",
+        "Admit paid desk, hub friends, and contributing-member subscriptions ($30/$50/$100) with a DID as scene members? One-off day-pass buyers are not. Admins/ops as steward. Disabled members are revoked.",
       )
     ) {
       return;

--- a/apps/web/src/components/admin/MembershipSyncButton.tsx
+++ b/apps/web/src/components/admin/MembershipSyncButton.tsx
@@ -12,7 +12,7 @@ export function MembershipSyncButton() {
   async function run() {
     if (
       !window.confirm(
-        "Push RegenHub roles onto the regenOS collective for every member with a DID? Disabled members are revoked.",
+        "Admit every member with a DID as member, admins/ops as steward? Desk and co-op do not grant calendar write. Disabled members are revoked.",
       )
     ) {
       return;

--- a/apps/web/src/components/admin/MembershipSyncButton.tsx
+++ b/apps/web/src/components/admin/MembershipSyncButton.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Loader2, RefreshCw } from "lucide-react";
+
+export function MembershipSyncButton() {
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function run() {
+    if (
+      !window.confirm(
+        "Push RegenHub roles onto the regenOS collective for every member with a DID? Disabled members are revoked.",
+      )
+    ) {
+      return;
+    }
+    setBusy(true);
+    setMsg(null);
+    setErr(null);
+    try {
+      const res = await fetch("/api/admin/membership-sync", { method: "POST" });
+      const json = (await res.json().catch(() => ({}))) as {
+        synced?: number;
+        skipped?: number;
+        failed?: number;
+        scanned?: number;
+        error?: string;
+      };
+      if (!res.ok) {
+        setErr(json.error ?? `Sync failed (${res.status})`);
+        return;
+      }
+      setMsg(
+        `Synced ${json.synced ?? 0} · skipped ${json.skipped ?? 0}` +
+          ((json.failed ?? 0) > 0 ? ` · ${json.failed} failed` : ""),
+      );
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-3 flex-wrap">
+      <Button type="button" size="sm" className="btn-glass" onClick={run} disabled={busy}>
+        {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <RefreshCw className="w-3.5 h-3.5" />}
+        Sync claims to regenOS
+      </Button>
+      {msg && <p className="text-xs text-sage">{msg}</p>}
+      {err && <p className="text-xs text-red-400">{err}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/components/portal/ImportLumaCard.tsx
+++ b/apps/web/src/components/portal/ImportLumaCard.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Loader2, Download } from "lucide-react";
+import { buildCreateEventInput, mintRkey } from "@/lib/regenos/eventForm";
+import { lumaEventToFormValues, type ParsedLumaEvent } from "@/lib/lumaImport";
+
+async function xrpcPost(nsid: string, body: unknown): Promise<void> {
+  const res = await fetch(`/xrpc/${nsid}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const json = (await res.json().catch(() => null)) as { message?: string; error?: string } | null;
+    throw new Error(json?.message ?? json?.error ?? `regenOS returned ${res.status}`);
+  }
+}
+
+export function ImportLumaCard({
+  authority,
+  onImported,
+}: {
+  authority: string;
+  onImported: () => Promise<void>;
+}) {
+  const [text, setText] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [events, setEvents] = useState<ParsedLumaEvent[]>([]);
+  const [picked, setPicked] = useState<Set<number>>(new Set());
+  const [done, setDone] = useState<string | null>(null);
+
+  async function preview() {
+    setBusy(true);
+    setError(null);
+    setDone(null);
+    try {
+      const res = await fetch("/api/portal/events/import-luma", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text }),
+      });
+      const json = (await res.json()) as {
+        events?: ParsedLumaEvent[];
+        errors?: string[];
+        error?: string;
+      };
+      if (!res.ok) throw new Error(json.error ?? `Preview failed (${res.status})`);
+      const list = json.events ?? [];
+      setEvents(list);
+      setPicked(new Set(list.map((_, i) => i)));
+      if (list.length === 0) {
+        setError(json.errors?.join(" · ") || "No Luma events in that paste.");
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function importPicked() {
+    setImporting(true);
+    setError(null);
+    setDone(null);
+    let ok = 0;
+    const fails: string[] = [];
+    try {
+      for (const i of [...picked].sort((a, b) => a - b)) {
+        const ev = events[i];
+        if (!ev) continue;
+        try {
+          await xrpcPost(
+            "social.scenius.createEvent",
+            buildCreateEventInput(lumaEventToFormValues(ev), { authority, rkey: mintRkey() }),
+          );
+          ok += 1;
+        } catch (e) {
+          fails.push(`${ev.name}: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      }
+      setDone(`Imported ${ok} of ${picked.size}` + (fails.length ? ` · ${fails.length} failed` : ""));
+      if (fails.length) setError(fails.join(" · "));
+      if (ok) await onImported();
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  return (
+    <Card className="glass-panel">
+      <CardContent className="p-6 space-y-3">
+        <h3 className="font-semibold flex items-center gap-2">
+          <Download className="w-4 h-4 text-sage" />
+          Import from Luma
+        </h3>
+        <p className="text-sm text-muted">
+          Paste luma.com event URLs or the HTML of a public Luma page. No Pro API.
+          Preview first, then write to the collective calendar.
+        </p>
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          rows={4}
+          placeholder="https://luma.com/regenhub-mp3c or https://lu.ma/…"
+          className="glass-input w-full px-3 py-2 rounded text-sm font-mono"
+        />
+        <div className="flex gap-2 flex-wrap">
+          <Button type="button" size="sm" className="btn-glass" onClick={preview} disabled={busy || !text.trim()}>
+            {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : null}
+            Preview
+          </Button>
+          {events.length > 0 && (
+            <Button
+              type="button"
+              size="sm"
+              className="btn-primary-glass"
+              onClick={importPicked}
+              disabled={importing || picked.size === 0}
+            >
+              {importing ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : null}
+              Import {picked.size} selected
+            </Button>
+          )}
+        </div>
+        {events.length > 0 && (
+          <ul className="text-sm space-y-1">
+            {events.map((e, i) => (
+              <li key={e.url || `${e.name}-${i}`} className="flex items-start gap-2">
+                <input
+                  type="checkbox"
+                  checked={picked.has(i)}
+                  onChange={() => {
+                    const next = new Set(picked);
+                    if (next.has(i)) next.delete(i);
+                    else next.add(i);
+                    setPicked(next);
+                  }}
+                />
+                <span>
+                  <span className="font-medium">{e.name}</span>
+                  {e.startAt && (
+                    <span className="text-muted">
+                      {" "}
+                      · {new Date(e.startAt).toLocaleString("en-US", { timeZone: "America/Denver" })}
+                    </span>
+                  )}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+        {done && <p className="text-xs text-sage">{done}</p>}
+        {error && <p className="text-xs text-red-400">{error}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/portal/ManageEvents.tsx
+++ b/apps/web/src/components/portal/ManageEvents.tsx
@@ -19,6 +19,7 @@ import {
   type EventFormValues,
   type EventVisibility,
 } from "@/lib/regenos/eventForm";
+import { ImportLumaCard } from "@/components/portal/ImportLumaCard";
 
 export interface ManageableEvent {
   uri: string;
@@ -157,10 +158,15 @@ export function ManageEvents({
       )}
 
       {editing === null ? (
-        <Button onClick={openCreate} className="btn-primary-glass gap-2 px-6">
-          <CalendarPlus className="w-4 h-4" />
-          New event
-        </Button>
+        <>
+          <div className="flex flex-wrap gap-3">
+            <Button onClick={openCreate} className="btn-primary-glass gap-2 px-6">
+              <CalendarPlus className="w-4 h-4" />
+              New event
+            </Button>
+          </div>
+          <ImportLumaCard authority={authority} onImported={refresh} />
+        </>
       ) : (
         <Card className="glass-panel">
           <CardContent className="p-6">

--- a/apps/web/src/lib/lumaImport.test.ts
+++ b/apps/web/src/lib/lumaImport.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { isoToLocalInput } from "@/lib/regenos/eventForm";
 import {
   extractLumaUrls,
   fetchLumaHtml,
@@ -159,8 +160,11 @@ describe("lumaEventToFormValues", () => {
     expect(form.placeName).toBe("RegenHub");
     expect(form.street).toBe("1515 Walnut St");
     expect(form.visibility).toBe("public");
-    expect(form.startsAt).toMatch(/^2026-08-14T/);
-    expect(form.endsAt).toMatch(/^2026-08-14T/);
+    // isoToLocalInput uses the runner's local zone — don't assert a calendar
+    // date from a -06:00 offset (CI is UTC; this box is Denver).
+    expect(form.startsAt).toBe(isoToLocalInput("2026-08-14T15:00:00.000-06:00"));
+    expect(form.endsAt).toBe(isoToLocalInput("2026-08-14T20:30:00.000-06:00"));
+    expect(form.startsAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
   });
 });
 

--- a/apps/web/src/lib/lumaImport.test.ts
+++ b/apps/web/src/lib/lumaImport.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractLumaUrls,
+  fetchLumaHtml,
+  isAllowedLumaUrl,
+  lumaEventToFormValues,
+  parseLumaHtml,
+  splitAddress,
+} from "./lumaImport";
+
+const CALENDAR_LD = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  name: "Upcoming Events on Regen Hub",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      item: {
+        "@type": "Event",
+        url: "https://www.meetup.com/boulder-blockchain/events/315966625/",
+        name: "August '26 Boulder Blockchain Meetup",
+        startDate: "2026-08-11T18:00:00.000-06:00",
+        location: { "@type": "Place", name: "1515 Walnut St suite 200", address: "1515 Walnut St suite 200" },
+      },
+    },
+    {
+      "@type": "ListItem",
+      position: 3,
+      item: {
+        "@type": "Event",
+        url: "https://luma.com/regenhub-mp3c",
+        name: "Co-op Launch Party at RegenHub",
+        startDate: "2026-08-14T15:00:00.000-06:00",
+        endDate: "2026-08-14T20:30:00.000-06:00",
+        location: {
+          "@type": "Place",
+          name: "RegenHub, 1515 Walnut St, Floor 2, Boulder, CO",
+          address: "RegenHub, 1515 Walnut St, Floor 2, Boulder, CO",
+        },
+      },
+    },
+  ],
+});
+
+const PAGE = `<html><script type="application/ld+json">${CALENDAR_LD}</script></html>`;
+
+describe("extractLumaUrls", () => {
+  it("dedupes and ignores non-luma hosts", () => {
+    const text = `
+      https://luma.com/regenhub-mp3c
+      https://luma.com/regenhub-mp3c/
+      https://evil.example/luma.com/nope
+      https://www.luma.com/jikrzhdi
+      https://lu.ma/og5dkqve
+    `;
+    expect(extractLumaUrls(text)).toEqual([
+      "https://luma.com/regenhub-mp3c",
+      "https://www.luma.com/jikrzhdi",
+      "https://lu.ma/og5dkqve",
+    ]);
+  });
+
+  it("rejects javascript and non-luma URLs", () => {
+    expect(isAllowedLumaUrl("https://luma.com/abc")).toBe(true);
+    expect(isAllowedLumaUrl("https://lu.ma/abc")).toBe(true);
+    expect(isAllowedLumaUrl("https://api.lu.ma/public/v1/x")).toBe(false);
+    expect(isAllowedLumaUrl("https://evil.com")).toBe(false);
+  });
+});
+
+describe("parseLumaHtml", () => {
+  it("reads ItemList JSON-LD and keeps luma.com events, dropping Meetup listings", () => {
+    const events = parseLumaHtml(PAGE);
+    expect(events.map((e) => e.name)).toEqual(["Co-op Launch Party at RegenHub"]);
+    expect(events[0]?.url).toBe("https://luma.com/regenhub-mp3c");
+    expect(events[0]?.placeName).toBe("RegenHub");
+    expect(events[0]?.street).toBe("1515 Walnut St");
+  });
+
+  it("accepts a raw JSON-LD Event", () => {
+    const events = parseLumaHtml(
+      JSON.stringify({
+        "@type": "Event",
+        name: "420 Happy Hour",
+        url: "https://luma.com/jikrzhdi",
+        startDate: "2026-08-21T16:00:00.000-06:00",
+        location: { name: "RegenHub", address: "1515 Walnut St, Boulder, CO" },
+      }),
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]?.name).toBe("420 Happy Hour");
+    expect(events[0]?.street).toBe("1515 Walnut St");
+  });
+
+  it("reads a PostalAddress object without treating the street as the place name", () => {
+    const events = parseLumaHtml(
+      JSON.stringify({
+        "@type": "Event",
+        name: "Local AI Meetup",
+        url: "https://luma.com/ilc8qttn",
+        startDate: "2026-09-03T18:00:00.000-06:00",
+        location: {
+          "@type": "Place",
+          name: "1515 Walnut St",
+          address: {
+            "@type": "PostalAddress",
+            streetAddress: "1515 Walnut St",
+            addressLocality: "Boulder",
+          },
+        },
+      }),
+    );
+    expect(events[0]?.placeName).toBe("");
+    expect(events[0]?.street).toBe("1515 Walnut St");
+  });
+});
+
+describe("fetchLumaHtml", () => {
+  it("follows lu.ma → luma.com and refuses a hop off those hosts", async () => {
+    const fetcher = async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "https://lu.ma/abc") {
+        return new Response(null, { status: 301, headers: { location: "https://luma.com/abc" } });
+      }
+      if (url === "https://luma.com/abc") {
+        return new Response("<html>ok</html>", { status: 200, headers: { "content-type": "text/html" } });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    };
+    const page = await fetchLumaHtml("https://lu.ma/abc", fetcher as typeof fetch);
+    expect(page.html).toBe("<html>ok</html>");
+
+    const evil = async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "https://luma.com/abc") {
+        return new Response(null, { status: 302, headers: { location: "https://evil.example/x" } });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    };
+    await expect(fetchLumaHtml("https://luma.com/abc", evil as typeof fetch)).rejects.toThrow(
+      /redirected off luma.com/,
+    );
+  });
+});
+
+describe("lumaEventToFormValues", () => {
+  it("fills the event form, including local datetime-local strings", () => {
+    const form = lumaEventToFormValues({
+      url: "https://luma.com/x",
+      name: "Party",
+      startAt: "2026-08-14T15:00:00.000-06:00",
+      endAt: "2026-08-14T20:30:00.000-06:00",
+      placeName: "RegenHub",
+      street: "1515 Walnut St",
+      description: "",
+    });
+    expect(form.name).toBe("Party");
+    expect(form.placeName).toBe("RegenHub");
+    expect(form.street).toBe("1515 Walnut St");
+    expect(form.visibility).toBe("public");
+    expect(form.startsAt).toMatch(/^2026-08-14T/);
+    expect(form.endsAt).toMatch(/^2026-08-14T/);
+  });
+});
+
+describe("splitAddress", () => {
+  it("pulls the numbered street out of a Luma place string", () => {
+    expect(splitAddress("RegenHub, 1515 Walnut St, Floor 2, Boulder, CO")).toEqual({
+      placeName: "RegenHub",
+      street: "1515 Walnut St",
+    });
+  });
+});

--- a/apps/web/src/lib/lumaImport.ts
+++ b/apps/web/src/lib/lumaImport.ts
@@ -1,0 +1,208 @@
+import { isoToLocalInput, type EventFormValues } from "@/lib/regenos/eventForm";
+
+/**
+ * One-way Luma → regenOS import without a Pro API key.
+ *
+ * Public Luma pages already ship schema.org JSON-LD. We parse that, never
+ * call api.lu.ma. Two-way sync is out of scope.
+ */
+
+export type ParsedLumaEvent = {
+  url: string;
+  name: string;
+  startAt: string | null;
+  endAt: string | null;
+  placeName: string;
+  street: string;
+  description: string;
+};
+
+const LUMA_HOSTS = new Set(["luma.com", "www.luma.com", "lu.ma", "www.lu.ma"]);
+const LUMA_URL_RE = /https?:\/\/(?:www\.)?(?:luma\.com|lu\.ma)\/[A-Za-z0-9_-]+/gi;
+
+export function isAllowedLumaUrl(raw: string): boolean {
+  try {
+    const u = new URL(raw);
+    return (u.protocol === "https:" || u.protocol === "http:") && LUMA_HOSTS.has(u.hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+/** Unique luma.com URLs in paste order. */
+export function extractLumaUrls(text: string): string[] {
+  const found = text.match(LUMA_URL_RE) ?? [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of found) {
+    const url = raw.replace(/\/+$/, "");
+    if (!isAllowedLumaUrl(url) || seen.has(url)) continue;
+    seen.add(url);
+    out.push(url);
+  }
+  return out;
+}
+
+function asArray<T>(v: T | T[] | undefined): T[] {
+  if (v == null) return [];
+  return Array.isArray(v) ? v : [v];
+}
+
+function typeOf(node: { "@type"?: unknown }): string[] {
+  return asArray(node["@type"]).map((t) => String(t).split("/").pop() ?? String(t));
+}
+
+function placeOf(location: unknown): { placeName: string; street: string } {
+  if (!location) return { placeName: "", street: "" };
+  if (typeof location === "string") return splitAddress(location);
+  if (typeof location !== "object") return { placeName: "", street: "" };
+  const loc = location as { name?: unknown; address?: unknown };
+  const name = typeof loc.name === "string" ? loc.name.trim() : "";
+  const named = name.includes(",") ? splitAddress(name) : { placeName: name, street: looksLikeStreet(name) ? name : "" };
+  if (typeof loc.address === "string") {
+    const addr = splitAddress(loc.address);
+    return {
+      placeName: named.placeName || addr.placeName,
+      street: addr.street || named.street,
+    };
+  }
+  if (loc.address && typeof loc.address === "object") {
+    const a = loc.address as { streetAddress?: unknown };
+    const street = typeof a.streetAddress === "string" ? a.streetAddress.trim() : "";
+    return {
+      placeName: looksLikeStreet(name) ? "" : name,
+      street: street || (looksLikeStreet(name) ? name : ""),
+    };
+  }
+  return { placeName: name, street: looksLikeStreet(name) ? name : "" };
+}
+
+function looksLikeStreet(s: string): boolean {
+  return /^\d+\s/.test(s.trim());
+}
+
+/** "RegenHub, 1515 Walnut St, Floor 2, Boulder, CO" → place + street. */
+export function splitAddress(raw: string): { placeName: string; street: string } {
+  const parts = raw.split(",").map((p) => p.trim()).filter(Boolean);
+  const streetPart = parts.find((p) => looksLikeStreet(p));
+  const place = parts.find((p) => p !== streetPart && !/^(Boulder|CO|Colorado|US|USA)$/i.test(p));
+  return { placeName: place ?? "", street: streetPart ?? "" };
+}
+
+function eventFromNode(node: Record<string, unknown>): ParsedLumaEvent | null {
+  const types = typeOf(node);
+  if (!types.includes("Event")) return null;
+  const name = typeof node.name === "string" ? node.name.trim() : "";
+  if (!name) return null;
+  const url = typeof node.url === "string" ? node.url : typeof node["@id"] === "string" ? node["@id"] : "";
+  const startAt = typeof node.startDate === "string" ? node.startDate : null;
+  const endAt = typeof node.endDate === "string" ? node.endDate : null;
+  const place = placeOf(node.location);
+  const description = typeof node.description === "string" ? node.description.trim() : "";
+  return { url, name, startAt, endAt, placeName: place.placeName, street: place.street, description };
+}
+
+function walk(node: unknown, out: ParsedLumaEvent[]): void {
+  if (node == null) return;
+  if (Array.isArray(node)) {
+    for (const n of node) walk(n, out);
+    return;
+  }
+  if (typeof node !== "object") return;
+  const rec = node as Record<string, unknown>;
+  const ev = eventFromNode(rec);
+  if (ev) out.push(ev);
+  const types = typeOf(rec);
+  if (types.includes("ItemList")) {
+    for (const item of asArray(rec.itemListElement)) {
+      if (item && typeof item === "object") {
+        const li = item as { item?: unknown };
+        walk(li.item ?? item, out);
+      }
+    }
+  }
+  if (rec["@graph"]) walk(rec["@graph"], out);
+}
+
+/** Pull schema.org Event objects out of a Luma HTML page (or raw JSON-LD). */
+export function parseLumaHtml(html: string): ParsedLumaEvent[] {
+  const blocks: unknown[] = [];
+  const re = /<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html))) {
+    try {
+      blocks.push(JSON.parse(m[1]!));
+    } catch {
+      // skip broken ld+json
+    }
+  }
+  if (blocks.length === 0) {
+    try {
+      blocks.push(JSON.parse(html));
+    } catch {
+      return [];
+    }
+  }
+  const out: ParsedLumaEvent[] = [];
+  for (const b of blocks) walk(b, out);
+  // Prefer luma.com events when a calendar page mixed in Meetup listings.
+  const lumaOnly = out.filter((e) => !e.url || isAllowedLumaUrl(e.url));
+  const chosen = lumaOnly.length > 0 ? lumaOnly : out;
+  const seen = new Set<string>();
+  const uniq: ParsedLumaEvent[] = [];
+  for (const e of chosen) {
+    const key = e.url || `${e.name}|${e.startAt}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    uniq.push(e);
+  }
+  return uniq;
+}
+
+/**
+ * Fetch a public Luma page. Follows at most 3 hops, and only onto luma.com / lu.ma
+ * (so a 301 from lu.ma → luma.com works; a hop off those hosts does not).
+ */
+export async function fetchLumaHtml(
+  startUrl: string,
+  fetcher: typeof fetch = fetch,
+): Promise<{ url: string; html: string }> {
+  if (!isAllowedLumaUrl(startUrl)) throw new Error("not a luma URL");
+  let url = startUrl;
+  for (let hop = 0; hop < 4; hop++) {
+    const res = await fetcher(url, {
+      headers: { accept: "text/html", "user-agent": "RegenHubLumaImport/1" },
+      redirect: "manual",
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (res.status >= 300 && res.status < 400) {
+      const loc = res.headers.get("location") ?? "";
+      let next: string;
+      try {
+        next = new URL(loc, url).href;
+      } catch {
+        throw new Error(`${url}: redirected off luma.com`);
+      }
+      if (!isAllowedLumaUrl(next)) throw new Error(`${url}: redirected off luma.com`);
+      url = next.replace(/\/+$/, "");
+      continue;
+    }
+    if (!res.ok) throw new Error(`${url}: HTTP ${res.status}`);
+    return { url, html: await res.text() };
+  }
+  throw new Error(`${startUrl}: too many redirects`);
+}
+
+export function lumaEventToFormValues(e: ParsedLumaEvent): EventFormValues {
+  return {
+    name: e.name,
+    description: e.description,
+    startsAt: isoToLocalInput(e.startAt),
+    endsAt: isoToLocalInput(e.endAt),
+    placeName: e.placeName,
+    street: e.street,
+    postalCode: "",
+    visibility: "public",
+    attendance: "open",
+  };
+}

--- a/apps/web/src/lib/regenos/membershipRole.test.ts
+++ b/apps/web/src/lib/regenos/membershipRole.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { planMembership, type MemberAxes } from "./membershipRole";
+
+const base: MemberAxes = {
+  did: "did:plc:alice",
+  disabled: false,
+  is_admin: false,
+  is_ops_admin: false,
+  is_coop_member: false,
+  member_type: "hub_friend",
+};
+
+describe("planMembership", () => {
+  it("skips rows with no DID", () => {
+    expect(planMembership({ ...base, did: null })).toEqual({ action: "skip", reason: "no DID" });
+    expect(planMembership({ ...base, did: "  " })).toEqual({ action: "skip", reason: "no DID" });
+  });
+
+  it("revokes a disabled member who still has a DID", () => {
+    expect(planMembership({ ...base, disabled: true })).toEqual({
+      action: "revoke",
+      did: "did:plc:alice",
+    });
+  });
+
+  it("maps admin / ops-admin to steward, co-op to facilitator, desk to builder", () => {
+    expect(planMembership({ ...base, is_admin: true })).toMatchObject({ role: "steward" });
+    expect(planMembership({ ...base, is_ops_admin: true })).toMatchObject({ role: "steward" });
+    expect(planMembership({ ...base, is_coop_member: true })).toMatchObject({ role: "facilitator" });
+    expect(planMembership({ ...base, member_type: "hot_desk" })).toMatchObject({ role: "builder" });
+    expect(planMembership({ ...base, member_type: "cold_desk" })).toMatchObject({ role: "builder" });
+    expect(planMembership({ ...base, member_type: "day_pass" })).toMatchObject({ role: "member" });
+  });
+
+  it("admin wins over desk type", () => {
+    expect(planMembership({ ...base, is_admin: true, member_type: "hot_desk" })).toMatchObject({
+      role: "steward",
+    });
+  });
+});

--- a/apps/web/src/lib/regenos/membershipRole.test.ts
+++ b/apps/web/src/lib/regenos/membershipRole.test.ts
@@ -6,6 +6,7 @@ const base: MemberAxes = {
   disabled: false,
   is_admin: false,
   is_ops_admin: false,
+  member_type: "hub_friend",
 };
 
 describe("planMembership", () => {
@@ -21,9 +22,26 @@ describe("planMembership", () => {
     });
   });
 
-  it("maps admin / ops-admin to steward; everyone else with a DID is member", () => {
+  it("maps admin / ops-admin to steward even if their type is day_pass", () => {
     expect(planMembership({ ...base, is_admin: true })).toMatchObject({ role: "steward" });
-    expect(planMembership({ ...base, is_ops_admin: true })).toMatchObject({ role: "steward" });
+    expect(
+      planMembership({ ...base, is_ops_admin: true, member_type: "day_pass" }),
+    ).toMatchObject({ role: "steward" });
+  });
+
+  it("admits paid desk and hub friends as member; revokes day-pass", () => {
+    expect(planMembership({ ...base, member_type: "cold_desk" })).toMatchObject({
+      action: "set",
+      role: "member",
+    });
+    expect(planMembership({ ...base, member_type: "hot_desk" })).toMatchObject({
+      action: "set",
+      role: "member",
+    });
     expect(planMembership(base)).toMatchObject({ action: "set", role: "member" });
+    expect(planMembership({ ...base, member_type: "day_pass" })).toEqual({
+      action: "revoke",
+      did: "did:plc:alice",
+    });
   });
 });

--- a/apps/web/src/lib/regenos/membershipRole.test.ts
+++ b/apps/web/src/lib/regenos/membershipRole.test.ts
@@ -6,8 +6,6 @@ const base: MemberAxes = {
   disabled: false,
   is_admin: false,
   is_ops_admin: false,
-  is_coop_member: false,
-  member_type: "hub_friend",
 };
 
 describe("planMembership", () => {
@@ -23,18 +21,9 @@ describe("planMembership", () => {
     });
   });
 
-  it("maps admin / ops-admin to steward, co-op to facilitator, desk to builder", () => {
+  it("maps admin / ops-admin to steward; everyone else with a DID is member", () => {
     expect(planMembership({ ...base, is_admin: true })).toMatchObject({ role: "steward" });
     expect(planMembership({ ...base, is_ops_admin: true })).toMatchObject({ role: "steward" });
-    expect(planMembership({ ...base, is_coop_member: true })).toMatchObject({ role: "facilitator" });
-    expect(planMembership({ ...base, member_type: "hot_desk" })).toMatchObject({ role: "builder" });
-    expect(planMembership({ ...base, member_type: "cold_desk" })).toMatchObject({ role: "builder" });
-    expect(planMembership({ ...base, member_type: "day_pass" })).toMatchObject({ role: "member" });
-  });
-
-  it("admin wins over desk type", () => {
-    expect(planMembership({ ...base, is_admin: true, member_type: "hot_desk" })).toMatchObject({
-      role: "steward",
-    });
+    expect(planMembership(base)).toMatchObject({ action: "set", role: "member" });
   });
 });

--- a/apps/web/src/lib/regenos/membershipRole.test.ts
+++ b/apps/web/src/lib/regenos/membershipRole.test.ts
@@ -7,6 +7,7 @@ const base: MemberAxes = {
   is_admin: false,
   is_ops_admin: false,
   member_type: "hub_friend",
+  hasLiveSubscription: false,
 };
 
 describe("planMembership", () => {
@@ -29,7 +30,7 @@ describe("planMembership", () => {
     ).toMatchObject({ role: "steward" });
   });
 
-  it("admits paid desk and hub friends as member; revokes day-pass", () => {
+  it("admits paid desk and hub friends as member without a subscription row", () => {
     expect(planMembership({ ...base, member_type: "cold_desk" })).toMatchObject({
       action: "set",
       role: "member",
@@ -39,9 +40,15 @@ describe("planMembership", () => {
       role: "member",
     });
     expect(planMembership(base)).toMatchObject({ action: "set", role: "member" });
+  });
+
+  it("admits day-pass only when a live recurring subscription is on the row", () => {
     expect(planMembership({ ...base, member_type: "day_pass" })).toEqual({
       action: "revoke",
       did: "did:plc:alice",
     });
+    expect(
+      planMembership({ ...base, member_type: "day_pass", hasLiveSubscription: true }),
+    ).toMatchObject({ action: "set", role: "member" });
   });
 });

--- a/apps/web/src/lib/regenos/membershipRole.ts
+++ b/apps/web/src/lib/regenos/membershipRole.ts
@@ -2,17 +2,21 @@
  * Map a RegenHub members row onto a regenOS lexicon role for
  * `social.scenius.setMembership`.
  *
- * Scene `member` is the paid roster plus hub friends — the people who
- * should see member-only events later. Day-pass is not that; a leftover
- * claim is revoked (404 "already absent" is success at the route).
+ * Scene `member` is who should see member-only events later:
+ *   - cold_desk / hot_desk / hub_friend (the permanent roster)
+ *   - day_pass WITH a live recurring subscription ($30/$50/$100 ladder)
+ *
+ * A one-off day-pass checkout also creates a `day_pass` row (no
+ * subscription). Those are not scene members. Leftover claims revoke
+ * (404 "already absent" is success at the route).
  *
  * This sync does **not** infer calendar write from billing. Builder+
  * (`owner_or_builder`) can create/edit events; those grants stay explicit
  * on regenOS.
  *
  *   steward — is_admin / is_ops_admin
- *   member  — cold_desk / hot_desk / hub_friend
- *   revoke  — disabled, or a DID that isn't a scene member (day_pass)
+ *   member  — permanent types, or day_pass + live sub
+ *   revoke  — disabled, or a DID that isn't a scene member
  *
  * No DID → skip.
  */
@@ -21,7 +25,7 @@ import type { MemberType } from "@/lib/supabase/types";
 
 export type LexiconRole = "member" | "builder" | "facilitator" | "steward";
 
-const SCENE_MEMBER_TYPES = new Set<MemberType>(["cold_desk", "hot_desk", "hub_friend"]);
+const PERMANENT_TYPES = new Set<MemberType>(["cold_desk", "hot_desk", "hub_friend"]);
 
 export type MemberAxes = {
   did: string | null;
@@ -29,6 +33,8 @@ export type MemberAxes = {
   is_admin: boolean;
   is_ops_admin: boolean;
   member_type: string;
+  /** Live Stripe sub: active / trialing / past_due. */
+  hasLiveSubscription: boolean;
 };
 
 export type MembershipPlan =
@@ -41,7 +47,10 @@ export function planMembership(m: MemberAxes): MembershipPlan {
   if (!did) return { action: "skip", reason: "no DID" };
   if (m.disabled) return { action: "revoke", did };
   if (m.is_admin || m.is_ops_admin) return { action: "set", did, role: "steward" };
-  if (SCENE_MEMBER_TYPES.has(m.member_type as MemberType)) {
+  if (PERMANENT_TYPES.has(m.member_type as MemberType)) {
+    return { action: "set", did, role: "member" };
+  }
+  if (m.member_type === "day_pass" && m.hasLiveSubscription) {
     return { action: "set", did, role: "member" };
   }
   return { action: "revoke", did };

--- a/apps/web/src/lib/regenos/membershipRole.ts
+++ b/apps/web/src/lib/regenos/membershipRole.ts
@@ -2,15 +2,16 @@
  * Map a RegenHub members row onto a regenOS lexicon role for
  * `social.scenius.setMembership`.
  *
- * Wire roles are the lexicon strings (member|builder|facilitator|steward),
- * not the internal 10/20/30/40 numbers. Highest matching axis wins.
+ * This sync does **not** infer calendar write from billing. On the AppView,
+ * builder+ (`owner_or_builder`) can create/edit events. Paying for a desk
+ * or holding co-op membership is access to the space, not stewardship of
+ * the collective calendar. Builder / facilitator grants stay explicit on
+ * regenOS (or a later RegenHub flag) — they are not a column here.
  *
- *   steward     — is_admin / is_ops_admin (the people who can run this sync)
- *   facilitator — is_coop_member
- *   builder     — hot_desk / cold_desk
- *   member      — everyone else with a DID (hub_friend, day_pass, approved)
+ *   steward — is_admin / is_ops_admin
+ *   member  — everyone else with a DID
  *
- * No DID → skip (nothing to claim). Disabled + DID → revoke.
+ * No DID → skip. Disabled + DID → revoke.
  */
 
 export type LexiconRole = "member" | "builder" | "facilitator" | "steward";
@@ -20,8 +21,6 @@ export type MemberAxes = {
   disabled: boolean;
   is_admin: boolean;
   is_ops_admin: boolean;
-  is_coop_member: boolean;
-  member_type: string;
 };
 
 export type MembershipPlan =
@@ -34,9 +33,5 @@ export function planMembership(m: MemberAxes): MembershipPlan {
   if (!did) return { action: "skip", reason: "no DID" };
   if (m.disabled) return { action: "revoke", did };
   if (m.is_admin || m.is_ops_admin) return { action: "set", did, role: "steward" };
-  if (m.is_coop_member) return { action: "set", did, role: "facilitator" };
-  if (m.member_type === "hot_desk" || m.member_type === "cold_desk") {
-    return { action: "set", did, role: "builder" };
-  }
   return { action: "set", did, role: "member" };
 }

--- a/apps/web/src/lib/regenos/membershipRole.ts
+++ b/apps/web/src/lib/regenos/membershipRole.ts
@@ -2,25 +2,33 @@
  * Map a RegenHub members row onto a regenOS lexicon role for
  * `social.scenius.setMembership`.
  *
- * This sync does **not** infer calendar write from billing. On the AppView,
- * builder+ (`owner_or_builder`) can create/edit events. Paying for a desk
- * or holding co-op membership is access to the space, not stewardship of
- * the collective calendar. Builder / facilitator grants stay explicit on
- * regenOS (or a later RegenHub flag) — they are not a column here.
+ * Scene `member` is the paid roster plus hub friends — the people who
+ * should see member-only events later. Day-pass is not that; a leftover
+ * claim is revoked (404 "already absent" is success at the route).
+ *
+ * This sync does **not** infer calendar write from billing. Builder+
+ * (`owner_or_builder`) can create/edit events; those grants stay explicit
+ * on regenOS.
  *
  *   steward — is_admin / is_ops_admin
- *   member  — everyone else with a DID
+ *   member  — cold_desk / hot_desk / hub_friend
+ *   revoke  — disabled, or a DID that isn't a scene member (day_pass)
  *
- * No DID → skip. Disabled + DID → revoke.
+ * No DID → skip.
  */
 
+import type { MemberType } from "@/lib/supabase/types";
+
 export type LexiconRole = "member" | "builder" | "facilitator" | "steward";
+
+const SCENE_MEMBER_TYPES = new Set<MemberType>(["cold_desk", "hot_desk", "hub_friend"]);
 
 export type MemberAxes = {
   did: string | null;
   disabled: boolean;
   is_admin: boolean;
   is_ops_admin: boolean;
+  member_type: string;
 };
 
 export type MembershipPlan =
@@ -33,5 +41,8 @@ export function planMembership(m: MemberAxes): MembershipPlan {
   if (!did) return { action: "skip", reason: "no DID" };
   if (m.disabled) return { action: "revoke", did };
   if (m.is_admin || m.is_ops_admin) return { action: "set", did, role: "steward" };
-  return { action: "set", did, role: "member" };
+  if (SCENE_MEMBER_TYPES.has(m.member_type as MemberType)) {
+    return { action: "set", did, role: "member" };
+  }
+  return { action: "revoke", did };
 }

--- a/apps/web/src/lib/regenos/membershipRole.ts
+++ b/apps/web/src/lib/regenos/membershipRole.ts
@@ -1,0 +1,42 @@
+/**
+ * Map a RegenHub members row onto a regenOS lexicon role for
+ * `social.scenius.setMembership`.
+ *
+ * Wire roles are the lexicon strings (member|builder|facilitator|steward),
+ * not the internal 10/20/30/40 numbers. Highest matching axis wins.
+ *
+ *   steward     — is_admin / is_ops_admin (the people who can run this sync)
+ *   facilitator — is_coop_member
+ *   builder     — hot_desk / cold_desk
+ *   member      — everyone else with a DID (hub_friend, day_pass, approved)
+ *
+ * No DID → skip (nothing to claim). Disabled + DID → revoke.
+ */
+
+export type LexiconRole = "member" | "builder" | "facilitator" | "steward";
+
+export type MemberAxes = {
+  did: string | null;
+  disabled: boolean;
+  is_admin: boolean;
+  is_ops_admin: boolean;
+  is_coop_member: boolean;
+  member_type: string;
+};
+
+export type MembershipPlan =
+  | { action: "skip"; reason: string }
+  | { action: "revoke"; did: string }
+  | { action: "set"; did: string; role: LexiconRole };
+
+export function planMembership(m: MemberAxes): MembershipPlan {
+  const did = m.did?.trim() || null;
+  if (!did) return { action: "skip", reason: "no DID" };
+  if (m.disabled) return { action: "revoke", did };
+  if (m.is_admin || m.is_ops_admin) return { action: "set", did, role: "steward" };
+  if (m.is_coop_member) return { action: "set", did, role: "facilitator" };
+  if (m.member_type === "hot_desk" || m.member_type === "cold_desk") {
+    return { action: "set", did, role: "builder" };
+  }
+  return { action: "set", did, role: "member" };
+}


### PR DESCRIPTION
Luma paste-import (no Pro API) + one-way membership-claim sync, one PR.

## Luma → regenOS

Public luma.com / lu.ma pages already ship schema.org JSON-LD. Stewards paste URLs or HTML on `/portal/events`, we fetch **only those hosts** (`lu.ma` 301 → `luma.com` is allowed; a hop off them is not), preview, then `createEvent` the selected rows. Meetup listings on a mixed calendar page are dropped when luma.com events exist.

Does not call `api.lu.ma`. Two-way sync is out of scope.

## Membership claims

`/admin/members` **Sync claims to regenOS**:

- scene `member` = paid desk + hub friend, **or** `day_pass` with a live subscription (`active`/`trialing`/`past_due` — the $30/$50/$100 ladder)
- admin/ops → `steward`
- one-off day-pass checkout (no sub) → revoke (404 already-absent is success)
- disabled → revoke

Public events stay public — no scene claim required to see them. Member-only events later use this roster as the paywall. Builder/facilitator (calendar write) stay explicit on regenOS.

`1b11ff0` dropped desk→builder. `a8719d2` narrowed the roster. `a283ca4` puts contributing-member day-pass subscribers back on.

The admin route talks to the AppView **server-to-server** with the steward cookie **and** `requireAdmin`. Those NSIDs stay off the public XRPC proxy.

Confirm dialog before the bulk write.

## Tests

`pnpm --filter web test` → **200/200** at `a283ca4`.

No migration. After merge I deploy; nothing to run on the DB.

## Demo

Narrated staging video in the first comment. Honest about the stack: local Next `127.0.0.1:3003` + local Supabase, **stub AppView** for session / `createEvent` / `setMembership`. The Luma fetch in the video is **real** `luma.com/regenhub` JSON-LD (Local AI Meetup + 420 Happy Hour).
