### PR TITLE
fix(web): guard and track OP payments

### DIFF
--- a/apps/web/src/app/api/portal/onchain/relay/prepare/route.test.ts
+++ b/apps/web/src/app/api/portal/onchain/relay/prepare/route.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   requirePortalMember: vi.fn(),
   createServiceClient: vi.fn(),
   getBlockNumber: vi.fn(),
+  readContract: vi.fn(),
 }));
 
 vi.mock("@/lib/onchain/portalMember", () => ({ requirePortalMember: mocks.requirePortalMember }));
@@ -11,7 +12,7 @@ vi.mock("@/lib/supabase/admin", () => ({ createServiceClient: mocks.createServic
 vi.mock("@/lib/onchain/config", async (importOriginal) => ({
   ...await importOriginal<typeof import("@/lib/onchain/config")>(),
   isGaslessRelayConfigured: () => true,
-  getOpPublicClient: () => ({ getBlockNumber: mocks.getBlockNumber }),
+  getOpPublicClient: () => ({ getBlockNumber: mocks.getBlockNumber, readContract: mocks.readContract }),
   assertOpPublicClient: vi.fn(async () => undefined),
 }));
 
@@ -64,6 +65,7 @@ beforeEach(() => {
     member: { id: 7, disabled: false },
   });
   mocks.getBlockNumber.mockResolvedValue(140_000_000n);
+  mocks.readContract.mockResolvedValue(500_000_000n);
 });
 describe("POST /api/portal/onchain/relay/prepare", () => {
   it("builds authorization only from the member's frozen invoice and verified wallet", async () => {
@@ -130,6 +132,35 @@ describe("POST /api/portal/onchain/relay/prepare", () => {
     expect(from).not.toHaveBeenCalledWith("onchain_relay_jobs");
   });
 
+  it("reports the exact native OP USDC shortfall before requesting a signature", async () => {
+    const jobs = jobsBuilder();
+    const tables = {
+      onchain_invoices: selectBuilder(invoice),
+      subscriptions: selectBuilder({ wallet_id: 12, payment_rail: "onchain" }),
+      member_wallets: selectBuilder({ address: "0x1111111111111111111111111111111111111111" }),
+      onchain_relay_jobs: jobs.chain,
+    };
+    mocks.createServiceClient.mockReturnValue({
+      from: (table: keyof typeof tables) => tables[table],
+    });
+    mocks.readContract.mockResolvedValue(3_858_523n);
+
+    const response = await POST(new Request("http://localhost/api/portal/onchain/relay/prepare", {
+      method: "POST",
+      body: JSON.stringify({ invoice_id: 101 }),
+    }));
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "This wallet has 3.858523 native USDC on OP Mainnet, but this payment requires 250. Add 246.141477 USDC to this wallet before authorizing.",
+      code: "insufficient_usdc_balance",
+      balance_usdc_micros: "3858523",
+      required_usdc_micros: "250000000",
+      shortfall_usdc_micros: "246141477",
+    });
+    expect(jobs.chain.upsert).not.toHaveBeenCalled();
+  });
+
   it("does not overwrite an expired signed job before the worker can recover a consumed authorization", async () => {
     const existing = {
       invoice_id: 101,
@@ -166,5 +197,6 @@ describe("POST /api/portal/onchain/relay/prepare", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ status: "queued" });
     expect(jobs.chain.upsert).not.toHaveBeenCalled();
+    expect(mocks.readContract).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/portal/onchain/relay/prepare/route.ts
+++ b/apps/web/src/app/api/portal/onchain/relay/prepare/route.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { NextResponse } from "next/server";
+import { getAddress, parseAbi } from "viem";
 import { createServiceClient } from "@/lib/supabase/admin";
 import {
   assertOpPublicClient,
@@ -13,6 +14,16 @@ import { publicAuthorization, type RelayJob } from "@/lib/onchain/gaslessRelay";
 import { requirePortalMember } from "@/lib/onchain/portalMember";
 
 const AUTHORIZATION_LIFETIME_SECONDS = 30 * 60;
+const USDC_BALANCE_ABI = parseAbi([
+  "function balanceOf(address account) view returns (uint256)",
+]);
+
+function formatUsdcMicros(value: bigint) {
+  const microsPerUsdc = BigInt(1_000_000);
+  const whole = value / microsPerUsdc;
+  const fraction = (value % microsPerUsdc).toString().padStart(6, "0").replace(/0+$/, "");
+  return fraction ? `${whole}.${fraction}` : whole.toString();
+}
 
 function responseForJob(job: RelayJob) {
   if (job.status === "submitted" && job.submitted_tx_hash) {
@@ -97,9 +108,39 @@ export async function POST(request: Request) {
     if (["signed", "submitting", "submitted"].includes(existing.status)) {
       return NextResponse.json(responseForJob(existing));
     }
-    if (existing.status === "prepared" && existing.valid_before > now + 30) {
-      return NextResponse.json(responseForJob(existing));
+  }
+
+  let authorizationFromBlock: number;
+  try {
+    const client = getOpPublicClient();
+    await assertOpPublicClient(client);
+    const observedBlock = await client.getBlockNumber();
+    const balance = await client.readContract({
+      address: NATIVE_USDC_ADDRESS,
+      abi: USDC_BALANCE_ABI,
+      functionName: "balanceOf",
+      args: [getAddress(wallet.address)],
+      blockNumber: observedBlock,
+    });
+    const required = BigInt(invoice.amount_usdc_micros);
+    if (balance < required) {
+      const shortfall = required - balance;
+      return NextResponse.json({
+        error: `This wallet has ${formatUsdcMicros(balance)} native USDC on OP Mainnet, but this payment requires ${formatUsdcMicros(required)}. Add ${formatUsdcMicros(shortfall)} USDC to this wallet before authorizing.`,
+        code: "insufficient_usdc_balance",
+        balance_usdc_micros: balance.toString(),
+        required_usdc_micros: required.toString(),
+        shortfall_usdc_micros: shortfall.toString(),
+      }, { status: 409 });
     }
+    authorizationFromBlock = Number(observedBlock);
+  } catch (error) {
+    console.error("[GaslessRelay] Could not verify wallet balance:", error);
+    return NextResponse.json({ error: "Could not verify the wallet's OP USDC balance" }, { status: 503 });
+  }
+
+  if (existing?.status === "prepared" && existing.valid_before > now + 30) {
+    return NextResponse.json(responseForJob(existing));
   }
 
   const values = {
@@ -115,21 +156,13 @@ export async function POST(request: Request) {
     valid_before: now + AUTHORIZATION_LIFETIME_SECONDS,
     signature: null,
     status: "prepared" as const,
-    authorization_from_block: 0,
+    authorization_from_block: authorizationFromBlock,
     submitted_tx_hash: null,
     attempts: 0,
     last_error: null,
     signed_at: null,
     submitted_at: null,
   };
-  try {
-    const client = getOpPublicClient();
-    await assertOpPublicClient(client);
-    values.authorization_from_block = Number(await client.getBlockNumber());
-  } catch (error) {
-    console.error("[GaslessRelay] Could not anchor authorization block:", error);
-    return NextResponse.json({ error: "Could not prepare the payment" }, { status: 503 });
-  }
   const { data: job, error: upsertError } = await admin
     .from("onchain_relay_jobs")
     .upsert(values, { onConflict: "invoice_id" })

--- a/apps/web/src/components/membership/CryptoSubscribeButton.tsx
+++ b/apps/web/src/components/membership/CryptoSubscribeButton.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { CheckCircle2, Loader2, Wallet } from "lucide-react";
 import { RegenHubWalletProvider } from "@/components/web3/RegenHubWalletProvider";
+import { pollOnchainPayment } from "@/lib/onchain/clientConfirmation";
 
 type Setup = {
   subscription_id: number;
@@ -81,38 +82,25 @@ function CryptoSubscribeButtonInner({ planKey, className }: Props) {
   const [txHash, setTxHash] = useState<Hash | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const submitAndTrack = useCallback(async (invoiceId: number, hash: Hash) => {
-    for (let attempt = 0; attempt < 12; attempt += 1) {
-      const response = await fetch("/api/portal/onchain/submit", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ invoice_id: invoiceId, tx_hash: hash }),
-      });
-      const result = await response.json();
-      if (!response.ok && response.status !== 202) {
-        throw new Error(result.error ?? "Could not track the transaction");
-      }
-      if (result.status === "paid") return true;
-      if (attempt < 11) await new Promise((resolve) => setTimeout(resolve, 5_000));
-    }
-    return false;
-  }, []);
-
   const confirmSubmittedPayment = useCallback(async (invoiceId: number, hash: Hash) => {
     setTxHash(hash);
     setPhase("confirming");
     sessionStorage.setItem(PENDING_PAYMENT_KEY, JSON.stringify({ invoiceId, hash }));
     try {
-      const paid = await submitAndTrack(invoiceId, hash);
+      const paid = await pollOnchainPayment({ invoiceId, txHash: hash });
       if (paid) {
         sessionStorage.removeItem(PENDING_PAYMENT_KEY);
         setPhase("complete");
         setTimeout(() => { window.location.href = "/portal?onchain=paid"; }, 1_500);
+      } else {
+        setError("OP safe confirmation is taking longer than expected. Your transaction was submitted; do not pay again. Use Check payment confirmation to resume.");
+        setPhase("idle");
       }
     } catch (cause) {
       setError(`${cause instanceof Error ? cause.message : "Confirmation is delayed"}. Your transaction was submitted; do not pay again. RegenHub will keep checking it.`);
+      setPhase("idle");
     }
-  }, [submitAndTrack]);
+  }, []);
 
   const sendPayment = useCallback(async (nextSetup: Setup) => {
     if (!address) throw new Error("Connect your wallet to continue.");
@@ -271,7 +259,7 @@ function CryptoSubscribeButtonInner({ planKey, className }: Props) {
         className={className ?? "btn-glass w-full gap-2"}
       >
         {phase === "complete" ? <CheckCircle2 className="w-4 h-4" /> : busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Wallet className="w-4 h-4" />}
-        {phase === "complete" ? "Payment confirmed" : busy ? PHASE_LABELS[phase as Exclude<Phase, "idle" | "complete">] : setup ? `Retry $${(amountCents / 100).toFixed(2)} USDC payment` : "Pay with crypto"}
+        {phase === "complete" ? "Payment confirmed" : busy ? PHASE_LABELS[phase as Exclude<Phase, "idle" | "complete">] : txHash ? "Check payment confirmation" : setup ? `Retry $${(amountCents / 100).toFixed(2)} USDC payment` : "Pay with crypto"}
       </Button>
 
       {isConnected && address && (

--- a/apps/web/src/components/portal/OnchainBillingCard.tsx
+++ b/apps/web/src/components/portal/OnchainBillingCard.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { CheckCircle2, Loader2, Wallet } from "lucide-react";
 import { RegenHubWalletProvider } from "@/components/web3/RegenHubWalletProvider";
+import { pollOnchainPayment } from "@/lib/onchain/clientConfirmation";
 
 type Props = {
   walletAddress: string | null;
@@ -147,21 +148,12 @@ function OnchainBillingCardInner(props: Props) {
       transferHash = txHash;
       setSubmittedTxHash(txHash);
       setMessage("Transaction submitted. RegenHub is checking OP confirmation…");
-      for (let attempt = 0; attempt < 12; attempt += 1) {
-        const res = await fetch("/api/portal/onchain/submit", {
-          method: "POST", headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ invoice_id: props.invoice.id, tx_hash: txHash }),
-        });
-        const result = await res.json();
-        if (!res.ok && res.status !== 202) throw new Error(result.error ?? "Could not track transaction");
-        if (result.status === "paid") {
-          setMessage("Payment confirmed — membership is active.");
-          setTimeout(() => window.location.reload(), 1_500);
-          return;
-        }
-        if (attempt < 11) await new Promise((resolve) => setTimeout(resolve, 5_000));
+      if (await pollOnchainPayment({ invoiceId: props.invoice.id, txHash })) {
+        setMessage("Payment confirmed — membership is active.");
+        setTimeout(() => window.location.reload(), 1_500);
+        return;
       }
-      setMessage("Payment submitted — confirmation will finish automatically.");
+      setMessage("Payment is still awaiting OP safe confirmation. Do not pay again; reopen this page to resume checking.");
     } catch (cause) {
       setError(transferHash
         ? `${cause instanceof Error ? cause.message : "Confirmation is delayed"}. Your transaction was submitted; do not pay again.`
@@ -169,6 +161,33 @@ function OnchainBillingCardInner(props: Props) {
       setMessage(null);
     } finally { setBusy(false); }
   }, [address, props.invoice, props.walletAddress, signTypedDataAsync, switchChainAsync]);
+
+  useEffect(() => {
+    const invoice = props.invoice;
+    if (!invoice?.txHash || !["submitted", "detected"].includes(invoice.status)) return;
+    const controller = new AbortController();
+    setBusy(true);
+    setMessage("Transaction submitted. RegenHub is checking OP confirmation…");
+    void pollOnchainPayment({
+      invoiceId: invoice.id,
+      txHash: invoice.txHash as Hash,
+      signal: controller.signal,
+    }).then((paid) => {
+      if (paid) {
+        setMessage("Payment confirmed — membership is active.");
+        setTimeout(() => window.location.reload(), 1_500);
+      } else {
+        setMessage("Payment is still awaiting OP safe confirmation. Do not pay again; reopen this page to resume checking.");
+      }
+    }).catch((cause) => {
+      if (!controller.signal.aborted) {
+        setError(`${cause instanceof Error ? cause.message : "Confirmation is delayed"}. Your transaction was submitted; do not pay again.`);
+      }
+    }).finally(() => {
+      if (!controller.signal.aborted) setBusy(false);
+    });
+    return () => controller.abort();
+  }, [props.invoice]);
 
   useEffect(() => {
     if (!pendingAction || !isConnected || !address) return;

--- a/apps/web/src/lib/onchain/clientConfirmation.test.ts
+++ b/apps/web/src/lib/onchain/clientConfirmation.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { pollOnchainPayment } from "./clientConfirmation";
+
+const txHash = `0x${"ab".repeat(32)}` as const;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("pollOnchainPayment", () => {
+  it("continues from submitted through detected until the invoice is paid", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ status: "submitted" }), { status: 202 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ status: "detected" }), { status: 202 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ status: "paid" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(pollOnchainPayment({
+      invoiceId: 101,
+      txHash,
+      attempts: 3,
+      intervalMs: 0,
+    })).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns pending after the bounded confirmation window without creating another payment", async () => {
+    const fetchMock = vi.fn().mockImplementation(async () => (
+      new Response(JSON.stringify({ status: "detected" }), { status: 202 })
+    ));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(pollOnchainPayment({
+      invoiceId: 101,
+      txHash,
+      attempts: 2,
+      intervalMs: 0,
+    })).resolves.toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledWith("/api/portal/onchain/submit", expect.objectContaining({
+      body: JSON.stringify({ invoice_id: 101, tx_hash: txHash }),
+    }));
+  });
+});

--- a/apps/web/src/lib/onchain/clientConfirmation.ts
+++ b/apps/web/src/lib/onchain/clientConfirmation.ts
@@ -1,0 +1,48 @@
+import type { Hash } from "viem";
+
+export const CONFIRMATION_POLL_ATTEMPTS = 72;
+export const CONFIRMATION_POLL_INTERVAL_MS = 5_000;
+
+type PollOptions = {
+  invoiceId: number;
+  txHash: Hash;
+  signal?: AbortSignal;
+  attempts?: number;
+  intervalMs?: number;
+};
+
+export async function pollOnchainPayment({
+  invoiceId,
+  txHash,
+  signal,
+  attempts = CONFIRMATION_POLL_ATTEMPTS,
+  intervalMs = CONFIRMATION_POLL_INTERVAL_MS,
+}: PollOptions) {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const response = await fetch("/api/portal/onchain/submit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ invoice_id: invoiceId, tx_hash: txHash }),
+      signal,
+    });
+    const result = await response.json();
+    if (!response.ok && response.status !== 202) {
+      throw new Error(result.error ?? "Could not track the transaction");
+    }
+    if (result.status === "paid") return true;
+    if (attempt < attempts - 1) {
+      await new Promise<void>((resolve, reject) => {
+        const onAbort = () => {
+          globalThis.clearTimeout(timeout);
+          reject(signal?.reason);
+        };
+        const timeout = globalThis.setTimeout(() => {
+          signal?.removeEventListener("abort", onAbort);
+          resolve();
+        }, intervalMs);
+        signal?.addEventListener("abort", onAbort, { once: true });
+      });
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

- check the verified wallet's native OP USDC balance at a pinned block before returning an unsigned authorization
- return the exact required balance and shortfall instead of asking an underfunded wallet to sign
- poll submitted payments for up to six minutes and resume confirmation automatically when a submitted/detected portal invoice is reopened
- leave a bounded, explicit do-not-pay-again state if OP safe confirmation remains delayed

## Verification

- 33/33 test files, 249/249 tests
- ESLint: 0 errors (2 pre-existing warnings)
- shared TypeScript build
- Next 16/Turbopack production build
- clean worktree at exact head `f0e37780a5c4a3619a9b0ae6c84729817e575b3a`

No migration or configuration change.
