### PR TITLE
Fix production gasless relay worker claim

### DIFF
--- a/apps/web/src/components/membership/CryptoSubscribeButton.tsx
+++ b/apps/web/src/components/membership/CryptoSubscribeButton.tsx
@@ -152,24 +152,25 @@ function CryptoSubscribeButtonInner({ planKey, className }: Props) {
       });
     }
 
-    for (let attempt = 0; attempt < 12; attempt += 1) {
-      const relayRes = await fetch("/api/portal/onchain/relay", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ invoice_id: nextSetup.invoice.id, signature }),
-      });
-      const relayed = await relayRes.json() as { status?: string; txHash?: Hash; error?: string };
-      if (!relayRes.ok && relayRes.status !== 202) {
-        throw new Error(relayed.error ?? "Could not submit gasless payment");
-      }
-      if (relayed.txHash) {
-        await confirmSubmittedPayment(nextSetup.invoice.id, relayed.txHash);
-        return;
-      }
-      signature = undefined;
-      if (attempt < 11) await new Promise((resolve) => setTimeout(resolve, 3_000));
+    const relayRes = await fetch("/api/portal/onchain/relay", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ invoice_id: nextSetup.invoice.id, signature }),
+    });
+    const relayed = await relayRes.json() as {
+      status?: string;
+      txHash?: Hash;
+      error?: string;
+      warning?: string;
+    };
+    if (!relayRes.ok && relayRes.status !== 202) {
+      throw new Error(relayed.error ?? "Could not submit gasless payment");
     }
-    throw new Error("Payment authorization is queued; RegenHub will keep retrying it. Do not authorize again.");
+    if (relayed.txHash) {
+      await confirmSubmittedPayment(nextSetup.invoice.id, relayed.txHash);
+      return;
+    }
+    throw new Error(relayed.warning ?? "Payment authorization is queued; RegenHub will keep retrying it. Do not authorize again.");
   }, [address, confirmSubmittedPayment, signTypedDataAsync, switchChainAsync]);
 
   const verifyAndPay = useCallback(async () => {

--- a/apps/web/src/components/portal/OnchainBillingCard.tsx
+++ b/apps/web/src/components/portal/OnchainBillingCard.tsx
@@ -130,21 +130,19 @@ function OnchainBillingCardInner(props: Props) {
       }
 
       let txHash = prepared.txHash ?? null;
-      for (let attempt = 0; !txHash && attempt < 12; attempt += 1) {
+      if (!txHash) {
         const relayRes = await fetch("/api/portal/onchain/relay", {
           method: "POST", headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ invoice_id: props.invoice.id, signature }),
         });
-        const relayed = await relayRes.json() as { txHash?: Hash; error?: string };
+        const relayed = await relayRes.json() as { txHash?: Hash; error?: string; warning?: string };
         if (!relayRes.ok && relayRes.status !== 202) {
           throw new Error(relayed.error ?? "Could not submit gasless payment");
         }
         txHash = relayed.txHash ?? null;
-        signature = undefined;
-        if (!txHash && attempt < 11) await new Promise((resolve) => setTimeout(resolve, 3_000));
-      }
-      if (!txHash) {
-        throw new Error("Payment authorization is queued; RegenHub will keep retrying it. Do not authorize again.");
+        if (!txHash) {
+          throw new Error(relayed.warning ?? "Payment authorization is queued; RegenHub will keep retrying it. Do not authorize again.");
+        }
       }
       transferHash = txHash;
       setSubmittedTxHash(txHash);

--- a/apps/web/src/lib/onchain/gaslessRelay.ts
+++ b/apps/web/src/lib/onchain/gaslessRelay.ts
@@ -104,15 +104,25 @@ async function claimWorker(admin: ServiceClient) {
   const token = randomUUID();
   const claimedAt = new Date().toISOString();
   const staleAt = new Date(Date.now() - WORKER_LEASE_MS).toISOString();
-  const { data, error } = await admin
-    .from("onchain_relay_worker")
-    .update({ lease_token: token, lease_claimed_at: claimedAt })
-    .eq("singleton", true)
-    .or(`lease_claimed_at.is.null,lease_claimed_at.lte.${staleAt}`)
-    .select("lease_token")
-    .maybeSingle();
-  if (error) throw error;
-  return data?.lease_token === token ? token : null;
+  const tryClaim = async (availability: "unclaimed" | "stale") => {
+    let query = admin
+      .from("onchain_relay_worker")
+      .update({ lease_token: token, lease_claimed_at: claimedAt })
+      .eq("singleton", true);
+    query = availability === "unclaimed"
+      ? query.is("lease_claimed_at", null)
+      : query.lte("lease_claimed_at", staleAt);
+    const { data, error } = await query.select("lease_token").maybeSingle();
+    if (error) throw error;
+    return data?.lease_token === token;
+  };
+
+  // PostgREST 12.2.12 miscompiles an OR filter on this PATCH into a qualified
+  // column reference that PostgreSQL rejects, even though the column exists.
+  // Two individually atomic conditional updates preserve the same lease
+  // semantics: claim an empty lease first, then recover a stale one.
+  if (await tryClaim("unclaimed")) return token;
+  return await tryClaim("stale") ? token : null;
 }
 
 async function releaseWorker(admin: ServiceClient, token: string) {

--- a/apps/web/src/lib/onchain/gaslessRelayQueue.test.ts
+++ b/apps/web/src/lib/onchain/gaslessRelayQueue.test.ts
@@ -77,6 +77,7 @@ function fakeAdmin(state: State) {
     let operation: "select" | "update" = "select";
     let updateValue: Record<string, unknown> | null = null;
     let selectAfterUpdate = false;
+    let workerEligible = true;
     const chain: Record<string, unknown> = {};
     chain.select = vi.fn(() => { selectAfterUpdate = operation === "update"; return chain; });
     chain.update = vi.fn((value: Record<string, unknown>) => {
@@ -84,15 +85,30 @@ function fakeAdmin(state: State) {
       updateValue = value;
       return chain;
     });
-    for (const method of ["eq", "neq", "is", "in", "or", "order", "limit"]) {
+    for (const method of ["eq", "neq", "in", "or", "order", "limit"]) {
       chain[method] = vi.fn(() => chain);
     }
+    chain.is = vi.fn((column: string, value: unknown) => {
+      if (table === "onchain_relay_worker" && column === "lease_claimed_at" && value === null) {
+        workerEligible = state.worker.lease_claimed_at === null;
+      }
+      return chain;
+    });
+    chain.lte = vi.fn((column: string, value: string) => {
+      if (table === "onchain_relay_worker" && column === "lease_claimed_at") {
+        workerEligible = Boolean(
+          state.worker.lease_claimed_at
+          && new Date(state.worker.lease_claimed_at).getTime() <= new Date(value).getTime(),
+        );
+      }
+      return chain;
+    });
 
     const execute = async () => {
       if (operation === "update" && updateValue) {
         if (table === "onchain_relay_worker") {
           const claiming = Boolean(updateValue.lease_claimed_at);
-          if (claiming && state.worker.lease_claimed_at) return { data: null, error: null };
+          if (claiming && !workerEligible) return { data: null, error: null };
           Object.assign(state.worker, updateValue);
           return { data: selectAfterUpdate ? { lease_token: state.worker.lease_token } : null, error: null };
         }
@@ -230,6 +246,20 @@ describe("gasless relay queue", () => {
 
     await expect(processGaslessRelayQueue(admin as never, 101)).resolves.toEqual({ status: "busy" });
     expect(mocks.writeContract).not.toHaveBeenCalled();
+  });
+
+  it("recovers a stale worker lease without an OR filter", async () => {
+    const state = stateFor(relayJob());
+    state.worker = {
+      lease_token: "crashed-worker",
+      lease_claimed_at: new Date(Date.now() - 10 * 60_000).toISOString(),
+    };
+    const admin = fakeAdmin(state);
+
+    const result = await processGaslessRelayQueue(admin as never, 101);
+
+    expect(result).toEqual({ status: "submitted", invoiceId: 101, txHash });
+    expect(state.worker).toEqual({ lease_token: null, lease_claimed_at: null });
   });
 
   it("scans a consumed authorization in provider-safe ten-block chunks", async () => {


### PR DESCRIPTION
## Outcome

Repairs the production gasless-USDC worker claim and removes the misleading 36-second browser retry loop.

## Root cause, reproduced in production

Migration 048 is present with the expected checksum, PostgreSQL has `onchain_relay_worker.lease_claimed_at`, and PostgREST loaded the schema successfully. The failure is narrower: PostgREST 12.2.12 miscompiles this PATCH filter:

```text
or=(lease_claimed_at.is.null,lease_claimed_at.lte.<cutoff>)
```

PostgreSQL then returns `42703: column onchain_relay_worker.lease_claimed_at does not exist`. A plain read of the same column succeeds.

The replacement performs two individually atomic conditional PATCHes: claim an unclaimed lease first, then recover a stale lease. Production probes through the live web container proved both the null-lease and stale-lease branches claim and release cleanly. No Supabase restart or migration is needed.

## Changes

- replace the broken combined OR worker claim with atomic `IS NULL` then stale-cutoff claims
- retain the five-minute crash-recovery lease and relayer nonce serialization
- add a stale-worker regression
- stop membership and portal clients after the first queued response and display the server warning instead of silently repeating the relay request 12 times

## Verification at `5c62a99`

- live production read: relay tables and `lease_claimed_at` confirmed in PostgreSQL
- live production reproduction: old OR PATCH fails with exact `42703`
- live production proof: null claim/release succeeds; stale claim takeover/release succeeds
- full web suite: 32/32 files, 246/246 tests
- lint: 0 errors, 2 pre-existing warnings
- shared build and Next 16/Turbopack production build: pass
- `git diff --check`: pass

No migration or configuration change.
