### PR TITLE
fix: bound OP authorization log scans

### DIFF
--- a/apps/web/src/lib/onchain/gaslessRelay.ts
+++ b/apps/web/src/lib/onchain/gaslessRelay.ts
@@ -59,6 +59,7 @@ const AUTHORIZATION_USED_EVENT = parseAbiItem(
 const AUTHORIZATION_CANCELED_EVENT = parseAbiItem(
   "event AuthorizationCanceled(address indexed authorizer, bytes32 indexed nonce)",
 );
+const MAX_LOG_BLOCKS_PER_REQUEST = BigInt(10);
 
 export function authorizationTypedData(job: Pick<RelayJob,
   "from_address" | "token_contract" | "treasury_address" | "amount_usdc_micros" | "valid_after" | "valid_before" | "authorization_nonce"
@@ -172,41 +173,75 @@ async function recoverUsedAuthorization(
 ): Promise<Hash | null> {
   const client = getOpPublicClient();
   await assertOpPublicClient(client);
+  const observedBlock = await client.getBlockNumber();
   const used = await client.readContract({
     address: getAddress(job.token_contract),
     abi: USDC_AUTHORIZATION_ABI,
     functionName: "authorizationState",
     args: [getAddress(job.from_address), job.authorization_nonce as Hex],
+    blockNumber: observedBlock,
   });
   if (!used) return null;
 
-  const logs = await client.getLogs({
-    address: getAddress(job.token_contract),
-    event: AUTHORIZATION_USED_EVENT,
-    args: {
-      authorizer: getAddress(job.from_address),
-      nonce: job.authorization_nonce as Hex,
-    },
-    fromBlock: BigInt(job.authorization_from_block),
-    toBlock: "latest",
-  });
-  const hashes = [...new Set(logs.map((log) => log.transactionHash).filter(Boolean))] as Hash[];
-  if (hashes.length === 0) {
-    const canceled = await client.getLogs({
-      address: getAddress(job.token_contract),
-      event: AUTHORIZATION_CANCELED_EVENT,
-      args: {
-        authorizer: getAddress(job.from_address),
-        nonce: job.authorization_nonce as Hex,
-      },
-      fromBlock: BigInt(job.authorization_from_block),
-      toBlock: "latest",
-    });
-    if (canceled.length > 0) {
-      throw new InvalidRelayJobError("payment authorization was canceled in the wallet");
+  const fromBlock = BigInt(job.authorization_from_block);
+  let throughBlock = observedBlock;
+  const latest = await client.getBlock({ blockNumber: observedBlock });
+  if (latest.timestamp > BigInt(job.valid_before)) {
+    const anchor = await client.getBlock({ blockNumber: fromBlock });
+    if (anchor.timestamp >= BigInt(job.valid_before)) {
+      throughBlock = fromBlock;
+    } else {
+      let low = fromBlock;
+      let high = observedBlock;
+      while (low < high) {
+        const middle = (low + high + BigInt(1)) / BigInt(2);
+        const block = await client.getBlock({ blockNumber: middle });
+        if (block.timestamp < BigInt(job.valid_before)) low = middle;
+        else high = middle - BigInt(1);
+      }
+      throughBlock = low;
     }
   }
-  if (hashes.length !== 1) {
+
+  let authorizationLogs: Awaited<ReturnType<typeof client.getLogs>> = [];
+  for (let chunkStart = fromBlock; chunkStart <= throughBlock; chunkStart += MAX_LOG_BLOCKS_PER_REQUEST) {
+    const chunkEnd = chunkStart + MAX_LOG_BLOCKS_PER_REQUEST - BigInt(1) < throughBlock
+      ? chunkStart + MAX_LOG_BLOCKS_PER_REQUEST - BigInt(1)
+      : throughBlock;
+    authorizationLogs = await client.getLogs({
+      address: getAddress(job.token_contract),
+      events: [AUTHORIZATION_USED_EVENT, AUTHORIZATION_CANCELED_EVENT],
+      fromBlock: chunkStart,
+      toBlock: chunkEnd,
+    });
+    authorizationLogs = authorizationLogs.filter((log) => {
+      const args = (log as { args?: { authorizer?: string; nonce?: Hex } }).args;
+      return args?.authorizer
+        && getAddress(args.authorizer) === getAddress(job.from_address)
+        && args.nonce?.toLowerCase() === job.authorization_nonce.toLowerCase();
+    });
+    if (authorizationLogs.length > 0) break;
+  }
+
+  const usedLogs = authorizationLogs.filter(
+    (log) => (log as { eventName?: string }).eventName === "AuthorizationUsed",
+  );
+  const canceledLogs = authorizationLogs.filter(
+    (log) => (log as { eventName?: string }).eventName === "AuthorizationCanceled",
+  );
+  const hashes = [...new Set(usedLogs
+    .map((log) => log.transactionHash)
+    .filter(Boolean))] as Hash[];
+  if (hashes.length === 0) {
+    if (canceledLogs.length > 0) {
+      throw new InvalidRelayJobError("payment authorization was canceled in the wallet");
+    }
+    // Circle reports both used and canceled authorizations as consumed. Do
+    // not infer a terminal cancellation from missing logs: a transient RPC
+    // inconsistency must remain retryable so a real transfer is not orphaned.
+    throw new Error("payment authorization is consumed but its event is not available yet");
+  }
+  if (hashes.length > 1) {
     throw new Error(`used authorization has ${hashes.length} matching transfer transactions`);
   }
   await recordSubmittedTransaction(admin, job, hashes[0]);

--- a/apps/web/src/lib/onchain/gaslessRelayQueue.test.ts
+++ b/apps/web/src/lib/onchain/gaslessRelayQueue.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   writeContract: vi.fn(),
   getBlockNumber: vi.fn(),
+  getBlock: vi.fn(),
   readContract: vi.fn(),
   getLogs: vi.fn(),
 }));
@@ -15,6 +16,7 @@ vi.mock("./config", async (importOriginal) => ({
   ...await importOriginal<typeof import("./config")>(),
   getOpPublicClient: () => ({
     getBlockNumber: mocks.getBlockNumber,
+    getBlock: mocks.getBlock,
     readContract: mocks.readContract,
     getLogs: mocks.getLogs,
   }),
@@ -27,6 +29,14 @@ import { processGaslessRelayQueue } from "./gaslessRelay";
 
 const txHash = `0x${"aa".repeat(32)}` as const;
 const fromAddress = "0x1111111111111111111111111111111111111111";
+
+function authorizationLog(eventName: "AuthorizationUsed" | "AuthorizationCanceled") {
+  return {
+    eventName,
+    args: { authorizer: fromAddress, nonce: `0x${"ab".repeat(32)}` },
+    transactionHash: txHash,
+  };
+}
 
 function relayJob(overrides: Partial<RelayJob> = {}): RelayJob {
   return {
@@ -127,6 +137,7 @@ function stateFor(job: RelayJob): State {
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.getBlockNumber.mockResolvedValue(140_000_000n);
+  mocks.getBlock.mockResolvedValue({ timestamp: BigInt(Math.floor(Date.now() / 1000)) });
   mocks.readContract.mockResolvedValue(false);
   mocks.getLogs.mockResolvedValue([]);
   mocks.writeContract.mockResolvedValue(txHash);
@@ -165,14 +176,17 @@ describe("gasless relay queue", () => {
     }));
     const admin = fakeAdmin(state);
     mocks.readContract.mockResolvedValue(true);
-    mocks.getLogs.mockResolvedValue([{ transactionHash: txHash }]);
+    mocks.getLogs.mockResolvedValue([authorizationLog("AuthorizationUsed")]);
 
     const result = await processGaslessRelayQueue(admin as never, 101);
 
     expect(result).toEqual({ status: "submitted", invoiceId: 101, txHash });
+    expect(mocks.readContract).toHaveBeenCalledWith(expect.objectContaining({
+      blockNumber: 140_000_000n,
+    }));
     expect(mocks.getLogs).toHaveBeenCalledWith(expect.objectContaining({
       fromBlock: 139_999_900n,
-      args: { authorizer: fromAddress, nonce: state.job.authorization_nonce },
+      toBlock: 139_999_909n,
     }));
     expect(mocks.writeContract).not.toHaveBeenCalled();
   });
@@ -180,18 +194,32 @@ describe("gasless relay queue", () => {
   it("recovers a consumed authorization after its signing window expires instead of inviting a second payment", async () => {
     const state = stateFor(relayJob({
       status: "submitting",
-      valid_before: Math.floor(Date.now() / 1000) - 1,
+      authorization_from_block: 1_000,
+      valid_before: 1_025,
       attempts: 1,
     }));
     const admin = fakeAdmin(state);
+    mocks.getBlockNumber.mockResolvedValue(1_100n);
+    mocks.getBlock.mockImplementation(async ({ blockNumber }: { blockNumber: bigint }) => ({
+      timestamp: blockNumber,
+    }));
     mocks.readContract.mockResolvedValue(true);
-    mocks.getLogs.mockResolvedValue([{ transactionHash: txHash }]);
+    mocks.getLogs.mockImplementation(async ({ fromBlock }: { fromBlock: bigint }) => (
+      fromBlock === 1_020n
+        ? [authorizationLog("AuthorizationUsed")]
+        : []
+    ));
 
     const result = await processGaslessRelayQueue(admin as never, 101);
 
     expect(result).toEqual({ status: "submitted", invoiceId: 101, txHash });
     expect(state.job.status).toBe("submitted");
     expect(state.invoice).toMatchObject({ status: "submitted", submitted_tx_hash: txHash });
+    expect(mocks.getLogs).toHaveBeenCalledTimes(3);
+    expect(mocks.getLogs).toHaveBeenLastCalledWith(expect.objectContaining({
+      fromBlock: 1_020n,
+      toBlock: 1_024n,
+    }));
     expect(mocks.writeContract).not.toHaveBeenCalled();
   });
 
@@ -204,17 +232,53 @@ describe("gasless relay queue", () => {
     expect(mocks.writeContract).not.toHaveBeenCalled();
   });
 
+  it("scans a consumed authorization in provider-safe ten-block chunks", async () => {
+    const state = stateFor(relayJob({
+      status: "submitting",
+      authorization_from_block: 139_999_900,
+      attempts: 1,
+    }));
+    const admin = fakeAdmin(state);
+    mocks.readContract.mockResolvedValue(true);
+    mocks.getLogs.mockImplementation(async ({ fromBlock }: { fromBlock: bigint }) => (
+      fromBlock === 139_999_920n
+        ? [authorizationLog("AuthorizationUsed")]
+        : []
+    ));
+
+    const result = await processGaslessRelayQueue(admin as never, 101);
+
+    expect(result).toEqual({ status: "submitted", invoiceId: 101, txHash });
+    expect(mocks.getLogs).toHaveBeenCalledTimes(3);
+    for (const [request] of mocks.getLogs.mock.calls) {
+      expect(request.toBlock - request.fromBlock).toBeLessThanOrEqual(9n);
+    }
+    expect(mocks.writeContract).not.toHaveBeenCalled();
+  });
+
   it("expires a wallet-canceled authorization instead of retrying it forever", async () => {
     const state = stateFor(relayJob({ status: "submitting", attempts: 1 }));
     const admin = fakeAdmin(state);
     mocks.readContract.mockResolvedValue(true);
-    mocks.getLogs
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([{ transactionHash: txHash }]);
+    mocks.getBlockNumber.mockResolvedValue(139_999_900n);
+    mocks.getLogs.mockResolvedValue([authorizationLog("AuthorizationCanceled")]);
 
     await expect(processGaslessRelayQueue(admin as never, 101))
       .rejects.toThrow("authorization was canceled");
     expect(state.job.status).toBe("expired");
+    expect(mocks.writeContract).not.toHaveBeenCalled();
+  });
+
+  it("keeps a consumed authorization retryable when neither event is available yet", async () => {
+    const state = stateFor(relayJob({ status: "submitting", attempts: 1 }));
+    const admin = fakeAdmin(state);
+    mocks.readContract.mockResolvedValue(true);
+    mocks.getBlockNumber.mockResolvedValue(139_999_900n);
+    mocks.getLogs.mockResolvedValue([]);
+
+    await expect(processGaslessRelayQueue(admin as never, 101))
+      .rejects.toThrow("event is not available yet");
+    expect(state.job.status).toBe("submitting");
     expect(mocks.writeContract).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Fix

Make gasless USDC authorization recovery compatible with the production Alchemy free-tier limit of 10 blocks per `eth_getLogs` request.

The previous recovery query scanned from the authorization anchor to `latest` in one request. Real wallet interaction takes longer than ten OP blocks, so Alchemy rejected the query before the relay could submit or recover a payment.

## Correctness

- `authorizationState == false` still returns immediately without any log query.
- Pin `authorizationState`, the block-timestamp search, and every event scan to one observed OP block so mixed provider heights cannot create a false terminal result.
- For a consumed nonce, resolve the last block whose timestamp is inside the signed authorization window using a bounded block-timestamp binary search.
- Scan Circle's `AuthorizationUsed` and `AuthorizationCanceled` events forward in inclusive 10-block chunks, then match the exact authorizer and nonce in-process.
- Never cap recovery to only the newest ten blocks: that could lose an older successfully broadcast transaction.
- Classify a job as terminally canceled only with a positive `AuthorizationCanceled` event. If Circle reports the nonce consumed but neither event is available, leave the job retryable rather than risk orphaning a real payment during an RPC inconsistency.
- Existing exact invoice/transaction receipt verification remains unchanged and is still the only credit boundary.

This also handles the currently expired smoke-test authorization without scanning the ~28,000 blocks accumulated since it was prepared.

## Verification

- Full web suite: 32 files, 245 tests passed
- New realistic regressions cover multi-chunk recovery, maximum inclusive range of ten blocks, expiry-block bounding, post-expiry transaction recovery, positive cancellation evidence, and retryable missing-event handling
- Lint: 0 errors, 2 pre-existing warnings
- Shared + Next 16/Turbopack production build passed
- `git diff --check` clean; worktree clean
- Verified at exact head `05ac5d8f0e243734889fd998c0a11eca3cd5dbee`

No migration or configuration change.
