### PR TITLE
feat: add self-serve crypto membership signup

### DIFF
--- a/apps/web/src/app/api/cron/past-due-sweep/route.test.ts
+++ b/apps/web/src/app/api/cron/past-due-sweep/route.test.ts
@@ -49,4 +49,19 @@ describe("POST /api/cron/past-due-sweep", () => {
     expect(json.swept).toBe(0);
     expect(json.flipped).toBe(0);
   });
+
+  it("only sweeps subscriptions whose lifecycle status is actually past_due", async () => {
+    process.env.CRON_SECRET = "secret-1";
+    const query: Record<string, ReturnType<typeof vi.fn>> = {};
+    for (const method of ["select", "eq", "lt", "is", "not"]) {
+      query[method] = vi.fn(() => query);
+    }
+    query.returns = vi.fn(async () => ({ data: [], error: null }));
+    vi.mocked(createServiceClient).mockReturnValue({ from: vi.fn(() => query) } as never);
+
+    const res = await POST(makeRequest("Bearer secret-1"));
+
+    expect(res.status).toBe(200);
+    expect(query.eq).toHaveBeenCalledWith("status", "past_due");
+  });
 });

--- a/apps/web/src/app/api/cron/past-due-sweep/route.ts
+++ b/apps/web/src/app/api/cron/past-due-sweep/route.ts
@@ -66,6 +66,7 @@ export async function POST(req: Request) {
   const { data: stale, error } = await admin
     .from("subscriptions")
     .select("id, member_id, stripe_subscription_id, plan_key, past_due_since, members(name, pin_code_slot, member_type)")
+    .eq("status", "past_due")
     .lt("past_due_since", cutoff)
     .is("access_disabled_at", null)
     .not("past_due_since", "is", null)

--- a/apps/web/src/app/api/membership/onchain/route.test.ts
+++ b/apps/web/src/app/api/membership/onchain/route.test.ts
@@ -54,17 +54,13 @@ describe("POST /api/membership/onchain", () => {
         onInsert: (value) => { subscriptionInsert = value as Record<string, unknown>; },
       }),
       member_wallets: builder({ selectData: { id: 12, address: "0x0000000000000000000000000000000000000001" } }),
-      applications: builder({
-        selectData: { status: "approved", approved_plan_key: "hot_desk", approved_monthly_cents: 25_000 },
-      }),
       onchain_invoices: builder({
         insertData: { id: 101, amount_cents: 25_000, amount_usdc_micros: 250_000_000, due_at: "now", status: "open" },
         onInsert: (value) => { invoiceInsert = value as Record<string, unknown>; },
       }),
     };
-    vi.mocked(createServiceClient).mockReturnValue({
-      from: vi.fn((table: keyof typeof tables) => tables[table]),
-    } as never);
+    const from = vi.fn((table: keyof typeof tables) => tables[table]);
+    vi.mocked(createServiceClient).mockReturnValue({ from } as never);
 
     const response = await POST(new Request("http://localhost/api/membership/onchain", {
       method: "POST",
@@ -90,6 +86,8 @@ describe("POST /api/membership/onchain", () => {
       chain_id: 10,
       status: "open",
     });
+    expect(new Date(String(invoiceInsert?.due_at)).getTime()).toBeGreaterThan(Date.now() + 6 * 24 * 60 * 60 * 1000);
+    expect(from).not.toHaveBeenCalledWith("applications");
   });
 
   it("does not create a crypto membership beside an existing card membership", async () => {

--- a/apps/web/src/app/api/membership/onchain/route.test.ts
+++ b/apps/web/src/app/api/membership/onchain/route.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/onchain/portalMember", () => ({ requirePortalMember: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ createServiceClient: vi.fn() }));
+vi.mock("@/lib/auditLog", () => ({
+  AuditAction: { ONCHAIN_SUBSCRIPTION_CREATED: "onchain_subscription_created" },
+  logAction: vi.fn(async () => undefined),
+}));
+
+import { POST } from "./route";
+import { requirePortalMember } from "@/lib/onchain/portalMember";
+import { createServiceClient } from "@/lib/supabase/admin";
+
+function builder(args: {
+  selectData?: unknown;
+  insertData?: unknown;
+  onInsert?: (value: unknown) => void;
+}) {
+  let inserted = false;
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const method of ["select", "eq", "in", "limit", "is", "delete"]) {
+    chain[method] = vi.fn(() => chain);
+  }
+  chain.insert = vi.fn((value: unknown) => {
+    inserted = true;
+    args.onInsert?.(value);
+    return chain;
+  });
+  chain.single = vi.fn(async () => ({
+    data: inserted ? args.insertData ?? null : args.selectData ?? null,
+    error: null,
+  }));
+  chain.maybeSingle = vi.fn(async () => ({ data: args.selectData ?? null, error: null }));
+  return chain;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(requirePortalMember).mockResolvedValue({
+    user: { id: "auth-1", email: "member@example.org" },
+    member: { id: 7, name: "Member", email: "member@example.org", disabled: false },
+  } as never);
+});
+
+describe("POST /api/membership/onchain", () => {
+  it("creates an incomplete subscription and payable first invoice without granting access", async () => {
+    let subscriptionInsert: Record<string, unknown> | null = null;
+    let invoiceInsert: Record<string, unknown> | null = null;
+    const tables = {
+      members: builder({ selectData: { id: 7, approved_for_daily: true, approved_for_full: true } }),
+      subscriptions: builder({
+        selectData: null,
+        insertData: { id: 91 },
+        onInsert: (value) => { subscriptionInsert = value as Record<string, unknown>; },
+      }),
+      member_wallets: builder({ selectData: { id: 12, address: "0x0000000000000000000000000000000000000001" } }),
+      applications: builder({
+        selectData: { status: "approved", approved_plan_key: "hot_desk", approved_monthly_cents: 25_000 },
+      }),
+      onchain_invoices: builder({
+        insertData: { id: 101, amount_cents: 25_000, amount_usdc_micros: 250_000_000, due_at: "now", status: "open" },
+        onInsert: (value) => { invoiceInsert = value as Record<string, unknown>; },
+      }),
+    };
+    vi.mocked(createServiceClient).mockReturnValue({
+      from: vi.fn((table: keyof typeof tables) => tables[table]),
+    } as never);
+
+    const response = await POST(new Request("http://localhost/api/membership/onchain", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ plan_key: "hot_desk" }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(subscriptionInsert).toMatchObject({
+      member_id: 7,
+      payment_rail: "onchain",
+      wallet_id: 12,
+      plan_key: "hot_desk",
+      monthly_cents: 25_000,
+      net_cents: 25_000,
+      status: "incomplete",
+    });
+    expect(invoiceInsert).toMatchObject({
+      subscription_id: 91,
+      member_id: 7,
+      amount_cents: 25_000,
+      amount_usdc_micros: 250_000_000,
+      chain_id: 10,
+      status: "open",
+    });
+  });
+
+  it("does not create a crypto membership beside an existing card membership", async () => {
+    const members = builder({ selectData: { id: 7, approved_for_daily: true, approved_for_full: true } });
+    const subscriptions = builder({ selectData: { id: 44, payment_rail: "stripe" } });
+    const from = vi.fn((table: string) => table === "members" ? members : subscriptions);
+    vi.mocked(createServiceClient).mockReturnValue({ from } as never);
+
+    const response = await POST(new Request("http://localhost/api/membership/onchain", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ plan_key: "hot_desk" }),
+    }));
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: "You already have a live membership." });
+    expect(from).not.toHaveBeenCalledWith("member_wallets");
+  });
+
+  it("requires signature verification before creating the subscription", async () => {
+    const members = builder({ selectData: { id: 7, approved_for_daily: true, approved_for_full: true } });
+    const subscriptions = builder({ selectData: null });
+    const wallets = builder({ selectData: null });
+    const from = vi.fn((table: string) => table === "members" ? members : table === "subscriptions" ? subscriptions : wallets);
+    vi.mocked(createServiceClient).mockReturnValue({ from } as never);
+
+    const response = await POST(new Request("http://localhost/api/membership/onchain", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ plan_key: "hot_desk" }),
+    }));
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: "Connect and verify a wallet first." });
+    expect(from).not.toHaveBeenCalledWith("onchain_invoices");
+  });
+});

--- a/apps/web/src/app/api/membership/onchain/route.ts
+++ b/apps/web/src/app/api/membership/onchain/route.ts
@@ -72,20 +72,9 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Connect and verify a wallet first." }, { status: 409 });
   }
 
-  // Honor the admin-approved rate when this is the plan from the application;
-  // otherwise use the catalog rate, matching the existing self-serve Stripe path.
-  const { data: application } = await admin
-    .from("applications")
-    .select("status, approved_plan_key, approved_monthly_cents")
-    .eq("supabase_user_id", session.user.id)
-    .maybeSingle();
-  const approvedCents = application?.status === "approved" &&
-    application.approved_plan_key === body.plan_key &&
-    Number.isInteger(application.approved_monthly_cents) &&
-    application.approved_monthly_cents > 0
-    ? application.approved_monthly_cents
-    : null;
-  const monthlyCents = approvedCents ?? plan.defaultMonthlyCents;
+  // Self-serve prices must come from server-owned catalog data. Application
+  // rows contain admin workflow fields and must never be a billing authority.
+  const monthlyCents = plan.defaultMonthlyCents;
   const periodStart = new Date().toISOString();
 
   const { data: subscription, error: subscriptionError } = await admin
@@ -107,9 +96,10 @@ export async function POST(request: Request) {
     .select("*")
     .single();
   if (subscriptionError || !subscription) {
+    console.error("[OnchainSignup] Subscription insert failed:", subscriptionError);
     return NextResponse.json(
-      { error: subscriptionError?.message ?? "Could not start crypto membership" },
-      { status: subscriptionError?.code === "23505" ? 409 : 400 },
+      { error: subscriptionError?.code === "23505" ? "Your crypto membership is already set up." : "Could not start crypto membership" },
+      { status: subscriptionError?.code === "23505" ? 409 : 500 },
     );
   }
 
@@ -118,6 +108,7 @@ export async function POST(request: Request) {
     memberId: member.id,
     periodStart,
     baseAmountCents: monthlyCents,
+    dueAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
   });
   const { data: invoice, error: invoiceError } = await admin
     .from("onchain_invoices")

--- a/apps/web/src/app/api/membership/onchain/route.ts
+++ b/apps/web/src/app/api/membership/onchain/route.ts
@@ -1,0 +1,143 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/admin";
+import { requirePortalMember } from "@/lib/onchain/portalMember";
+import { discountedCents, invoiceValues } from "@/lib/onchain/invoice";
+import { getPlan } from "@/lib/plans";
+import type { PlanKey } from "@/lib/supabase/types";
+import { AuditAction, logAction } from "@/lib/auditLog";
+
+type Body = { plan_key?: PlanKey };
+
+/**
+ * Start a first-time direct-USDC membership after the member has signature-
+ * verified a wallet. Access remains unchanged until the initial invoice is
+ * actually paid and credited by the normal on-chain verifier.
+ */
+export async function POST(request: Request) {
+  const session = await requirePortalMember();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = await request.json().catch(() => null) as Body | null;
+  const plan = body?.plan_key ? getPlan(body.plan_key) : null;
+  if (!body?.plan_key || !plan?.selfServe) {
+    return NextResponse.json({ error: "Unknown membership plan" }, { status: 400 });
+  }
+
+  const admin = createServiceClient();
+  const { data: member, error: memberError } = await admin
+    .from("members")
+    .select("id, approved_for_daily, approved_for_full")
+    .eq("id", session.member.id)
+    .single();
+  if (memberError || !member) {
+    return NextResponse.json({ error: "Couldn't look up your membership." }, { status: 500 });
+  }
+
+  const isDeskTier = plan.grantsMemberType === "hot_desk" || plan.grantsMemberType === "cold_desk";
+  if ((isDeskTier && !member.approved_for_full) || (!isDeskTier && !member.approved_for_daily)) {
+    return NextResponse.json(
+      { error: isDeskTier ? "Full Access has not been approved yet." : "Membership has not been approved yet." },
+      { status: 403 },
+    );
+  }
+
+  const { data: existing, error: existingError } = await admin
+    .from("subscriptions")
+    .select("id, payment_rail")
+    .eq("member_id", member.id)
+    .in("status", ["active", "trialing", "past_due", "incomplete"])
+    .limit(1)
+    .maybeSingle();
+  if (existingError) {
+    return NextResponse.json({ error: "Couldn't check your membership." }, { status: 500 });
+  }
+  if (existing) {
+    return NextResponse.json(
+      { error: existing.payment_rail === "onchain" ? "Your crypto membership is already set up. Open the portal to continue." : "You already have a live membership." },
+      { status: 409 },
+    );
+  }
+
+  const { data: wallet, error: walletError } = await admin
+    .from("member_wallets")
+    .select("id, address")
+    .eq("member_id", member.id)
+    .eq("verification_method", "signature")
+    .is("revoked_at", null)
+    .maybeSingle();
+  if (walletError) {
+    return NextResponse.json({ error: "Couldn't look up your verified wallet." }, { status: 500 });
+  }
+  if (!wallet) {
+    return NextResponse.json({ error: "Connect and verify a wallet first." }, { status: 409 });
+  }
+
+  // Honor the admin-approved rate when this is the plan from the application;
+  // otherwise use the catalog rate, matching the existing self-serve Stripe path.
+  const { data: application } = await admin
+    .from("applications")
+    .select("status, approved_plan_key, approved_monthly_cents")
+    .eq("supabase_user_id", session.user.id)
+    .maybeSingle();
+  const approvedCents = application?.status === "approved" &&
+    application.approved_plan_key === body.plan_key &&
+    Number.isInteger(application.approved_monthly_cents) &&
+    application.approved_monthly_cents > 0
+    ? application.approved_monthly_cents
+    : null;
+  const monthlyCents = approvedCents ?? plan.defaultMonthlyCents;
+  const periodStart = new Date().toISOString();
+
+  const { data: subscription, error: subscriptionError } = await admin
+    .from("subscriptions")
+    .insert({
+      member_id: member.id,
+      payment_rail: "onchain",
+      wallet_id: wallet.id,
+      stripe_subscription_id: null,
+      stripe_customer_id: null,
+      stripe_price_id: null,
+      plan_key: body.plan_key,
+      monthly_cents: monthlyCents,
+      net_cents: discountedCents(monthlyCents),
+      status: "incomplete",
+      current_period_end: periodStart,
+      cancel_at_period_end: false,
+    })
+    .select("*")
+    .single();
+  if (subscriptionError || !subscription) {
+    return NextResponse.json(
+      { error: subscriptionError?.message ?? "Could not start crypto membership" },
+      { status: subscriptionError?.code === "23505" ? 409 : 400 },
+    );
+  }
+
+  const initialInvoice = invoiceValues({
+    subscriptionId: subscription.id,
+    memberId: member.id,
+    periodStart,
+    baseAmountCents: monthlyCents,
+  });
+  const { data: invoice, error: invoiceError } = await admin
+    .from("onchain_invoices")
+    .insert(initialInvoice)
+    .select("id, amount_cents, amount_usdc_micros, due_at, status")
+    .single();
+  if (invoiceError || !invoice) {
+    // No money or access has moved yet. Remove the incomplete shell so the
+    // member can retry instead of getting stuck behind the live-sub guard.
+    await admin.from("subscriptions").delete().eq("id", subscription.id).eq("status", "incomplete");
+    console.error("[OnchainSignup] Initial invoice insert failed:", invoiceError);
+    return NextResponse.json({ error: "Could not create the first crypto invoice" }, { status: 500 });
+  }
+
+  await logAction({
+    action: AuditAction.ONCHAIN_SUBSCRIPTION_CREATED,
+    actorMemberId: member.id,
+    target: { table: "subscriptions", id: subscription.id },
+    payload: { member_id: member.id, plan_key: body.plan_key, monthly_cents: monthlyCents, wallet: wallet.address, source: "self_serve" },
+  }, admin);
+
+  return NextResponse.json({ subscription_id: subscription.id, invoice });
+}

--- a/apps/web/src/app/api/portal/application/route.test.ts
+++ b/apps/web/src/app/api/portal/application/route.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ createServiceClient: vi.fn() }));
+vi.mock("@/lib/applicationNotify", () => ({
+  notifyNewApplication: vi.fn(),
+  interestLabel: vi.fn(() => "Hot Desk"),
+}));
+vi.mock("@/lib/email", () => ({
+  sendEmail: vi.fn(async () => undefined),
+  applicationReceivedEmail: vi.fn(() => ({ subject: "Received", html: "ok", text: "ok" })),
+}));
+
+import { POST } from "./route";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/admin";
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("POST /api/portal/application", () => {
+  it("writes validated applicant fields through the server client", async () => {
+    const publicFrom = vi.fn();
+    vi.mocked(createClient).mockResolvedValue({
+      auth: { getUser: vi.fn(async () => ({ data: { user: { id: "auth-1", email: "member@example.org" } } })) },
+      from: publicFrom,
+    } as never);
+
+    let updated: Record<string, unknown> | null = null;
+    const lookup: Record<string, ReturnType<typeof vi.fn>> = {};
+    for (const method of ["select", "eq"]) lookup[method] = vi.fn(() => lookup);
+    lookup.maybeSingle = vi.fn(async () => ({ data: { id: 12, email: "member@example.org" }, error: null }));
+
+    const mutation: Record<string, ReturnType<typeof vi.fn>> = {};
+    mutation.update = vi.fn((values: Record<string, unknown>) => { updated = values; return mutation; });
+    for (const method of ["eq", "select"]) mutation[method] = vi.fn(() => mutation);
+    mutation.single = vi.fn(async () => ({ data: { id: 12 }, error: null }));
+
+    let calls = 0;
+    vi.mocked(createServiceClient).mockReturnValue({
+      from: vi.fn(() => calls++ === 0 ? lookup : mutation),
+    } as never);
+
+    const response = await POST(new Request("http://localhost/api/portal/application", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Member", membership_interest: "hot_desk" }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(updated).toMatchObject({
+      supabase_user_id: "auth-1",
+      email: "member@example.org",
+      name: "Member",
+      membership_interest: "hot_desk",
+      status: "pending",
+    });
+    expect(publicFrom).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/portal/application/route.ts
+++ b/apps/web/src/app/api/portal/application/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/admin";
 import { notifyNewApplication, interestLabel } from "@/lib/applicationNotify";
 import { sendEmail, applicationReceivedEmail } from "@/lib/email";
 import type { MembershipInterest } from "@/lib/supabase/types";
@@ -53,25 +54,51 @@ export async function POST(req: Request) {
 
   const telegramHandle = telegram?.trim().replace(/^@+/, "") || null;
 
-  // Upsert by supabase_user_id — authenticated user updating their own application
-  const { data, error } = await supabase
+  // Application workflow fields (approval, plan, rate) are deliberately not
+  // client-writable. Perform the validated write with the service client and
+  // target only the caller's existing row. Never use an email upsert that
+  // could overwrite another account's application.
+  const admin = createServiceClient();
+  const { data: existing, error: lookupError } = await admin
     .from("applications")
-    .upsert(
-      {
-        supabase_user_id: user.id,
-        email,
-        name: name.trim(),
-        telegram: telegramHandle,
-        about: about?.trim() || null,
-        why_join: why_join?.trim() || null,
-        membership_interest: membership_interest ?? "member_basic",
-        status: "pending",
-        updated_at: new Date().toISOString(),
-      },
-      { onConflict: "email", ignoreDuplicates: false }
-    )
-    .select()
-    .single();
+    .select("id, email")
+    .eq("supabase_user_id", user.id)
+    .maybeSingle();
+  if (lookupError) {
+    console.error("[PortalApplication] Lookup error:", lookupError);
+    return NextResponse.json({ error: "Failed to save application" }, { status: 500 });
+  }
+
+  if (!existing || existing.email !== email) {
+    const { data: emailOwner, error: emailLookupError } = await admin
+      .from("applications")
+      .select("id, supabase_user_id")
+      .eq("email", email)
+      .maybeSingle();
+    if (emailLookupError) {
+      console.error("[PortalApplication] Email lookup error:", emailLookupError);
+      return NextResponse.json({ error: "Failed to save application" }, { status: 500 });
+    }
+    if (emailOwner && emailOwner.supabase_user_id !== user.id) {
+      return NextResponse.json({ error: "That email is already attached to another application." }, { status: 409 });
+    }
+  }
+
+  const values = {
+    supabase_user_id: user.id,
+    email,
+    name: name.trim(),
+    telegram: telegramHandle,
+    about: about?.trim() || null,
+    why_join: why_join?.trim() || null,
+    membership_interest: membership_interest ?? "member_basic",
+    status: "pending" as const,
+    updated_at: new Date().toISOString(),
+  };
+  const write = existing
+    ? admin.from("applications").update(values).eq("id", existing.id).select().single()
+    : admin.from("applications").insert(values).select().single();
+  const { data, error } = await write;
 
   if (error) {
     console.error("[PortalApplication] DB error:", error);

--- a/apps/web/src/app/api/portal/onchain/wallet/challenge/route.test.ts
+++ b/apps/web/src/app/api/portal/onchain/wallet/challenge/route.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/onchain/portalMember", () => ({ requirePortalMember: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ createServiceClient: vi.fn() }));
+vi.mock("@/lib/onchain/walletChallenge", () => ({
+  createWalletChallenge: vi.fn(() => ({
+    nonceHash: "hash",
+    message: "Sign this RegenHub challenge",
+    expiresAt: new Date("2026-08-27T00:00:00.000Z"),
+  })),
+}));
+
+import { POST } from "./route";
+import { requirePortalMember } from "@/lib/onchain/portalMember";
+import { createServiceClient } from "@/lib/supabase/admin";
+
+function chain(data: unknown) {
+  const value: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const method of ["select", "eq", "in", "limit", "insert"]) {
+    value[method] = vi.fn(() => value);
+  }
+  value.maybeSingle = vi.fn(async () => ({ data, error: null }));
+  value.single = vi.fn(async () => ({ data, error: null }));
+  return value;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(requirePortalMember).mockResolvedValue({
+    user: { id: "auth-1" },
+    member: { id: 7, name: "Member", email: "member@example.org", disabled: false },
+  } as never);
+});
+
+describe("POST /api/portal/onchain/wallet/challenge", () => {
+  it("allows an approved member to verify a wallet before the on-chain subscription exists", async () => {
+    const subscriptions = chain(null);
+    const members = chain({ approved_for_daily: true, approved_for_full: false });
+    const challenges = chain({ id: 3, message: "Sign this RegenHub challenge", expires_at: "2026-08-27T00:00:00.000Z" });
+    vi.mocked(createServiceClient).mockReturnValue({
+      from: vi.fn((table: string) => table === "subscriptions" ? subscriptions : table === "members" ? members : challenges),
+    } as never);
+
+    const response = await POST(new Request("http://localhost/api/portal/onchain/wallet/challenge", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ address: "0x0000000000000000000000000000000000000001" }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(challenges.insert).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/portal/onchain/wallet/challenge/route.ts
+++ b/apps/web/src/app/api/portal/onchain/wallet/challenge/route.ts
@@ -13,15 +13,28 @@ export async function POST(request: Request) {
   }
 
   const admin = createServiceClient();
-  const { data: subscription } = await admin
+  const { data: subscription, error: subscriptionError } = await admin
     .from("subscriptions")
-    .select("id")
+    .select("id, payment_rail")
     .eq("member_id", session.member.id)
-    .eq("payment_rail", "onchain")
     .in("status", ["active", "trialing", "past_due", "incomplete"])
+    .limit(1)
     .maybeSingle();
-  if (!subscription) {
-    return NextResponse.json({ error: "No on-chain membership is configured" }, { status: 409 });
+  if (subscriptionError) {
+    return NextResponse.json({ error: "Could not check membership billing" }, { status: 500 });
+  }
+  if (subscription?.payment_rail !== "onchain") {
+    if (subscription) {
+      return NextResponse.json({ error: "A card membership is already active" }, { status: 409 });
+    }
+    const { data: member } = await admin
+      .from("members")
+      .select("approved_for_daily, approved_for_full")
+      .eq("id", session.member.id)
+      .single();
+    if (!member?.approved_for_daily && !member?.approved_for_full) {
+      return NextResponse.json({ error: "Membership has not been approved yet" }, { status: 403 });
+    }
   }
 
   const address = getAddress(body.address);

--- a/apps/web/src/app/membership/page.tsx
+++ b/apps/web/src/app/membership/page.tsx
@@ -5,6 +5,7 @@ import { getSelfServePlans } from "@/lib/stripe";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { SubscribeButton } from "@/components/membership/SubscribeButton";
+import { CryptoSubscribeButton } from "@/components/membership/CryptoSubscribeButton";
 import { Check, Sparkles, ArrowRight } from "lucide-react";
 import { isSyntheticEmail } from "@/lib/regenos/syntheticEmail";
 
@@ -211,13 +212,16 @@ export default async function MembershipPage({ searchParams }: PageProps) {
                           </Button>
                         </Link>
                       ) : (
-                        <SubscribeButton
-                          planKey={key}
-                          isAuthenticated={!!user}
-                          authedEmail={subscriptionEmail}
-                          cta={isFeatured ? "Subscribe — most popular" : "Subscribe"}
-                          className={isFeatured ? "btn-primary-glass w-full" : "btn-glass w-full"}
-                        />
+                        <div className="space-y-2">
+                          <SubscribeButton
+                            planKey={key}
+                            isAuthenticated={!!user}
+                            authedEmail={subscriptionEmail}
+                            cta={isFeatured ? "Pay by card — most popular" : "Pay by card"}
+                            className={isFeatured ? "btn-primary-glass w-full" : "btn-glass w-full"}
+                          />
+                          {user && <CryptoSubscribeButton planKey={key} />}
+                        </div>
                       )}
                     </CardContent>
                   </Card>
@@ -272,13 +276,16 @@ export default async function MembershipPage({ searchParams }: PageProps) {
                           <Button className="btn-glass w-full">Request Full Access →</Button>
                         </Link>
                       ) : (
-                        <SubscribeButton
-                          planKey={key}
-                          isAuthenticated={!!user}
-                          authedEmail={subscriptionEmail}
-                          cta={`Subscribe — ${def.label}`}
-                          className="btn-primary-glass w-full"
-                        />
+                        <div className="space-y-2">
+                          <SubscribeButton
+                            planKey={key}
+                            isAuthenticated={!!user}
+                            authedEmail={subscriptionEmail}
+                            cta={`Pay by card — ${def.label}`}
+                            className="btn-primary-glass w-full"
+                          />
+                          {user && <CryptoSubscribeButton planKey={key} />}
+                        </div>
                       )}
                     </CardContent>
                   </Card>

--- a/apps/web/src/app/portal/page.tsx
+++ b/apps/web/src/app/portal/page.tsx
@@ -105,7 +105,10 @@ export default async function PortalPage() {
       .from("subscriptions")
       .select("id, payment_rail, wallet_id, plan_key, monthly_cents, net_cents, status, cancel_at_period_end, current_period_end, past_due_since, discount_cents")
       .eq("member_id", member.id)
-      .in("status", ["active", "trialing", "past_due"])
+      // `incomplete` is the first-payment state for a self-serve on-chain
+      // membership. It must render the invoice/payment card even though no
+      // access is granted until the transfer is credited.
+      .in("status", ["active", "trialing", "past_due", "incomplete"])
       .order("created_at", { ascending: false })
       .limit(1)
       .maybeSingle();
@@ -496,7 +499,13 @@ export default async function PortalPage() {
                     {activeSubscription.payment_rail === "onchain" ? "USDC renewal past due" : "Payment failed — update your card to keep access"}
                   </p>
                 )}
-                {!activeSubscription.cancel_at_period_end && activeSubscription.status !== "past_due" && (
+                {activeSubscription.status === "incomplete" && (
+                  <p className="text-sm text-amber-400 flex items-center gap-1.5">
+                    <AlertCircle className="w-4 h-4" />
+                    Awaiting your first USDC payment — access starts after confirmation
+                  </p>
+                )}
+                {!activeSubscription.cancel_at_period_end && !["past_due", "incomplete"].includes(activeSubscription.status) && (
                   <p className="text-sm text-muted">
                     Renews{" "}
                     {activeSubscription.current_period_end

--- a/apps/web/src/components/membership/CryptoSubscribeButton.tsx
+++ b/apps/web/src/components/membership/CryptoSubscribeButton.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState } from "react";
+import { getAddress } from "viem";
+import { Button } from "@/components/ui/button";
+import { Loader2, Wallet } from "lucide-react";
+
+type EthereumProvider = {
+  request(args: { method: string; params?: unknown[] | object }): Promise<unknown>;
+};
+
+type Props = {
+  planKey: string;
+  className?: string;
+};
+
+function provider(): EthereumProvider | null {
+  return (window as unknown as { ethereum?: EthereumProvider }).ethereum ?? null;
+}
+
+export function CryptoSubscribeButton({ planKey, className }: Props) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function start() {
+    const wallet = provider();
+    if (!wallet) {
+      setError("Install or open MetaMask or Coinbase Wallet, then try again.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const accounts = await wallet.request({ method: "eth_requestAccounts" }) as string[];
+      if (!accounts[0]) throw new Error("No wallet account was selected.");
+      const address = getAddress(accounts[0]);
+
+      const challengeRes = await fetch("/api/portal/onchain/wallet/challenge", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ address }),
+      });
+      const challenge = await challengeRes.json();
+      if (!challengeRes.ok) throw new Error(challenge.error ?? "Could not create wallet challenge");
+
+      const signature = await wallet.request({
+        method: "personal_sign",
+        params: [challenge.message, address],
+      });
+      const verifyRes = await fetch("/api/portal/onchain/wallet/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ challenge_id: challenge.id, address, signature }),
+      });
+      const verified = await verifyRes.json();
+      if (!verifyRes.ok) throw new Error(verified.error ?? "Wallet verification failed");
+
+      const setupRes = await fetch("/api/membership/onchain", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ plan_key: planKey }),
+      });
+      const setup = await setupRes.json();
+      if (!setupRes.ok) throw new Error(setup.error ?? "Could not start crypto membership");
+      window.location.href = "/portal?onchain=ready";
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not start crypto membership");
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div>
+      <Button
+        type="button"
+        onClick={start}
+        disabled={busy}
+        className={className ?? "btn-glass w-full gap-2"}
+      >
+        {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Wallet className="w-4 h-4" />}
+        {busy ? "Connecting wallet…" : "Pay with crypto"}
+      </Button>
+      {error && <p className="text-xs text-red-400 mt-2">{error}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/components/portal/LinkRegenOSCard.tsx
+++ b/apps/web/src/components/portal/LinkRegenOSCard.tsx
@@ -58,11 +58,6 @@ export function LinkRegenOSCard() {
         const data = (await res.json()) as { did?: string; handle?: string };
         if (cancelled) return;
         setHandle(data.did ? (data.handle ?? data.did) : null);
-        // Both sessions are live in this browser and the portal has already
-        // resolved the member. That is the same possession proof as the
-        // manual button, so finish the link without asking for a redundant
-        // second click. The button remains as a retry if this request fails.
-        if (data.did) await link();
       } catch {
         if (!cancelled) setHandle(null);
       }
@@ -70,7 +65,7 @@ export function LinkRegenOSCard() {
     return () => {
       cancelled = true;
     };
-  }, [link]);
+  }, []);
 
   if (linked) {
     return (

--- a/apps/web/src/components/portal/LinkRegenOSCard.tsx
+++ b/apps/web/src/components/portal/LinkRegenOSCard.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Link2, Loader2, CheckCircle } from "lucide-react";
@@ -12,34 +13,14 @@ import { Link2, Loader2, CheckCircle } from "lucide-react";
  * point them at /auth/login to pick up a regenOS session, then they come back.
  */
 export function LinkRegenOSCard() {
+  const router = useRouter();
   const [busy, setBusy] = useState(false);
   const [handle, setHandle] = useState<string | null | undefined>(undefined);
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [linked, setLinked] = useState(false);
 
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetch("/xrpc/social.scenius.getSession", { cache: "no-store" });
-        if (!res.ok) {
-          if (!cancelled) setHandle(null);
-          return;
-        }
-        const data = (await res.json()) as { did?: string; handle?: string };
-        if (cancelled) return;
-        setHandle(data.did ? (data.handle ?? data.did) : null);
-      } catch {
-        if (!cancelled) setHandle(null);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  async function link() {
+  const link = useCallback(async () => {
     setBusy(true);
     setErr(null);
     setMsg(null);
@@ -57,12 +38,39 @@ export function LinkRegenOSCard() {
       }
       setLinked(true);
       setMsg(json.already ? "Already linked." : "Linked this regenOS identity to your membership.");
+      router.refresh();
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e));
     } finally {
       setBusy(false);
     }
-  }
+  }, [router]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/xrpc/social.scenius.getSession", { cache: "no-store" });
+        if (!res.ok) {
+          if (!cancelled) setHandle(null);
+          return;
+        }
+        const data = (await res.json()) as { did?: string; handle?: string };
+        if (cancelled) return;
+        setHandle(data.did ? (data.handle ?? data.did) : null);
+        // Both sessions are live in this browser and the portal has already
+        // resolved the member. That is the same possession proof as the
+        // manual button, so finish the link without asking for a redundant
+        // second click. The button remains as a retry if this request fails.
+        if (data.did) await link();
+      } catch {
+        if (!cancelled) setHandle(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [link]);
 
   if (linked) {
     return (

--- a/apps/web/src/lib/onchain/invoice.test.ts
+++ b/apps/web/src/lib/onchain/invoice.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { addCalendarMonth, discountedCents, invoiceValues } from "./invoice";
+import { describe, expect, it, vi } from "vitest";
+import { addCalendarMonth, discountedCents, invoiceValues, markDueOnchainSubscriptionsPastDue } from "./invoice";
 
 describe("on-chain invoice math", () => {
   it("uses the agreed membership rate while the crypto discount is zero", () => {
@@ -31,5 +31,38 @@ describe("on-chain invoice math", () => {
       token_contract: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
       treasury_address: "0xA594263e0449A28eAEf5BA6420E81cC1996b7782",
     });
+  });
+
+  it("allows a first invoice to have a setup window without changing its billing period", () => {
+    expect(invoiceValues({
+      subscriptionId: 7,
+      memberId: 9,
+      periodStart: "2026-09-01T00:00:00.000Z",
+      dueAt: "2026-09-08T00:00:00.000Z",
+      baseAmountCents: 25_000,
+    })).toMatchObject({
+      period_start: "2026-09-01T00:00:00.000Z",
+      period_end: "2026-10-01T00:00:00.000Z",
+      due_at: "2026-09-08T00:00:00.000Z",
+    });
+  });
+
+  it("never promotes an unpaid incomplete signup into past_due membership", async () => {
+    const invoices: Record<string, ReturnType<typeof vi.fn>> = {};
+    for (const method of ["select", "in", "lte"]) invoices[method] = vi.fn(() => invoices);
+    invoices.then = vi.fn((resolve) => Promise.resolve(resolve({
+      data: [{ id: 4, subscription_id: 7 }],
+      error: null,
+    })));
+
+    const subscriptions: Record<string, ReturnType<typeof vi.fn>> = {};
+    for (const method of ["update", "eq", "in", "is"]) subscriptions[method] = vi.fn(() => subscriptions);
+    subscriptions.then = vi.fn((resolve) => Promise.resolve(resolve({ data: null, error: null })));
+
+    await markDueOnchainSubscriptionsPastDue({
+      from: vi.fn((table: string) => table === "onchain_invoices" ? invoices : subscriptions),
+    } as never, new Date("2026-09-10T00:00:00.000Z"));
+
+    expect(subscriptions.in).toHaveBeenCalledWith("status", ["active", "trialing", "past_due"]);
   });
 });

--- a/apps/web/src/lib/onchain/invoice.ts
+++ b/apps/web/src/lib/onchain/invoice.ts
@@ -30,6 +30,7 @@ export function invoiceValues(args: {
   memberId: number;
   periodStart: string;
   baseAmountCents: number;
+  dueAt?: string;
 }) {
   const amountCents = discountedCents(args.baseAmountCents);
   return {
@@ -37,7 +38,7 @@ export function invoiceValues(args: {
     member_id: args.memberId,
     period_start: args.periodStart,
     period_end: addCalendarMonth(args.periodStart),
-    due_at: args.periodStart,
+    due_at: args.dueAt ?? args.periodStart,
     base_amount_cents: args.baseAmountCents,
     discount_bps: ONCHAIN_DISCOUNT_BPS,
     amount_cents: amountCents,
@@ -107,6 +108,10 @@ export async function markDueOnchainSubscriptionsPastDue(
       .from("subscriptions")
       .update({ status: "past_due", past_due_since: nowIso })
       .eq("id", invoice.subscription_id)
+      // An incomplete subscription represents a first payment that has never
+      // been credited. It must not become scene membership or enter access
+      // downgrade machinery merely because its setup window elapsed.
+      .in("status", ["active", "trialing", "past_due"])
       .is("past_due_since", null);
   }
   return due?.length ?? 0;

--- a/supabase/migrations/047_lock_application_writes.sql
+++ b/supabase/migrations/047_lock_application_writes.sql
@@ -1,0 +1,13 @@
+-- Migration 047: application workflow fields are server/admin-owned.
+--
+-- Migration 005 gave applicants FOR ALL access to their row. That also made
+-- approval, approved plan, and approved rate fields writable through the
+-- public REST API. Application writes now go through the validated server
+-- route; authenticated applicants retain read-only access to their own row.
+
+drop policy if exists "applicants_own" on applications;
+
+create policy "applicants_read_own" on applications
+  for select
+  using (supabase_user_id = auth.uid());
+


### PR DESCRIPTION
## Outcome

Approved members can now choose **Pay with crypto** before any subscription exists. RegenHub connects and signature-verifies their wallet, creates an `incomplete` on-chain row in the existing `subscriptions` ledger, freezes the first native-USDC invoice at the approved rate, and takes them to the portal to approve the exact transfer.

The regenOS link prompt now clearly displays the resident identity and keeps the irreversible binding behind an explicit member click.

## Safety boundaries

- Requires the plan-specific membership approval.
- Requires a signature-verified wallet; `members.ethereum_address` is not used.
- Rejects an existing live membership on either payment rail.
- Creates no door access, member tier, or monthly passes before the normal on-chain verifier credits the invoice.
- Uses the server-owned plan catalog for price; application workflow fields are never billing authority.
- Keeps an unpaid first invoice `incomplete`: it cannot become `past_due`, count as scene membership, or enter the door-code downgrade sweep.
- Keeps on-chain membership in `subscriptions`, preserving regenOS scene membership behavior.
- Shows `incomplete` in the portal as **Awaiting your first USDC payment**.
- Keeps regenOS identity linking behind an explicit member click.

## Verification

At `39e9143fdd8d302f9e2775c23ad37a2226492068`:

- web tests: 28/28 files, 226/226 tests
- lint: 0 errors (2 pre-existing warnings)
- shared TypeScript build: passed
- production build: passed
- `git diff --check`: clean

Migration `047_lock_application_writes.sql` replaces the old applicant `FOR ALL` policy with own-row read access. Validated application writes now run through the authenticated server route, which cannot overwrite another account's application. Deploy the new code first, then apply migration 047; no new environment variable is required.

## Release check

After deploy, use the approved test member to verify:

1. `/portal` presents the live regenOS DID and links it only after explicit confirmation.
2. `/membership` shows **Pay with crypto**.
3. Wallet ownership signature succeeds.
4. `/portal` shows the first $250 USDC invoice.
5. The supervised payment credits once before the recurring cron is enabled.
