### PR TITLE
Fix injected wallet selection

### DIFF
--- a/apps/web/src/components/membership/CryptoSubscribeButton.tsx
+++ b/apps/web/src/components/membership/CryptoSubscribeButton.tsx
@@ -4,34 +4,49 @@ import { useState } from "react";
 import { getAddress } from "viem";
 import { Button } from "@/components/ui/button";
 import { Loader2, Wallet } from "lucide-react";
-
-type EthereumProvider = {
-  request(args: { method: string; params?: unknown[] | object }): Promise<unknown>;
-};
+import {
+  discoverInjectedWallets,
+  rememberInjectedWallet,
+  rememberedInjectedWallet,
+  type InjectedWallet,
+} from "@/lib/onchain/injectedWallet";
 
 type Props = {
   planKey: string;
   className?: string;
 };
 
-function provider(): EthereumProvider | null {
-  return (window as unknown as { ethereum?: EthereumProvider }).ethereum ?? null;
-}
-
 export function CryptoSubscribeButton({ planKey, className }: Props) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [walletOptions, setWalletOptions] = useState<InjectedWallet[]>([]);
 
   async function start() {
-    const wallet = provider();
-    if (!wallet) {
-      setError("Install or open MetaMask or Coinbase Wallet, then try again.");
-      return;
-    }
     setBusy(true);
     setError(null);
     try {
-      const accounts = await wallet.request({ method: "eth_requestAccounts" }) as string[];
+      const wallets = await discoverInjectedWallets();
+      if (wallets.length === 0) throw new Error("Install or open MetaMask, Coinbase Wallet, or another browser wallet, then try again.");
+      const remembered = rememberedInjectedWallet(wallets);
+      if (remembered || wallets.length === 1) {
+        await startWithWallet(remembered ?? wallets[0]);
+        return;
+      }
+      setWalletOptions(wallets);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not find a browser wallet");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function startWithWallet(selected: InjectedWallet) {
+    setBusy(true);
+    setError(null);
+    setWalletOptions([]);
+    rememberInjectedWallet(selected);
+    try {
+      const accounts = await selected.provider.request({ method: "eth_requestAccounts" }) as string[];
       if (!accounts[0]) throw new Error("No wallet account was selected.");
       const address = getAddress(accounts[0]);
 
@@ -43,7 +58,7 @@ export function CryptoSubscribeButton({ planKey, className }: Props) {
       const challenge = await challengeRes.json();
       if (!challengeRes.ok) throw new Error(challenge.error ?? "Could not create wallet challenge");
 
-      const signature = await wallet.request({
+      const signature = await selected.provider.request({
         method: "personal_sign",
         params: [challenge.message, address],
       });
@@ -65,6 +80,7 @@ export function CryptoSubscribeButton({ planKey, className }: Props) {
       window.location.href = "/portal?onchain=ready";
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : "Could not start crypto membership");
+    } finally {
       setBusy(false);
     }
   }
@@ -80,6 +96,22 @@ export function CryptoSubscribeButton({ planKey, className }: Props) {
         {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Wallet className="w-4 h-4" />}
         {busy ? "Connecting wallet…" : "Pay with crypto"}
       </Button>
+      {walletOptions.length > 1 && (
+        <div className="mt-2 rounded-lg border border-white/10 bg-black/10 p-2 space-y-1.5">
+          <p className="text-xs text-muted px-1">Choose the wallet you want to use:</p>
+          {walletOptions.map((wallet) => (
+            <Button
+              key={wallet.id}
+              type="button"
+              disabled={busy}
+              onClick={() => startWithWallet(wallet)}
+              className="btn-glass w-full justify-start text-xs"
+            >
+              <Wallet className="w-3.5 h-3.5" /> {wallet.name}
+            </Button>
+          ))}
+        </div>
+      )}
       {error && <p className="text-xs text-red-400 mt-2">{error}</p>}
     </div>
   );

--- a/apps/web/src/components/portal/OnchainBillingCard.tsx
+++ b/apps/web/src/components/portal/OnchainBillingCard.tsx
@@ -4,10 +4,12 @@ import { useState } from "react";
 import { encodeFunctionData, erc20Abi, getAddress, type Address, type Hash } from "viem";
 import { Button } from "@/components/ui/button";
 import { Loader2, Wallet } from "lucide-react";
-
-type EthereumProvider = {
-  request(args: { method: string; params?: unknown[] | object }): Promise<unknown>;
-};
+import {
+  discoverInjectedWallets,
+  rememberInjectedWallet,
+  rememberedInjectedWallet,
+  type InjectedWallet,
+} from "@/lib/onchain/injectedWallet";
 
 type Props = {
   walletAddress: string | null;
@@ -25,31 +27,50 @@ type Props = {
   configured: boolean;
 };
 
-function provider(): EthereumProvider | null {
-  return (window as unknown as { ethereum?: EthereumProvider }).ethereum ?? null;
-}
-
 export function OnchainBillingCard(props: Props) {
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [walletOptions, setWalletOptions] = useState<InjectedWallet[]>([]);
+  const [walletAction, setWalletAction] = useState<"verify" | "pay" | null>(null);
 
-  async function connectAndVerify() {
-    const wallet = provider();
-    if (!wallet) {
-      setError("Install or open MetaMask or Coinbase Wallet, then try again.");
-      return;
-    }
+  async function chooseWallet(action: "verify" | "pay") {
     setBusy(true); setError(null); setMessage(null);
     try {
-      const accounts = await wallet.request({ method: "eth_requestAccounts" }) as string[];
+      const wallets = await discoverInjectedWallets();
+      if (wallets.length === 0) throw new Error("Install or open MetaMask, Coinbase Wallet, or another browser wallet, then try again.");
+      const remembered = rememberedInjectedWallet(wallets);
+      if (remembered || wallets.length === 1) {
+        await runWalletAction(action, remembered ?? wallets[0]);
+        return;
+      }
+      setWalletAction(action);
+      setWalletOptions(wallets);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not find a browser wallet");
+    } finally { setBusy(false); }
+  }
+
+  async function runWalletAction(action: "verify" | "pay", selected: InjectedWallet) {
+    setWalletOptions([]);
+    setWalletAction(null);
+    rememberInjectedWallet(selected);
+    if (action === "verify") await connectAndVerify(selected);
+    else await pay(selected);
+  }
+
+  async function connectAndVerify(selected: InjectedWallet) {
+    setBusy(true); setError(null); setMessage(null);
+    try {
+      const accounts = await selected.provider.request({ method: "eth_requestAccounts" }) as string[];
+      if (!accounts[0]) throw new Error("No wallet account was selected.");
       const address = getAddress(accounts[0]);
       const challengeRes = await fetch("/api/portal/onchain/wallet/challenge", {
         method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ address }),
       });
       const challenge = await challengeRes.json();
       if (!challengeRes.ok) throw new Error(challenge.error ?? "Could not create wallet challenge");
-      const signature = await wallet.request({ method: "personal_sign", params: [challenge.message, address] });
+      const signature = await selected.provider.request({ method: "personal_sign", params: [challenge.message, address] });
       const verifyRes = await fetch("/api/portal/onchain/wallet/verify", {
         method: "POST", headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ challenge_id: challenge.id, address, signature }),
@@ -63,23 +84,22 @@ export function OnchainBillingCard(props: Props) {
     } finally { setBusy(false); }
   }
 
-  async function pay() {
+  async function pay(selected: InjectedWallet) {
     if (!props.invoice || !props.walletAddress) return;
-    const wallet = provider();
-    if (!wallet) { setError("Install or open MetaMask or Coinbase Wallet, then try again."); return; }
     setBusy(true); setError(null); setMessage(null);
     try {
-      const accounts = await wallet.request({ method: "eth_requestAccounts" }) as string[];
+      const accounts = await selected.provider.request({ method: "eth_requestAccounts" }) as string[];
+      if (!accounts[0]) throw new Error("No wallet account was selected.");
       const address = getAddress(accounts[0]);
       if (address.toLowerCase() !== props.walletAddress.toLowerCase()) {
         throw new Error(`Connect the verified wallet ${props.walletAddress.slice(0, 8)}…${props.walletAddress.slice(-4)}`);
       }
       try {
-        await wallet.request({ method: "wallet_switchEthereumChain", params: [{ chainId: "0xa" }] });
+        await selected.provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: "0xa" }] });
       } catch (cause) {
         const code = (cause as { code?: number }).code;
         if (code !== 4902) throw cause;
-        await wallet.request({ method: "wallet_addEthereumChain", params: [{
+        await selected.provider.request({ method: "wallet_addEthereumChain", params: [{
           chainId: "0xa", chainName: "OP Mainnet", nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
           rpcUrls: ["https://mainnet.optimism.io"], blockExplorerUrls: ["https://optimistic.etherscan.io"],
         }] });
@@ -88,7 +108,7 @@ export function OnchainBillingCard(props: Props) {
         abi: erc20Abi, functionName: "transfer",
         args: [props.treasuryAddress, BigInt(props.invoice.amountMicros)],
       });
-      const txHash = await wallet.request({ method: "eth_sendTransaction", params: [{
+      const txHash = await selected.provider.request({ method: "eth_sendTransaction", params: [{
         from: address, to: props.tokenAddress, data,
       }] }) as Hash;
       setMessage("Transaction submitted. RegenHub is checking OP confirmation…");
@@ -113,7 +133,7 @@ export function OnchainBillingCard(props: Props) {
       </div>
       <p className="text-xs text-muted">Native USDC on OP Mainnet · same membership rate · your wallet always approves the transaction.</p>
       {!props.walletVerifiedBySignature ? (
-        <Button disabled={busy} onClick={connectAndVerify} className="btn-glass text-xs gap-2">
+        <Button disabled={busy} onClick={() => chooseWallet("verify")} className="btn-glass text-xs gap-2">
           {busy && <Loader2 className="w-3.5 h-3.5 animate-spin" />} Connect & verify wallet
         </Button>
       ) : props.invoice && props.invoice.status !== "paid" ? (
@@ -122,13 +142,29 @@ export function OnchainBillingCard(props: Props) {
             <p className="font-medium">${(props.invoice.amountCents / 100).toFixed(2)} USDC</p>
             <p className="text-xs text-muted">Due {new Date(props.invoice.dueAt).toLocaleDateString()}</p>
           </div>
-          <Button disabled={busy || !props.configured || ["submitted", "detected"].includes(props.invoice.status)} onClick={pay} className="bg-sage/20 hover:bg-sage/40 text-sage border border-sage/30 text-xs gap-2">
+          <Button disabled={busy || !props.configured || ["submitted", "detected"].includes(props.invoice.status)} onClick={() => chooseWallet("pay")} className="bg-sage/20 hover:bg-sage/40 text-sage border border-sage/30 text-xs gap-2">
             {busy && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
             {["submitted", "detected"].includes(props.invoice.status) ? "Confirming…" : "Pay with crypto"}
           </Button>
         </div>
       ) : (
         <p className="text-xs text-emerald-400">Wallet verified. Your next invoice appears here seven days before renewal.</p>
+      )}
+      {walletOptions.length > 1 && walletAction && (
+        <div className="rounded-lg border border-white/10 bg-black/10 p-2 space-y-1.5">
+          <p className="text-xs text-muted px-1">Choose the wallet you want to use:</p>
+          {walletOptions.map((wallet) => (
+            <Button
+              key={wallet.id}
+              type="button"
+              disabled={busy}
+              onClick={() => runWalletAction(walletAction, wallet)}
+              className="btn-glass w-full justify-start text-xs"
+            >
+              <Wallet className="w-3.5 h-3.5" /> {wallet.name}
+            </Button>
+          ))}
+        </div>
       )}
       {props.walletAddress && <p className="text-[11px] text-muted font-mono break-all">Verified wallet: {props.walletAddress}</p>}
       {props.invoice?.txHash && <a className="text-xs text-sage underline" href={`https://optimistic.etherscan.io/tx/${props.invoice.txHash}`} target="_blank" rel="noreferrer">View transaction</a>}

--- a/apps/web/src/lib/onchain/injectedWallet.test.ts
+++ b/apps/web/src/lib/onchain/injectedWallet.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  discoverInjectedWallets,
+  rememberInjectedWallet,
+  rememberedInjectedWallet,
+  type EthereumProvider,
+  type InjectedWallet,
+} from "./injectedWallet";
+
+type TestWindow = EventTarget & {
+  ethereum?: EthereumProvider & { providers?: EthereumProvider[] };
+  sessionStorage: Storage;
+};
+
+const originalWindow = globalThis.window;
+
+function provider(flags: Partial<EthereumProvider> = {}): EthereumProvider {
+  return { request: vi.fn(), ...flags };
+}
+
+function storage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() { return values.size; },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => [...values.keys()][index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+function installWindow(ethereum?: TestWindow["ethereum"]): TestWindow {
+  const target = new EventTarget() as TestWindow;
+  target.ethereum = ethereum;
+  target.sessionStorage = storage();
+  vi.stubGlobal("window", target);
+  return target;
+}
+
+function announce(target: EventTarget, detail: unknown) {
+  const event = new Event("eip6963:announceProvider") as Event & { detail: unknown };
+  event.detail = detail;
+  target.dispatchEvent(event);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  if (originalWindow) vi.stubGlobal("window", originalWindow);
+});
+
+describe("injected wallet discovery", () => {
+  it("returns each EIP-6963 wallet instead of trusting the contested window.ethereum slot", async () => {
+    const coinbase = provider({ isCoinbaseWallet: true });
+    const metamask = provider({ isMetaMask: true });
+    const target = installWindow(coinbase);
+    target.addEventListener("eip6963:requestProvider", () => {
+      announce(target, { info: { uuid: "coinbase", name: "Coinbase Wallet", rdns: "com.coinbase.wallet" }, provider: coinbase });
+      announce(target, { info: { uuid: "metamask", name: "MetaMask", rdns: "io.metamask" }, provider: metamask });
+    });
+
+    const wallets = await discoverInjectedWallets(0);
+
+    expect(wallets.map(({ name }) => name)).toEqual(["Coinbase Wallet", "MetaMask"]);
+    expect(wallets.find(({ name }) => name === "MetaMask")?.provider).toBe(metamask);
+  });
+
+  it("falls back to the legacy providers array and identifies MetaMask and Coinbase", async () => {
+    const coinbase = provider({ isCoinbaseWallet: true });
+    const metamask = provider({ isMetaMask: true });
+    installWindow(Object.assign(coinbase, { providers: [coinbase, metamask] }));
+
+    const wallets = await discoverInjectedWallets(0);
+
+    expect(wallets.map(({ name }) => name)).toEqual(["Coinbase Wallet", "MetaMask"]);
+  });
+
+  it("remembers the exact wallet chosen for the portal payment handoff", () => {
+    installWindow();
+    const wallets: InjectedWallet[] = [
+      { id: "coinbase", name: "Coinbase Wallet", rdns: "com.coinbase.wallet", provider: provider() },
+      { id: "metamask", name: "MetaMask", rdns: "io.metamask", provider: provider() },
+    ];
+
+    rememberInjectedWallet(wallets[1]);
+
+    expect(rememberedInjectedWallet(wallets)).toBe(wallets[1]);
+  });
+});

--- a/apps/web/src/lib/onchain/injectedWallet.ts
+++ b/apps/web/src/lib/onchain/injectedWallet.ts
@@ -1,0 +1,92 @@
+export type EthereumProvider = {
+  request(args: { method: string; params?: unknown[] | object }): Promise<unknown>;
+  isMetaMask?: boolean;
+  isCoinbaseWallet?: boolean;
+  isBraveWallet?: boolean;
+  isRabby?: boolean;
+};
+
+export type InjectedWallet = {
+  id: string;
+  name: string;
+  rdns: string;
+  provider: EthereumProvider;
+};
+
+type Eip6963Detail = {
+  info: { uuid: string; name: string; rdns: string };
+  provider: EthereumProvider;
+};
+
+const REMEMBERED_WALLET_KEY = "regenhub.injected-wallet-rdns";
+
+function legacyWallet(provider: EthereumProvider, index: number): InjectedWallet {
+  if (provider.isRabby) {
+    return { id: `legacy:rabby:${index}`, name: "Rabby Wallet", rdns: "io.rabby", provider };
+  }
+  if (provider.isBraveWallet) {
+    return { id: `legacy:brave:${index}`, name: "Brave Wallet", rdns: "com.brave.wallet", provider };
+  }
+  if (provider.isCoinbaseWallet) {
+    return { id: `legacy:coinbase:${index}`, name: "Coinbase Wallet", rdns: "com.coinbase.wallet", provider };
+  }
+  if (provider.isMetaMask) {
+    return { id: `legacy:metamask:${index}`, name: "MetaMask", rdns: "io.metamask", provider };
+  }
+  return { id: `legacy:injected:${index}`, name: "Browser wallet", rdns: `injected.${index}`, provider };
+}
+
+/**
+ * Discover every injected wallet without trusting the contested
+ * `window.ethereum` slot. EIP-6963 is authoritative; the legacy providers
+ * array remains as a fallback for older extensions.
+ */
+export async function discoverInjectedWallets(waitMs = 100): Promise<InjectedWallet[]> {
+  const discovered: InjectedWallet[] = [];
+  const seen = new Set<EthereumProvider>();
+  const announce = (event: Event) => {
+    const detail = (event as CustomEvent<Eip6963Detail>).detail;
+    if (!detail?.provider || !detail.info || seen.has(detail.provider)) return;
+    seen.add(detail.provider);
+    discovered.push({
+      id: detail.info.uuid,
+      name: detail.info.name,
+      rdns: detail.info.rdns,
+      provider: detail.provider,
+    });
+  };
+
+  window.addEventListener("eip6963:announceProvider", announce);
+  window.dispatchEvent(new Event("eip6963:requestProvider"));
+  await new Promise((resolve) => setTimeout(resolve, waitMs));
+  window.removeEventListener("eip6963:announceProvider", announce);
+
+  const ethereum = (window as unknown as {
+    ethereum?: EthereumProvider & { providers?: EthereumProvider[] };
+  }).ethereum;
+  const legacyProviders = ethereum?.providers?.length ? ethereum.providers : ethereum ? [ethereum] : [];
+  for (const [index, provider] of legacyProviders.entries()) {
+    if (seen.has(provider)) continue;
+    seen.add(provider);
+    discovered.push(legacyWallet(provider, index));
+  }
+
+  return discovered.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function rememberInjectedWallet(wallet: InjectedWallet) {
+  try {
+    window.sessionStorage.setItem(REMEMBERED_WALLET_KEY, wallet.rdns);
+  } catch {
+    // Wallet selection still works when storage is unavailable.
+  }
+}
+
+export function rememberedInjectedWallet(wallets: InjectedWallet[]): InjectedWallet | null {
+  try {
+    const rdns = window.sessionStorage.getItem(REMEMBERED_WALLET_KEY);
+    return wallets.find((wallet) => wallet.rdns === rdns) ?? null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Outcome

- discovers injected browser wallets through EIP-6963 instead of trusting the contested `window.ethereum` slot
- shows a wallet chooser when MetaMask, Coinbase Wallet, or multiple extensions are installed
- remembers the member's chosen provider through the signup-to-portal handoff so wallet verification and the USDC transaction use the same wallet
- retains legacy multi-provider fallback for older extensions

## Verification

Exact head `35702a8`:

- web tests: 29/29 files, 229/229 tests
- lint: 0 errors (2 pre-existing warnings)
- shared build: passed
- production build: passed
- diff check: clean

No schema or deployment configuration changes.