### PR TITLE
fix: resolve DID subscriptions through linked member

### DIFF
--- a/apps/web/src/app/api/membership/subscribe/route.test.ts
+++ b/apps/web/src/app/api/membership/subscribe/route.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ createServiceClient: vi.fn() }));
+vi.mock("@/lib/stripe", () => ({
+  isStripeConfigured: vi.fn(() => true),
+  getPlan: vi.fn(() => ({
+    selfServe: true,
+    grantsMemberType: "hot_desk",
+    defaultMonthlyCents: 25000,
+    label: "Hot Desk",
+    monthlyDayPasses: 0,
+  })),
+  getOrCreateCustomer: vi.fn(async () => ({ id: "cus_linked" })),
+  getStripe: vi.fn(() => ({
+    checkout: {
+      sessions: {
+        create: vi.fn(async () => ({ id: "cs_linked", url: "https://checkout.example/session" })),
+      },
+    },
+  })),
+}));
+
+import { POST } from "./route";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/admin";
+import { getOrCreateCustomer } from "@/lib/stripe";
+
+function resolvedBuilder(data: unknown) {
+  const eq = vi.fn();
+  const builder = {
+    select: vi.fn(),
+    eq,
+    in: vi.fn(),
+    maybeSingle: vi.fn(async () => ({ data, error: null })),
+  };
+  builder.select.mockReturnValue(builder);
+  eq.mockReturnValue(builder);
+  builder.in.mockReturnValue(builder);
+  return builder;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("POST /api/membership/subscribe", () => {
+  it("uses the linked member instead of a regenOS synthetic auth email", async () => {
+    vi.mocked(createClient).mockResolvedValue({
+      auth: {
+        getUser: vi.fn(async () => ({
+          data: {
+            user: {
+              id: "auth-did-1",
+              email: "did-plc-abc@did.regenhub.invalid",
+            },
+          },
+        })),
+      },
+    } as never);
+
+    const member = {
+      id: 42,
+      name: "Aaron",
+      email: "aaron@example.org",
+      stripe_customer_id: "cus_linked",
+      member_type: "day_pass",
+      supabase_user_id: "auth-did-1",
+      approved_for_daily: true,
+      approved_for_full: true,
+    };
+    const members = resolvedBuilder(member);
+    const subscriptions = resolvedBuilder(null);
+    vi.mocked(createServiceClient).mockReturnValue({
+      from: vi.fn((table: string) => table === "members" ? members : subscriptions),
+    } as never);
+
+    const response = await POST(new Request("http://localhost/api/membership/subscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ plan_key: "hot_desk" }),
+    }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ url: "https://checkout.example/session" });
+    expect(members.eq).toHaveBeenCalledWith("supabase_user_id", "auth-did-1");
+    expect(members.eq).not.toHaveBeenCalledWith("email", "did-plc-abc@did.regenhub.invalid");
+    expect(getOrCreateCustomer).toHaveBeenCalledWith(member);
+  });
+});

--- a/apps/web/src/app/api/membership/subscribe/route.ts
+++ b/apps/web/src/app/api/membership/subscribe/route.ts
@@ -9,6 +9,7 @@ import {
   isStripeConfigured,
 } from "@/lib/stripe";
 import type { PlanKey } from "@/lib/supabase/types";
+import { isSyntheticEmail } from "@/lib/regenos/syntheticEmail";
 
 interface SubscribeBody {
   plan_key: PlanKey;
@@ -56,14 +57,46 @@ export async function POST(req: Request) {
     );
   }
 
-  // Determine the member to attach this subscription to
+  // Determine the member to attach this subscription to. A regenOS
+  // participant may have a synthetic auth email, so authenticated callers
+  // MUST resolve through the member↔auth-user link first. Looking up
+  // `user.email` here leaks the internal `@did.regenhub.invalid` address into
+  // checkout and misses the real member row created from their application.
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
+  const admin = createServiceClient();
 
-  let memberEmail: string;
+  type SubscriptionMember = {
+    id: number;
+    name: string;
+    email: string;
+    stripe_customer_id: string | null;
+    member_type: string;
+    supabase_user_id: string | null;
+    approved_for_daily: boolean;
+    approved_for_full: boolean;
+  };
+
+  let member: SubscriptionMember | null = null;
+  let memberEmail: string | null = null;
   let memberName: string | null = null;
-  if (user?.email) {
-    memberEmail = user.email;
+  if (user) {
+    const { data: linkedMember, error: linkedMemberError } = await admin
+      .from("members")
+      .select("id, name, email, stripe_customer_id, member_type, supabase_user_id, approved_for_daily, approved_for_full")
+      .eq("supabase_user_id", user.id)
+      .maybeSingle();
+    if (linkedMemberError) {
+      console.error("[Subscribe] Linked member lookup failed:", linkedMemberError);
+      return NextResponse.json({ error: "Couldn't look up your membership." }, { status: 500 });
+    }
+    member = linkedMember as SubscriptionMember | null;
+
+    // Backward compatibility for pre-link accounts. Never use a synthetic
+    // address as a membership identity.
+    if (!member && user.email && !isSyntheticEmail(user.email)) {
+      memberEmail = user.email.trim().toLowerCase();
+    }
   } else if (body.email?.trim()) {
     memberEmail = body.email.trim().toLowerCase();
     memberName = body.name?.trim() ?? null;
@@ -71,21 +104,26 @@ export async function POST(req: Request) {
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(memberEmail)) {
       return NextResponse.json({ error: "Invalid email" }, { status: 400 });
     }
-  } else {
+  } else if (!user) {
     return NextResponse.json({ error: "Email required" }, { status: 400 });
   }
-
-  const admin = createServiceClient();
 
   // Find the member row. We DON'T auto-create here anymore — self-serve
   // subscription now requires explicit admin approval, which means a
   // member record must already exist (created via the free-day flow OR
   // by admin manually). If no record, return a friendly "please apply" msg.
-  const { data: member } = await admin
-    .from("members")
-    .select("id, name, email, stripe_customer_id, member_type, supabase_user_id, approved_for_daily, approved_for_full")
-    .eq("email", memberEmail)
-    .maybeSingle();
+  if (!member && memberEmail) {
+    const { data: emailMember, error: emailMemberError } = await admin
+      .from("members")
+      .select("id, name, email, stripe_customer_id, member_type, supabase_user_id, approved_for_daily, approved_for_full")
+      .eq("email", memberEmail)
+      .maybeSingle();
+    if (emailMemberError) {
+      console.error("[Subscribe] Email member lookup failed:", emailMemberError);
+      return NextResponse.json({ error: "Couldn't look up your membership." }, { status: 500 });
+    }
+    member = emailMember as SubscriptionMember | null;
+  }
 
   if (!member) {
     return NextResponse.json(

--- a/apps/web/src/app/membership/page.tsx
+++ b/apps/web/src/app/membership/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { SubscribeButton } from "@/components/membership/SubscribeButton";
 import { Check, Sparkles, ArrowRight } from "lucide-react";
+import { isSyntheticEmail } from "@/lib/regenos/syntheticEmail";
 
 export const metadata: Metadata = {
   title: "Membership — RegenHub",
@@ -47,14 +48,16 @@ export default async function MembershipPage({ searchParams }: PageProps) {
   let hasActiveSub = false;
   let approvedForDaily: boolean | null = null; // null = unauthed; UI shows generic CTA
   let approvedForFull = false;
+  let subscriptionEmail = user?.email && !isSyntheticEmail(user.email) ? user.email : undefined;
   if (user) {
     const { data: existingMember } = await supabase
       .from("members")
-      .select("id, approved_for_daily, approved_for_full")
+      .select("id, email, approved_for_daily, approved_for_full")
       .eq("supabase_user_id", user.id)
       .maybeSingle();
     approvedForDaily = existingMember?.approved_for_daily ?? false;
     approvedForFull = existingMember?.approved_for_full ?? false;
+    subscriptionEmail = existingMember?.email ?? subscriptionEmail;
     if (existingMember?.id) {
       const { data: existingSub } = await supabase
         .from("subscriptions")
@@ -211,7 +214,7 @@ export default async function MembershipPage({ searchParams }: PageProps) {
                         <SubscribeButton
                           planKey={key}
                           isAuthenticated={!!user}
-                          authedEmail={user?.email}
+                          authedEmail={subscriptionEmail}
                           cta={isFeatured ? "Subscribe — most popular" : "Subscribe"}
                           className={isFeatured ? "btn-primary-glass w-full" : "btn-glass w-full"}
                         />
@@ -272,7 +275,7 @@ export default async function MembershipPage({ searchParams }: PageProps) {
                         <SubscribeButton
                           planKey={key}
                           isAuthenticated={!!user}
-                          authedEmail={user?.email}
+                          authedEmail={subscriptionEmail}
                           cta={`Subscribe — ${def.label}`}
                           className="btn-primary-glass w-full"
                         />


### PR DESCRIPTION
## Outcome

Fixes the production path Aaron reproduced after signing in with a BYOD/passkey regenOS identity, applying with a real contact email, and being approved.

- authenticated subscription checkout now resolves the member by `members.supabase_user_id` first
- it never treats the internal `@did.regenhub.invalid` auth address as payment identity
- the membership page displays the linked member's real email instead of the synthetic address
- existing email-based and unauthenticated checkout paths remain available for legacy callers

The approval flow already stores the application's auth UID on the created member row, so this change consumes the identity link that already exists instead of adding a parallel mapping.

## Root cause

The regenOS participant handoff deliberately mints a Supabase session using a stable synthetic email when the DID has no verified login email. Application approval correctly creates a member with the real application email and the same `supabase_user_id`. The subscription route contradicted its own contract: it ignored that linked member and queried `members.email = auth.users.email`, which can only miss for a synthetic address.

## Verification

At `9bda89a44c957691b4b5c6300b0639909155c753`:

- web tests: 25/25 files, 218/218 tests
- regression test proves a synthetic-email session checks out through its linked real-email member
- lint: 0 errors (2 pre-existing warnings)
- production build: passed
- `git diff --check`: clean

## Separate finding

The real email typed by a synthetic-email regenOS participant is currently a contact address, not a possession-verified login address. The application acknowledgment proves delivery only informally; it is not a verification gate. Adding a real gate changes the onboarding/session handoff and should be handled separately rather than hidden inside this checkout repair.
