### PR TITLE
refactor: share membership access lifecycle

### DIFF
--- a/apps/web/src/app/api/cron/past-due-sweep/route.ts
+++ b/apps/web/src/app/api/cron/past-due-sweep/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
 import { createServiceClient } from "@/lib/supabase/admin";
-import { clearUserCode, formatLockStatus } from "@regenhub/shared";
-
-const GRACE_DAYS = 7;
+import {
+  BILLING_GRACE_DAYS,
+  downgradeMembershipAccess,
+} from "@/lib/membershipLifecycle";
 
 async function notifyTelegram(text: string) {
   const token = process.env.TELEGRAM_BOT_TOKEN;
@@ -46,7 +47,9 @@ export async function POST(req: Request) {
   }
 
   const admin = createServiceClient();
-  const cutoff = new Date(Date.now() - GRACE_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  const cutoff = new Date(
+    Date.now() - BILLING_GRACE_DAYS * 24 * 60 * 60 * 1000,
+  ).toISOString();
 
   type StaleRow = {
     id: number;
@@ -90,27 +93,18 @@ export async function POST(req: Request) {
       const wasFullMember =
         row.members?.member_type === "cold_desk" || row.members?.member_type === "hot_desk";
       const slot = row.members?.pin_code_slot ?? null;
-      const memberUpdate: { member_type: "day_pass"; pin_code_slot?: null; pin_code?: null } = {
-        member_type: "day_pass",
-      };
       let lockRevokeNote = "";
-      if (wasFullMember && slot) {
-        memberUpdate.pin_code_slot = null;
-        memberUpdate.pin_code = null;
-        try {
-          const lockResults = await clearUserCode(slot);
-          lockRevokeNote = `\n\n🔒 Cleared PIN slot ${slot}: ${formatLockStatus(lockResults)}`;
-        } catch (err) {
-          console.error(`[PastDueCron] Lock revoke failed for slot ${slot}:`, err);
-          lockRevokeNote = `\n\n⚠️ *Action needed:* Lock revoke failed for slot ${slot}. Run Lock Sync from /admin/access.`;
-        }
+      const downgrade = await downgradeMembershipAccess(admin, {
+        memberId: row.member_id,
+        currentPinSlot: slot,
+        revokePermanentPin: wasFullMember,
+      });
+      if (downgrade.memberUpdateError) throw downgrade.memberUpdateError;
+      if (downgrade.revokedSlot && downgrade.lockRevokeFailed) {
+        lockRevokeNote = `\n\n⚠️ *Action needed:* Lock revoke failed for slot ${downgrade.revokedSlot}. Run Lock Sync from /admin/access.`;
+      } else if (downgrade.revokedSlot && downgrade.lockStatus) {
+        lockRevokeNote = `\n\n🔒 Cleared PIN slot ${downgrade.revokedSlot}: ${downgrade.lockStatus}`;
       }
-
-      const { error: memErr } = await admin
-        .from("members")
-        .update(memberUpdate)
-        .eq("id", row.member_id);
-      if (memErr) throw memErr;
 
       const name = row.members?.name ?? "A member";
       await notifyTelegram(

--- a/apps/web/src/app/api/webhooks/stripe/route.ts
+++ b/apps/web/src/app/api/webhooks/stripe/route.ts
@@ -13,14 +13,9 @@ import {
 } from "@/lib/email";
 import type { StripeSubscriptionStatus } from "@/lib/supabase/types";
 import {
-  allocateSlotWithRetry,
-  setUserCode,
-  clearUserCode,
-  formatLockStatus,
-  generateRandomCode,
-  MEMBER_SLOT_MIN,
-  MEMBER_SLOT_MAX,
-} from "@regenhub/shared";
+  activateMembershipAccess,
+  downgradeMembershipAccess,
+} from "@/lib/membershipLifecycle";
 
 type ServiceClient = ReturnType<typeof createServiceClient>;
 
@@ -335,24 +330,17 @@ async function handleSubscriptionDeleted(admin: ServiceClient, sub: Stripe.Subsc
     cancelledPlan?.grantsMemberType === "hot_desk";
   const slot = row.members?.pin_code_slot ?? null;
 
-  // Flip member back to day_pass (they keep portal/day-pass access)
-  const memberUpdate: { member_type: "day_pass"; pin_code_slot?: null; pin_code?: null } = {
-    member_type: "day_pass",
-  };
   let lockRevokeNote = "";
-  if (wasDeskTier && slot) {
-    memberUpdate.pin_code_slot = null;
-    memberUpdate.pin_code = null;
-    try {
-      const lockResults = await clearUserCode(slot);
-      lockRevokeNote = `\n\n🔒 Cleared PIN slot ${slot} on lock: ${formatLockStatus(lockResults)}`;
-    } catch (err) {
-      console.error("[Webhook] Failed to revoke lock code on cancel:", err);
-      lockRevokeNote = `\n\n⚠️ *Action needed:* Lock revoke failed for slot ${slot}. Run Lock Sync from /admin/access.`;
-    }
+  const downgrade = await downgradeMembershipAccess(admin, {
+    memberId: row.member_id,
+    currentPinSlot: slot,
+    revokePermanentPin: wasDeskTier,
+  });
+  if (downgrade.revokedSlot && downgrade.lockRevokeFailed) {
+    lockRevokeNote = `\n\n⚠️ *Action needed:* Lock revoke failed for slot ${downgrade.revokedSlot}. Run Lock Sync from /admin/access.`;
+  } else if (downgrade.revokedSlot && downgrade.lockStatus) {
+    lockRevokeNote = `\n\n🔒 Cleared PIN slot ${downgrade.revokedSlot} on lock: ${downgrade.lockStatus}`;
   }
-
-  await admin.from("members").update(memberUpdate).eq("id", row.member_id);
   await notifyTelegram(
     `👋 ${name}'s ${planLabel(row.plan_key)} subscription ended. Now on day-pass status.${lockRevokeNote}`,
   );
@@ -667,73 +655,19 @@ async function upsertSubscription(
   let autoAllocatedSlot: number | null = null;
   let autoAllocationFailure: string | null = null;
   if (isActiveStatus(status)) {
-    // Only update member_type if the plan grants physical access
-    if (plan.grantsMemberType) {
-      await admin
-        .from("members")
-        .update({ member_type: plan.grantsMemberType, disabled: false })
-        .eq("id", member.id);
-    } else {
-      // Digital-only plan — just clear disabled flag
-      await admin.from("members").update({ disabled: false }).eq("id", member.id);
-    }
+    const activation = await activateMembershipAccess(admin, {
+      memberId: member.id,
+      currentPinSlot: member.pin_code_slot,
+      grantsMemberType: plan.grantsMemberType,
+    });
+    autoAllocatedSlot = activation.autoAllocatedSlot;
+    autoAllocationFailure = activation.autoAllocationFailure;
 
     // Clear any stale past_due_since on grant
     await admin
       .from("subscriptions")
       .update({ past_due_since: null, access_disabled_at: null })
       .eq("stripe_subscription_id", sub.id);
-
-    // Desk-tier self-serve: auto-allocate a permanent PIN slot + push to lock.
-    // Without this, a $250/$500 subscriber pays then sees "No slot assigned"
-    // on /portal/my-code. Skip if a slot is already assigned (admin pre-allocated
-    // or sub flapped). Skip non-desk plans (hub_friend is comp, social tiers
-    // don't get permanent slots).
-    const needsSlot =
-      (plan.grantsMemberType === "cold_desk" || plan.grantsMemberType === "hot_desk") &&
-      !member.pin_code_slot;
-    if (needsSlot) {
-      const code = generateRandomCode();
-      const allocation = await allocateSlotWithRetry<{ id: number; pin_code_slot: number }>({
-        min: MEMBER_SLOT_MIN,
-        max: MEMBER_SLOT_MAX,
-        getUsedSlots: async () => {
-          const { data } = await admin
-            .from("members")
-            .select("pin_code_slot")
-            .not("pin_code_slot", "is", null);
-          return new Set((data ?? []).map((r) => r.pin_code_slot as number));
-        },
-        tryInsert: (slot) =>
-          admin
-            .from("members")
-            .update({ pin_code_slot: slot, pin_code: code })
-            .eq("id", member.id)
-            .select("id, pin_code_slot")
-            .single(),
-      });
-
-      if (allocation.ok) {
-        autoAllocatedSlot = allocation.slot;
-        try {
-          const lockResults = await setUserCode(allocation.slot, code);
-          // A door that didn't respond OR accepted-but-may-not-have-landed
-          // (low battery / offline) both warrant a heads-up to the admin.
-          const lockStatus = formatLockStatus(lockResults);
-          autoAllocationFailure = /didn't respond|may not/i.test(lockStatus)
-            ? `lock push partial: ${lockStatus}`
-            : null;
-        } catch (err) {
-          console.error("[Webhook] setUserCode failed for new desk member:", err);
-          autoAllocationFailure = "lock push failed — needs Lock Sync";
-        }
-      } else {
-        console.error("[Webhook] Slot allocation failed for new desk member:", allocation.error);
-        autoAllocationFailure = allocation.exhausted
-          ? "no slots available (1-100 exhausted)"
-          : `allocation error: ${allocation.error}`;
-      }
-    }
 
     // First-time activation side effects (new subscription, not a status flap)
     if (isNew) {

--- a/apps/web/src/lib/membershipLifecycle.test.ts
+++ b/apps/web/src/lib/membershipLifecycle.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { makeSupabaseMock } from "../../test/mockSupabase";
+
+vi.mock("@regenhub/shared", () => ({
+  MEMBER_SLOT_MIN: 1,
+  MEMBER_SLOT_MAX: 100,
+  generateRandomCode: vi.fn(() => "654321"),
+  allocateSlotWithRetry: vi.fn(),
+  setUserCode: vi.fn(),
+  clearUserCode: vi.fn(),
+  formatLockStatus: vi.fn(() => "all locks updated"),
+}));
+
+import {
+  activateMembershipAccess,
+  BILLING_GRACE_DAYS,
+  downgradeMembershipAccess,
+} from "./membershipLifecycle";
+import {
+  allocateSlotWithRetry,
+  clearUserCode,
+  setUserCode,
+} from "@regenhub/shared";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function memberUpdates(sb: ReturnType<typeof makeSupabaseMock>) {
+  return vi.mocked(sb.from).mock.results
+    .filter((result) => result.type === "return")
+    .map((result) => result.value as { update: ReturnType<typeof vi.fn> })
+    .flatMap((builder) => vi.mocked(builder.update).mock.calls.map(([value]) => value));
+}
+
+describe("membership lifecycle", () => {
+  it("keeps the shared billing grace at seven days", () => {
+    expect(BILLING_GRACE_DAYS).toBe(7);
+  });
+
+  it("activates a contributing member without allocating a permanent PIN", async () => {
+    const sb = makeSupabaseMock();
+
+    const result = await activateMembershipAccess(sb as never, {
+      memberId: 41,
+      currentPinSlot: null,
+      grantsMemberType: "day_pass",
+    });
+
+    expect(memberUpdates(sb)).toContainEqual({ member_type: "day_pass", disabled: false });
+    expect(allocateSlotWithRetry).not.toHaveBeenCalled();
+    expect(result).toEqual({ autoAllocatedSlot: null, autoAllocationFailure: null });
+  });
+
+  it("allocates and pushes a permanent PIN for a new desk member", async () => {
+    const sb = makeSupabaseMock({ selects: { members: { data: [] } } });
+    vi.mocked(allocateSlotWithRetry).mockImplementation(async (options: never) => {
+      const { tryInsert } = options as { tryInsert: (slot: number) => Promise<unknown> };
+      await tryInsert(22);
+      return { ok: true, slot: 22, value: { id: 41, pin_code_slot: 22 } };
+    });
+    vi.mocked(setUserCode).mockResolvedValue([{ entity: "lock.front", ok: true }]);
+
+    const result = await activateMembershipAccess(sb as never, {
+      memberId: 41,
+      currentPinSlot: null,
+      grantsMemberType: "hot_desk",
+    });
+
+    expect(memberUpdates(sb)).toContainEqual({ member_type: "hot_desk", disabled: false });
+    expect(memberUpdates(sb)).toContainEqual({ pin_code_slot: 22, pin_code: "654321" });
+    expect(setUserCode).toHaveBeenCalledWith(22, "654321");
+    expect(result).toEqual({ autoAllocatedSlot: 22, autoAllocationFailure: null });
+  });
+
+  it("downgrades a desk member and revokes the permanent PIN", async () => {
+    const sb = makeSupabaseMock();
+    vi.mocked(clearUserCode).mockResolvedValue([{ entity: "lock.front", ok: true }]);
+
+    const result = await downgradeMembershipAccess(sb as never, {
+      memberId: 41,
+      currentPinSlot: 22,
+      revokePermanentPin: true,
+    });
+
+    expect(clearUserCode).toHaveBeenCalledWith(22);
+    expect(memberUpdates(sb)).toContainEqual({
+      member_type: "day_pass",
+      pin_code_slot: null,
+      pin_code: null,
+    });
+    expect(result).toEqual({
+      revokedSlot: 22,
+      lockStatus: "all locks updated",
+      lockRevokeFailed: false,
+      memberUpdateError: null,
+    });
+  });
+
+  it("downgrades non-desk access without touching a lock", async () => {
+    const sb = makeSupabaseMock();
+
+    await downgradeMembershipAccess(sb as never, {
+      memberId: 41,
+      currentPinSlot: 22,
+      revokePermanentPin: false,
+    });
+
+    expect(clearUserCode).not.toHaveBeenCalled();
+    expect(memberUpdates(sb)).toContainEqual({ member_type: "day_pass" });
+  });
+});

--- a/apps/web/src/lib/membershipLifecycle.ts
+++ b/apps/web/src/lib/membershipLifecycle.ts
@@ -1,0 +1,146 @@
+import type { MemberType } from "@/lib/supabase/types";
+import { createServiceClient } from "@/lib/supabase/admin";
+import {
+  allocateSlotWithRetry,
+  clearUserCode,
+  formatLockStatus,
+  generateRandomCode,
+  MEMBER_SLOT_MAX,
+  MEMBER_SLOT_MIN,
+  setUserCode,
+} from "@regenhub/shared";
+
+type ServiceClient = ReturnType<typeof createServiceClient>;
+
+export const BILLING_GRACE_DAYS = 7;
+
+export type ActivationResult = {
+  autoAllocatedSlot: number | null;
+  autoAllocationFailure: string | null;
+};
+
+/**
+ * Apply the physical/member access portion of an active subscription.
+ *
+ * Billing adapters own their financial rows and notifications. This helper
+ * owns the shared member tier + permanent PIN behavior so Stripe and on-chain
+ * payments cannot drift.
+ */
+export async function activateMembershipAccess(
+  admin: ServiceClient,
+  args: {
+    memberId: number;
+    currentPinSlot: number | null;
+    grantsMemberType: MemberType | null;
+  },
+): Promise<ActivationResult> {
+  if (args.grantsMemberType) {
+    await admin
+      .from("members")
+      .update({ member_type: args.grantsMemberType, disabled: false })
+      .eq("id", args.memberId);
+  } else {
+    await admin.from("members").update({ disabled: false }).eq("id", args.memberId);
+  }
+
+  const needsSlot =
+    (args.grantsMemberType === "cold_desk" || args.grantsMemberType === "hot_desk") &&
+    !args.currentPinSlot;
+  if (!needsSlot) {
+    return { autoAllocatedSlot: null, autoAllocationFailure: null };
+  }
+
+  const code = generateRandomCode();
+  const allocation = await allocateSlotWithRetry<{ id: number; pin_code_slot: number }>({
+    min: MEMBER_SLOT_MIN,
+    max: MEMBER_SLOT_MAX,
+    getUsedSlots: async () => {
+      const { data } = await admin
+        .from("members")
+        .select("pin_code_slot")
+        .not("pin_code_slot", "is", null);
+      return new Set((data ?? []).map((row) => row.pin_code_slot as number));
+    },
+    tryInsert: (slot) =>
+      admin
+        .from("members")
+        .update({ pin_code_slot: slot, pin_code: code })
+        .eq("id", args.memberId)
+        .select("id, pin_code_slot")
+        .single(),
+  });
+
+  if (!allocation.ok) {
+    console.error("[MembershipLifecycle] Permanent PIN allocation failed:", allocation.error);
+    return {
+      autoAllocatedSlot: null,
+      autoAllocationFailure: allocation.exhausted
+        ? "no slots available (1-100 exhausted)"
+        : `allocation error: ${allocation.error}`,
+    };
+  }
+
+  try {
+    const lockResults = await setUserCode(allocation.slot, code);
+    const lockStatus = formatLockStatus(lockResults);
+    return {
+      autoAllocatedSlot: allocation.slot,
+      autoAllocationFailure: /didn't respond|may not/i.test(lockStatus)
+        ? `lock push partial: ${lockStatus}`
+        : null,
+    };
+  } catch (error) {
+    console.error("[MembershipLifecycle] Permanent PIN push failed:", error);
+    return {
+      autoAllocatedSlot: allocation.slot,
+      autoAllocationFailure: "lock push failed — needs Lock Sync",
+    };
+  }
+}
+
+export type DowngradeResult = {
+  revokedSlot: number | null;
+  lockStatus: string | null;
+  lockRevokeFailed: boolean;
+  memberUpdateError: unknown | null;
+};
+
+/** Downgrade a lapsed/canceled membership and revoke its permanent door PIN. */
+export async function downgradeMembershipAccess(
+  admin: ServiceClient,
+  args: {
+    memberId: number;
+    currentPinSlot: number | null;
+    revokePermanentPin: boolean;
+  },
+): Promise<DowngradeResult> {
+  const revokedSlot = args.revokePermanentPin ? args.currentPinSlot : null;
+  let lockStatus: string | null = null;
+  let lockRevokeFailed = false;
+
+  if (revokedSlot) {
+    try {
+      lockStatus = formatLockStatus(await clearUserCode(revokedSlot));
+    } catch (error) {
+      console.error(`[MembershipLifecycle] Permanent PIN revoke failed for slot ${revokedSlot}:`, error);
+      lockRevokeFailed = true;
+    }
+  }
+
+  const memberUpdate: {
+    member_type: "day_pass";
+    pin_code_slot?: null;
+    pin_code?: null;
+  } = { member_type: "day_pass" };
+  if (revokedSlot) {
+    memberUpdate.pin_code_slot = null;
+    memberUpdate.pin_code = null;
+  }
+
+  const { error: memberUpdateError } = await admin
+    .from("members")
+    .update(memberUpdate)
+    .eq("id", args.memberId);
+
+  return { revokedSlot, lockStatus, lockRevokeFailed, memberUpdateError };
+}


### PR DESCRIPTION
## Summary

- extract shared membership activation/downgrade and permanent-PIN handling from Stripe-specific code
- route both Stripe cancellation and the past-due sweep through the shared lifecycle
- centralize the existing seven-day billing grace without changing policy
- add focused tests for contributing-member activation, desk PIN allocation, and downgrade/revocation

This is deliberately the behavior-preserving first tranche for direct on-chain billing. It contains no schema or payment-rail changes; those follow only after this access-critical seam is reviewed.

## Coupling preserved

The regenOS membership claim added in #69 continues to derive contributing membership from live rows in `subscriptions`. The next tranche will add `payment_rail = stripe | onchain` to that same ledger rather than creating a parallel membership table.

## Verification

- `pnpm --filter web test` — 20 files, 205 tests passed
- `pnpm --filter web lint` — 0 errors; 2 pre-existing warnings
- `pnpm build` — passed
- verified at `4665989d36f8f70d71b5f14e7df9a5d7e03e892c`
