### PR TITLE
Credit included OP payments and fix renewal reminders

### DIFF
--- a/apps/web/src/app/api/cron/onchain-billing/route.ts
+++ b/apps/web/src/app/api/cron/onchain-billing/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { createServiceClient } from "@/lib/supabase/admin";
-import { generateUpcomingOnchainInvoices, markDueOnchainSubscriptionsPastDue } from "@/lib/onchain/invoice";
+import { generateUpcomingOnchainInvoices, isRenewalInvoice, markDueOnchainSubscriptionsPastDue } from "@/lib/onchain/invoice";
 import { advanceFinalizedOnchainPayments, processOnchainInvoice, retryPendingOnchainEffects } from "@/lib/onchain/verifyPayment";
 import { isGaslessRelayConfigured } from "@/lib/onchain/config";
 import { processGaslessRelayQueue } from "@/lib/onchain/gaslessRelay";
@@ -41,6 +41,9 @@ export async function POST(req: Request) {
   if (reminderQueryError) throw reminderQueryError;
   let remindersSent = 0;
   for (const invoice of unsentReminders ?? []) {
+    // A first-payment invoice uses due_at as its seven-day setup deadline;
+    // it is not a renewal date and must not receive a renewal reminder.
+    if (!isRenewalInvoice(invoice)) continue;
     const { data: member } = await admin.from("members").select("name, email").eq("id", invoice.member_id).single();
     const { data: subscription } = await admin.from("subscriptions").select("plan_key").eq("id", invoice.subscription_id).single();
     if (!member?.email || !subscription) continue;
@@ -48,7 +51,7 @@ export async function POST(req: Request) {
       name: member.name,
       planLabel: planLabel(subscription.plan_key),
       amountUsdc: (invoice.amount_cents / 100).toFixed(2),
-      dueDate: new Date(invoice.due_at).toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" }),
+      renewalDate: new Date(invoice.period_start).toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" }),
       siteUrl: process.env.NEXT_PUBLIC_SITE_URL ?? "https://regenhub.xyz",
     });
     if (await sendEmail({ to: member.email, ...mail })) {

--- a/apps/web/src/components/membership/CryptoSubscribeButton.tsx
+++ b/apps/web/src/components/membership/CryptoSubscribeButton.tsx
@@ -31,7 +31,7 @@ type Setup = {
   };
 };
 
-type Phase = "idle" | "connecting" | "verifying" | "preparing" | "sending" | "confirming" | "complete";
+type Phase = "idle" | "connecting" | "verifying" | "preparing" | "sending" | "confirming" | "received" | "complete";
 
 type RelayAuthorization = {
   domain: {
@@ -67,6 +67,7 @@ const PHASE_LABELS: Record<Exclude<Phase, "idle" | "complete">, string> = {
   preparing: "Preparing your membership invoice…",
   sending: "Authorizing gasless USDC payment…",
   confirming: "Confirming on OP Mainnet…",
+  received: "Payment received",
 };
 
 function CryptoSubscribeButtonInner({ planKey, className }: Props) {
@@ -87,7 +88,13 @@ function CryptoSubscribeButtonInner({ planKey, className }: Props) {
     setPhase("confirming");
     sessionStorage.setItem(PENDING_PAYMENT_KEY, JSON.stringify({ invoiceId, hash }));
     try {
-      const paid = await pollOnchainPayment({ invoiceId, txHash: hash });
+      const paid = await pollOnchainPayment({
+        invoiceId,
+        txHash: hash,
+        onStatus: (status) => {
+          if (status === "detected") setPhase("received");
+        },
+      });
       if (paid) {
         sessionStorage.removeItem(PENDING_PAYMENT_KEY);
         setPhase("complete");
@@ -258,7 +265,7 @@ function CryptoSubscribeButtonInner({ planKey, className }: Props) {
         disabled={busy || phase === "complete"}
         className={className ?? "btn-glass w-full gap-2"}
       >
-        {phase === "complete" ? <CheckCircle2 className="w-4 h-4" /> : busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Wallet className="w-4 h-4" />}
+        {phase === "complete" || phase === "received" ? <CheckCircle2 className="w-4 h-4" /> : busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Wallet className="w-4 h-4" />}
         {phase === "complete" ? "Payment confirmed" : busy ? PHASE_LABELS[phase as Exclude<Phase, "idle" | "complete">] : txHash ? "Check payment confirmation" : setup ? `Retry $${(amountCents / 100).toFixed(2)} USDC payment` : "Pay with crypto"}
       </Button>
 

--- a/apps/web/src/components/portal/OnchainBillingCard.tsx
+++ b/apps/web/src/components/portal/OnchainBillingCard.tsx
@@ -63,6 +63,7 @@ function OnchainBillingCardInner(props: Props) {
   const [pendingAction, setPendingAction] = useState<WalletAction | null>(null);
   const [connectModalSeen, setConnectModalSeen] = useState(false);
   const [submittedTxHash, setSubmittedTxHash] = useState<Hash | null>(null);
+  const [paymentDetected, setPaymentDetected] = useState(props.invoice?.status === "detected");
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -148,7 +149,16 @@ function OnchainBillingCardInner(props: Props) {
       transferHash = txHash;
       setSubmittedTxHash(txHash);
       setMessage("Transaction submitted. RegenHub is checking OP confirmation…");
-      if (await pollOnchainPayment({ invoiceId: props.invoice.id, txHash })) {
+      if (await pollOnchainPayment({
+        invoiceId: props.invoice.id,
+        txHash,
+        onStatus: (status) => {
+          if (status === "detected") {
+            setPaymentDetected(true);
+            setMessage("Payment received. RegenHub is completing safe OP confirmation…");
+          }
+        },
+      })) {
         setMessage("Payment confirmed — membership is active.");
         setTimeout(() => window.location.reload(), 1_500);
         return;
@@ -166,12 +176,21 @@ function OnchainBillingCardInner(props: Props) {
     const invoice = props.invoice;
     if (!invoice?.txHash || !["submitted", "detected"].includes(invoice.status)) return;
     const controller = new AbortController();
+    setPaymentDetected(invoice.status === "detected");
     setBusy(true);
-    setMessage("Transaction submitted. RegenHub is checking OP confirmation…");
+    setMessage(invoice.status === "detected"
+      ? "Payment received. RegenHub is completing safe OP confirmation…"
+      : "Transaction submitted. RegenHub is checking OP confirmation…");
     void pollOnchainPayment({
       invoiceId: invoice.id,
       txHash: invoice.txHash as Hash,
       signal: controller.signal,
+      onStatus: (status) => {
+        if (status === "detected") {
+          setPaymentDetected(true);
+          setMessage("Payment received. RegenHub is completing safe OP confirmation…");
+        }
+      },
     }).then((paid) => {
       if (paid) {
         setMessage("Payment confirmed — membership is active.");
@@ -249,8 +268,8 @@ function OnchainBillingCardInner(props: Props) {
             <p className="text-xs text-muted">Due {new Date(props.invoice.dueAt).toLocaleDateString()}</p>
           </div>
           <Button disabled={busy || Boolean(submittedTxHash) || !props.configured || ["submitted", "detected"].includes(props.invoice.status)} onClick={() => begin("pay")} className="bg-sage/20 hover:bg-sage/40 text-sage border border-sage/30 text-xs gap-2">
-            {busy && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
-            {["submitted", "detected"].includes(props.invoice.status) ? "Confirming…" : "Review & pay"}
+            {busy && !paymentDetected && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+            {paymentDetected || props.invoice.status === "detected" ? "Payment received" : props.invoice.status === "submitted" ? "Confirming…" : "Review & pay"}
           </Button>
         </div>
       ) : props.invoice?.status === "paid" ? (

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -495,24 +495,24 @@ export function onchainRenewalReminderEmail(args: {
   name: string;
   planLabel: string;
   amountUsdc: string;
-  dueDate: string;
+  renewalDate: string;
   siteUrl: string;
 }) {
   const firstName = args.name.split(" ")[0];
   const base = args.siteUrl.replace(/\/$/, "");
   return {
-    subject: `Your RegenHub crypto renewal is due ${args.dueDate}`,
+    subject: `Your RegenHub membership renews ${args.renewalDate}`,
     html: `
       <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 560px; margin: 0 auto; padding: 24px; color: #1a1a1a; line-height: 1.55;">
         <p>Hi ${firstName},</p>
-        <p>Your <strong>${args.planLabel}</strong> membership renews on <strong>${args.dueDate}</strong>.</p>
+        <p>Your <strong>${args.planLabel}</strong> membership renews on <strong>${args.renewalDate}</strong>.</p>
         <p>Your membership rate is <strong>${args.amountUsdc} USDC</strong>. Open the portal, connect your verified wallet, and RegenHub will prepare the exact native-USDC transfer on OP Mainnet for you to approve.</p>
         <p style="margin: 20px 0;"><a href="${base}/portal" style="background: #2d5e3e; color: white; padding: 12px 20px; border-radius: 8px; text-decoration: none; display: inline-block;">Review and pay</a></p>
-        <p>You stay in good standing through the due date, with the same seven-day grace period afterward if you need it.</p>
+        <p>You stay in good standing through the renewal date, with the same seven-day grace period afterward if you need it.</p>
         <p>&mdash; RegenHub</p>
       </div>
     `,
-    text: `Hi ${firstName},\n\nYour ${args.planLabel} membership renews on ${args.dueDate}.\n\nYour membership rate is ${args.amountUsdc} USDC. Open the portal, connect your verified wallet, and RegenHub will prepare the exact native-USDC transfer on OP Mainnet for you to approve:\n${base}/portal\n\nYou stay in good standing through the due date, with the same seven-day grace period afterward if you need it.\n\n— RegenHub`,
+    text: `Hi ${firstName},\n\nYour ${args.planLabel} membership renews on ${args.renewalDate}.\n\nYour membership rate is ${args.amountUsdc} USDC. Open the portal, connect your verified wallet, and RegenHub will prepare the exact native-USDC transfer on OP Mainnet for you to approve:\n${base}/portal\n\nYou stay in good standing through the renewal date, with the same seven-day grace period afterward if you need it.\n\n— RegenHub`,
   };
 }
 

--- a/apps/web/src/lib/onchain/clientConfirmation.test.ts
+++ b/apps/web/src/lib/onchain/clientConfirmation.test.ts
@@ -14,14 +14,17 @@ describe("pollOnchainPayment", () => {
       .mockResolvedValueOnce(new Response(JSON.stringify({ status: "detected" }), { status: 202 }))
       .mockResolvedValueOnce(new Response(JSON.stringify({ status: "paid" }), { status: 200 }));
     vi.stubGlobal("fetch", fetchMock);
+    const onStatus = vi.fn();
 
     await expect(pollOnchainPayment({
       invoiceId: 101,
       txHash,
       attempts: 3,
       intervalMs: 0,
+      onStatus,
     })).resolves.toBe(true);
     expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(onStatus.mock.calls.map(([status]) => status)).toEqual(["submitted", "detected", "paid"]);
   });
 
   it("returns pending after the bounded confirmation window without creating another payment", async () => {

--- a/apps/web/src/lib/onchain/clientConfirmation.ts
+++ b/apps/web/src/lib/onchain/clientConfirmation.ts
@@ -9,6 +9,7 @@ type PollOptions = {
   signal?: AbortSignal;
   attempts?: number;
   intervalMs?: number;
+  onStatus?: (status: string) => void;
 };
 
 export async function pollOnchainPayment({
@@ -17,6 +18,7 @@ export async function pollOnchainPayment({
   signal,
   attempts = CONFIRMATION_POLL_ATTEMPTS,
   intervalMs = CONFIRMATION_POLL_INTERVAL_MS,
+  onStatus,
 }: PollOptions) {
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     const response = await fetch("/api/portal/onchain/submit", {
@@ -29,6 +31,7 @@ export async function pollOnchainPayment({
     if (!response.ok && response.status !== 202) {
       throw new Error(result.error ?? "Could not track the transaction");
     }
+    onStatus?.(result.status);
     if (result.status === "paid") return true;
     if (attempt < attempts - 1) {
       await new Promise<void>((resolve, reject) => {

--- a/apps/web/src/lib/onchain/invoice.test.ts
+++ b/apps/web/src/lib/onchain/invoice.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { addCalendarMonth, discountedCents, invoiceValues, markDueOnchainSubscriptionsPastDue } from "./invoice";
+import { addCalendarMonth, discountedCents, invoiceValues, isRenewalInvoice, markDueOnchainSubscriptionsPastDue } from "./invoice";
 
 describe("on-chain invoice math", () => {
   it("uses the agreed membership rate while the crypto discount is zero", () => {
@@ -45,6 +45,17 @@ describe("on-chain invoice math", () => {
       period_end: "2026-10-01T00:00:00.000Z",
       due_at: "2026-09-08T00:00:00.000Z",
     });
+  });
+
+  it("distinguishes renewal dates from first-payment setup deadlines", () => {
+    expect(isRenewalInvoice({
+      period_start: "2026-09-27T21:27:14.059Z",
+      due_at: "2026-09-27T21:27:14.059+00:00",
+    })).toBe(true);
+    expect(isRenewalInvoice({
+      period_start: "2026-08-27T21:27:14.059Z",
+      due_at: "2026-09-03T21:27:14.095Z",
+    })).toBe(false);
   });
 
   it("never promotes an unpaid incomplete signup into past_due membership", async () => {

--- a/apps/web/src/lib/onchain/invoice.ts
+++ b/apps/web/src/lib/onchain/invoice.ts
@@ -25,6 +25,12 @@ export function addCalendarMonth(iso: string): string {
   return source.toISOString();
 }
 
+export function isRenewalInvoice(invoice: { period_start: string; due_at: string }): boolean {
+  const periodStart = new Date(invoice.period_start).getTime();
+  const dueAt = new Date(invoice.due_at).getTime();
+  return Number.isFinite(periodStart) && periodStart === dueAt;
+}
+
 export function invoiceValues(args: {
   subscriptionId: number;
   memberId: number;

--- a/apps/web/src/lib/onchain/verifyPayment.ts
+++ b/apps/web/src/lib/onchain/verifyPayment.ts
@@ -158,7 +158,7 @@ export type ProcessInvoiceResult =
   | { status: "paid"; txHash: string; paymentId: number; wasNew: boolean }
   | { status: "exception"; txHash: string; reason: string };
 
-/** Verify one submitted transaction and credit only after its block is OP-safe. */
+/** Verify one submitted transaction and credit its exact successful OP receipt. */
 export async function processOnchainInvoice(
   admin: ServiceClient,
   invoiceId: number,
@@ -264,19 +264,6 @@ export async function processOnchainInvoice(
     return { status: "exception", txHash, reason };
   }
 
-  const [safeBlock, finalizedBlock] = await Promise.all([
-    client.getBlock({ blockTag: "safe" }),
-    client.getBlock({ blockTag: "finalized" }),
-  ]);
-  if (receipt.blockNumber > safeBlock.number) {
-    await admin
-      .from("onchain_invoices")
-      .update({ status: "detected", detected_at: new Date().toISOString(), exception_reason: null })
-      .eq("id", invoice.id);
-    return { status: "detected", txHash };
-  }
-
-  const chainStatus = receipt.blockNumber <= finalizedBlock.number ? "finalized" : "safe";
   const rawLog = {
     address: transfer.raw.address,
     blockHash: transfer.raw.blockHash,
@@ -296,7 +283,7 @@ export async function processOnchainInvoice(
     p_to_address: transfer.to,
     p_token_contract: transfer.address,
     p_amount_micros: Number(transfer.amount),
-    p_chain_status: chainStatus,
+    p_chain_status: "included",
     p_raw_log: rawLog,
   });
   if (creditError) throw creditError;
@@ -338,7 +325,7 @@ export async function retryPendingOnchainEffects(admin: ServiceClient) {
   }
 }
 
-/** Mark previously safe credits finalized once OP's finalized head passes them. */
+/** Mark included/safe credits finalized once OP's finalized head passes them. */
 export async function advanceFinalizedOnchainPayments(admin: ServiceClient) {
   const client = getOpPublicClient();
   await assertOpPublicClient(client);
@@ -346,7 +333,7 @@ export async function advanceFinalizedOnchainPayments(admin: ServiceClient) {
   const { data, error } = await admin
     .from("onchain_payments")
     .select("id, block_number, block_hash")
-    .eq("chain_status", "safe")
+    .in("chain_status", ["included", "safe"])
     .lte("block_number", Number(finalized.number))
     .limit(100);
   if (error) throw error;

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -395,7 +395,7 @@ export interface Database {
           to_address: string;
           token_contract: string;
           amount_micros: number;
-          chain_status: "safe" | "finalized" | "reorged";
+          chain_status: "included" | "safe" | "finalized" | "reorged";
           match_status: "credited" | "exception" | "rejected";
           exception_reason: string | null;
           observed_at: string;
@@ -416,7 +416,7 @@ export interface Database {
           to_address: string;
           token_contract: string;
           amount_micros: number;
-          chain_status: "safe" | "finalized" | "reorged";
+          chain_status: "included" | "safe" | "finalized" | "reorged";
           match_status: "credited" | "exception" | "rejected";
           exception_reason?: string | null;
           credited_at?: string | null;

--- a/supabase/migrations/049_credit_included_onchain_payments.sql
+++ b/supabase/migrations/049_credit_included_onchain_payments.sql
@@ -1,0 +1,13 @@
+-- Credit exact native-USDC payments as soon as their successful OP receipt is
+-- available. Membership payments are high-trust and the product should not
+-- hold access behind OP's occasionally multi-minute safe-head lag.
+
+alter table onchain_payments
+  drop constraint onchain_payments_chain_status_check;
+
+alter table onchain_payments
+  add constraint onchain_payments_chain_status_check
+  check (chain_status in ('included', 'safe', 'finalized', 'reorged'));
+
+comment on column onchain_payments.chain_status is
+  'included = exact successful receipt credited before OP safe/finalized; rechecked for canonical finalization by cron';


### PR DESCRIPTION
## Summary

- credit an exact successful Optimism USDC payment as soon as its receipt is included, while retaining canonical finalized-head verification
- show “Payment received” immediately instead of leaving members on an alarming confirmation spinner
- suppress renewal reminders for initial setup invoices and label real renewal dates from the billed period
- widen the payment chain-status constraint with migration 049 to distinguish `included` from `safe`

## Product decision

This intentionally trades reorg protection before granting membership access for a faster signup experience. Exact receipt/token/sender/recipient/amount validation remains mandatory. The scheduled verifier still checks canonical inclusion at finalized head and marks a missing/replaced payment `reorged`; it does not automatically revoke effects already granted. This follows the owner’s stated high-trust membership policy.

## Verification

- 33/33 test files, 250/250 tests
- lint: 0 errors (2 existing warnings)
- shared package build
- Next 16/Turbopack production build
- `git diff --check`

## Deployment

Migration 049 is required before code that writes `chain_status = 'included'` is exercised. It only widens the existing check constraint and is backward-compatible with the currently deployed application.
