### PR TITLE
feat(web): admin tool for stale member auth links

### DIFF
--- a/apps/web/src/app/admin/members/stale-links/page.tsx
+++ b/apps/web/src/app/admin/members/stale-links/page.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+interface StaleMember {
+  member_id: number;
+  email: string | null;
+  name: string;
+  supabase_user_id: string | null;
+  has_did: boolean;
+}
+
+export default function StaleLinksPage() {
+  const [members, setMembers] = useState<StaleMember[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<number | null>(null);
+
+  function load() {
+    fetch("/api/admin/members/stale-links")
+      .then((r) => r.json())
+      .then((json) => {
+        if (json.error) {
+          setError(json.error);
+          return;
+        }
+        setMembers(json.members ?? []);
+      })
+      .catch(() => setError("Failed to load stale links"));
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function relink(m: StaleMember) {
+    if (!confirm(`Relink ${m.name} (${m.email ?? "no email"}) to their current sign-in? This cannot be undone.`)) return;
+    setBusyId(m.member_id);
+    try {
+      const res = await fetch(`/api/admin/members/${m.member_id}/relink-auth`, { method: "POST" });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? "Relink failed");
+      if (json.noop) {
+        alert(json.message ?? "Already linked to the current identity");
+      } else {
+        alert(`Relinked ${m.name} to their current sign-in.`);
+        setMembers((prev) => (prev ?? []).filter((x) => x.member_id !== m.member_id));
+      }
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Relink failed");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-forest">Stale Auth Links</h1>
+        <p className="text-muted text-sm mt-1">
+          Members whose supabase_user_id points at an auth identity that no longer exists (migration 050) —
+          usually from a deleted account whose email later moved onto this row. Relinking points them at
+          whatever auth.users row their email signs in through today.
+        </p>
+      </div>
+
+      {error && <p className="text-red-400 text-sm">{error}</p>}
+
+      {!members ? (
+        <div className="glass-panel-subtle p-8 rounded-xl text-center text-muted">Loading…</div>
+      ) : members.length === 0 ? (
+        <div className="glass-panel-subtle p-8 rounded-xl text-center text-muted">
+          No members have a stale auth link right now.
+        </div>
+      ) : (
+        <div className="glass-panel rounded-xl overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="text-left text-xs uppercase tracking-wider text-muted border-b border-white/10">
+              <tr>
+                <th className="px-4 py-3 font-medium">Member</th>
+                <th className="px-4 py-3 font-medium">Name</th>
+                <th className="px-4 py-3 font-medium">Email</th>
+                <th className="px-4 py-3 font-medium">DID</th>
+                <th className="px-4 py-3 font-medium">Dead auth id</th>
+                <th className="px-4 py-3 font-medium"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {members.map((m) => (
+                <tr key={m.member_id} className="border-b border-white/5 last:border-0">
+                  <td className="px-4 py-3">
+                    <Link href={`/admin/members/${m.member_id}`} className="text-sage hover:underline">
+                      #{m.member_id}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 font-medium">{m.name}</td>
+                  <td className="px-4 py-3 text-muted">{m.email ?? "—"}</td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`glass-panel-subtle px-2 py-0.5 text-xs rounded-full ${
+                        m.has_did ? "text-sage" : "text-muted"
+                      }`}
+                    >
+                      {m.has_did ? "Yes" : "No"}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-muted font-mono text-xs">{m.supabase_user_id ?? "—"}</td>
+                  <td className="px-4 py-3">
+                    <Button
+                      size="sm"
+                      disabled={busyId === m.member_id}
+                      onClick={() => relink(m)}
+                      className="btn-primary-glass text-xs"
+                    >
+                      {busyId === m.member_id ? "Relinking…" : "Relink to current sign-in"}
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -3,7 +3,7 @@ import { createServiceClient } from "@/lib/supabase/admin";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { Users, Key, Zap, UserPlus, AlertTriangle, ClipboardList, Calendar, DollarSign, Inbox } from "lucide-react";
+import { Users, Key, Zap, UserPlus, AlertTriangle, ClipboardList, Calendar, DollarSign, Inbox, Link2 } from "lucide-react";
 import { FunnelCard } from "@/components/admin/FunnelCard";
 import { effectiveMonthlyCents } from "@/lib/stripeNet";
 
@@ -271,6 +271,11 @@ export default async function AdminPage() {
               <Link href="/admin/members/new">
                 <Button size="sm" className="btn-glass w-full gap-2 text-xs">
                   <UserPlus className="w-3.5 h-3.5" /> Add Member
+                </Button>
+              </Link>
+              <Link href="/admin/members/stale-links">
+                <Button size="sm" className="btn-glass w-full gap-2 text-xs">
+                  <Link2 className="w-3.5 h-3.5" /> Stale Auth Links
                 </Button>
               </Link>
             </div>

--- a/apps/web/src/app/api/admin/members/[id]/relink-auth/route.test.ts
+++ b/apps/web/src/app/api/admin/members/[id]/relink-auth/route.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeSupabaseMock } from "../../../../../../../test/mockSupabase";
+
+vi.mock("@/lib/admin", () => ({ requireAdmin: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ createServiceClient: vi.fn() }));
+
+import { POST } from "./route";
+import { requireAdmin } from "@/lib/admin";
+import { createServiceClient } from "@/lib/supabase/admin";
+
+const ADMIN_USER = { id: "admin-auth-1", email: "admin@example.com" };
+const OLD_AUTH_ID = "dead0000-0000-0000-0000-000000000000";
+const NEW_AUTH_ID = "1111aaaa-0000-0000-0000-000000000000";
+
+function req() {
+  return new Request("http://localhost/api/admin/members/7/relink-auth", { method: "POST" });
+}
+
+const ctx = { params: Promise.resolve({ id: "7" }) };
+
+type UpdateResult = { data: unknown; error: { message: string } | null };
+
+/**
+ * The shared mockSupabase helper's `.update(...)` loses the mutation
+ * response as soon as you chain `.eq(...)` (its `eq` falls back to the
+ * SELECT builder) — this route's whole concurrency-guard path lives on
+ * `await …update(…).eq(…).eq(…).select(…)`. Widen it here, as
+ * mockSupabase.ts's own docstring invites (same pattern as
+ * auth/regenos/link and auth/regenos/session's tests).
+ */
+function makeAdminMock(opts: {
+  member?: Record<string, unknown> | null;
+  rpcs?: Record<string, { data?: unknown; error?: { message: string } | null }>;
+  updateResult?: UpdateResult;
+} = {}) {
+  const updates: { table: string; payload: unknown }[] = [];
+  const base = makeSupabaseMock({
+    selects: { members: { data: opts.member ?? null } },
+    rpcs: opts.rpcs,
+  });
+  const updateResult: UpdateResult = opts.updateResult ?? { data: [{ id: 7 }], error: null };
+  const innerFrom = base.from;
+  const from = vi.fn((table: string) => {
+    const builder = innerFrom(table) as Record<string, unknown>;
+    builder.update = vi.fn((payload: unknown) => {
+      updates.push({ table, payload });
+      const chain: Record<string, unknown> = {
+        eq: vi.fn(() => chain),
+        is: vi.fn(() => chain),
+        select: vi.fn(() => chain),
+        then: (onfulfilled?: (v: UpdateResult) => unknown) =>
+          Promise.resolve(updateResult).then(onfulfilled),
+      };
+      return chain;
+    });
+    return builder;
+  });
+  return { ...base, from, __updates: updates };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/admin/members/[id]/relink-auth", () => {
+  it("returns 403 when the caller isn't an admin", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(null as never);
+
+    const res = await POST(req(), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when the member doesn't exist", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(ADMIN_USER as never);
+    vi.mocked(createServiceClient).mockReturnValue(makeAdminMock({ member: null }) as never);
+
+    const res = await POST(req(), ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when the member's email has no live auth.users identity", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(ADMIN_USER as never);
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeAdminMock({
+        member: { id: 7, email: "ben@example.com", supabase_user_id: OLD_AUTH_ID },
+        rpcs: { current_auth_user_for_email: { data: null } },
+      }) as never,
+    );
+
+    const res = await POST(req(), ctx);
+    const json = await res.json();
+    expect(res.status).toBe(404);
+    expect(json.error).toMatch(/No auth\.users identity/);
+  });
+
+  it("is a no-op when already linked to the current identity", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(ADMIN_USER as never);
+    const admin = makeAdminMock({
+      member: { id: 7, email: "ben@example.com", supabase_user_id: NEW_AUTH_ID },
+      rpcs: { current_auth_user_for_email: { data: NEW_AUTH_ID } },
+    });
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+
+    const res = await POST(req(), ctx);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toMatchObject({ noop: true });
+    expect(admin.__updates).toEqual([]);
+  });
+
+  it("relinks supabase_user_id and logs the action on success", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(ADMIN_USER as never);
+    const admin = makeAdminMock({
+      member: { id: 7, email: "ben@example.com", supabase_user_id: OLD_AUTH_ID },
+      rpcs: { current_auth_user_for_email: { data: NEW_AUTH_ID } },
+      updateResult: { data: [{ id: 7 }], error: null },
+    });
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+
+    const res = await POST(req(), ctx);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toMatchObject({ success: true, from: OLD_AUTH_ID, to: NEW_AUTH_ID });
+    expect(admin.__updates).toEqual([
+      { table: "members", payload: { supabase_user_id: NEW_AUTH_ID } },
+    ]);
+  });
+
+  it("returns 409 when the auth link changed concurrently", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(ADMIN_USER as never);
+    const admin = makeAdminMock({
+      member: { id: 7, email: "ben@example.com", supabase_user_id: OLD_AUTH_ID },
+      rpcs: { current_auth_user_for_email: { data: NEW_AUTH_ID } },
+      updateResult: { data: [], error: null },
+    });
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+
+    const res = await POST(req(), ctx);
+    expect(res.status).toBe(409);
+  });
+});

--- a/apps/web/src/app/api/admin/members/[id]/relink-auth/route.ts
+++ b/apps/web/src/app/api/admin/members/[id]/relink-auth/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/admin";
+import { createServiceClient } from "@/lib/supabase/admin";
+import { logAction, AuditAction, actorIdFromAuthUid } from "@/lib/auditLog";
+
+/**
+ * POST /api/admin/members/[id]/relink-auth
+ *
+ * Repoints a member's supabase_user_id at whatever auth.users row currently
+ * owns their email — the fix for migration 050's "stale link" case: a member
+ * row whose supabase_user_id points at an auth.users row that was orphaned
+ * (e.g. by "delete member" on an old account) while a new auth.users row was
+ * created for the same email during a later signup. Trigger 013 only relinks
+ * when supabase_user_id IS NULL, so this doesn't happen automatically.
+ */
+export async function POST(
+  _req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const user = await requireAdmin();
+  if (!user) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id: idParam } = await ctx.params;
+  const memberId = parseInt(idParam, 10);
+  if (!memberId) {
+    return NextResponse.json({ error: "Invalid member id" }, { status: 400 });
+  }
+
+  const admin = createServiceClient();
+
+  const { data: member, error: memberErr } = await admin
+    .from("members")
+    .select("id, email, supabase_user_id")
+    .eq("id", memberId)
+    .maybeSingle();
+  if (memberErr || !member) {
+    return NextResponse.json({ error: "Member not found" }, { status: 404 });
+  }
+
+  const { data: newAuthId, error: rpcErr } = await admin.rpc(
+    "current_auth_user_for_email",
+    { target_email: member.email },
+  );
+  if (rpcErr) {
+    return NextResponse.json({ error: rpcErr.message }, { status: 500 });
+  }
+  if (!newAuthId) {
+    return NextResponse.json(
+      { error: "No auth.users identity found for this member's email" },
+      { status: 404 },
+    );
+  }
+
+  const oldValue = member.supabase_user_id as string | null;
+  if (newAuthId === oldValue) {
+    return NextResponse.json({
+      noop: true,
+      message: "Already linked to the current identity",
+    });
+  }
+
+  const filteredUpdate = oldValue === null
+    ? admin.from("members").update({ supabase_user_id: newAuthId }).eq("id", member.id).is("supabase_user_id", null)
+    : admin.from("members").update({ supabase_user_id: newAuthId }).eq("id", member.id).eq("supabase_user_id", oldValue);
+  const { data: updated, error: updateErr } = await filteredUpdate.select("id");
+  if (updateErr) {
+    return NextResponse.json({ error: updateErr.message }, { status: 500 });
+  }
+  if (!updated || updated.length === 0) {
+    return NextResponse.json(
+      { error: "Member's auth link changed concurrently, please retry" },
+      { status: 409 },
+    );
+  }
+
+  const actorMemberId = await actorIdFromAuthUid(user.id, admin);
+  await logAction(
+    {
+      action: AuditAction.MEMBER_AUTH_RELINKED,
+      actorMemberId,
+      target: { table: "members", id: member.id },
+      payload: {
+        from_supabase_user_id: oldValue,
+        to_supabase_user_id: newAuthId,
+        email: member.email,
+      },
+    },
+    admin,
+  );
+
+  return NextResponse.json({ success: true, from: oldValue, to: newAuthId });
+}

--- a/apps/web/src/app/api/admin/members/[id]/route.test.ts
+++ b/apps/web/src/app/api/admin/members/[id]/route.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeSupabaseMock } from "../../../../../../test/mockSupabase";
+
+vi.mock("@/lib/admin", () => ({ requireAdmin: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ createServiceClient: vi.fn() }));
+
+import { DELETE } from "./route";
+import { requireAdmin } from "@/lib/admin";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/admin";
+
+const ADMIN_USER = { id: "admin-1", email: "admin@example.com" };
+const ctx = { params: Promise.resolve({ id: "7" }) };
+
+function req() {
+  return new Request("http://localhost/api/admin/members/7", { method: "DELETE" });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("DELETE /api/admin/members/[id]", () => {
+  it("returns 403 when the caller isn't an admin", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(null as never);
+
+    const res = await DELETE(req(), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("deletes with no warning when the email has no live auth identity and no application on file", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(ADMIN_USER as never);
+    vi.mocked(createClient).mockResolvedValue(
+      makeSupabaseMock({
+        selects: { members: { data: { pin_code_slot: null, email: "ben@example.com" } } },
+      }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeSupabaseMock({
+        rpcs: { current_auth_user_for_email: { data: null } },
+        selects: { applications: { data: [] } },
+      }) as never,
+    );
+
+    const res = await DELETE(req(), ctx);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.warning).toBeUndefined();
+  });
+
+  it("warns when the email can still sign in via a live auth.users row (the stale-link scenario)", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(ADMIN_USER as never);
+    vi.mocked(createClient).mockResolvedValue(
+      makeSupabaseMock({
+        selects: { members: { data: { pin_code_slot: null, email: "ben@example.com" } } },
+      }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeSupabaseMock({
+        rpcs: { current_auth_user_for_email: { data: "11111111-1111-1111-1111-111111111111" } },
+        selects: { applications: { data: [] } },
+      }) as never,
+    );
+
+    const res = await DELETE(req(), ctx);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.warning).toMatch(/can still sign in/);
+    expect(json.warning).not.toMatch(/application on file/);
+  });
+
+  it("warns when an application exists under the same email", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(ADMIN_USER as never);
+    vi.mocked(createClient).mockResolvedValue(
+      makeSupabaseMock({
+        selects: { members: { data: { pin_code_slot: null, email: "ben@example.com" } } },
+      }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeSupabaseMock({
+        rpcs: { current_auth_user_for_email: { data: null } },
+        selects: { applications: { data: [{ id: 42 }] } },
+      }) as never,
+    );
+
+    const res = await DELETE(req(), ctx);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.warning).toMatch(/application on file/);
+  });
+
+  it("combines both conditions into one warning when both apply", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(ADMIN_USER as never);
+    vi.mocked(createClient).mockResolvedValue(
+      makeSupabaseMock({
+        selects: { members: { data: { pin_code_slot: null, email: "ben@example.com" } } },
+      }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeSupabaseMock({
+        rpcs: { current_auth_user_for_email: { data: "11111111-1111-1111-1111-111111111111" } },
+        selects: { applications: { data: [{ id: 42 }] } },
+      }) as never,
+    );
+
+    const res = await DELETE(req(), ctx);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.warning).toMatch(/can still sign in/);
+    expect(json.warning).toMatch(/application on file/);
+  });
+});

--- a/apps/web/src/app/api/admin/members/[id]/route.ts
+++ b/apps/web/src/app/api/admin/members/[id]/route.ts
@@ -152,10 +152,11 @@ export async function DELETE(
   const supabase = await createClient();
   const { id } = await params;
 
-  // Fetch the member first so we can clear their lock code
+  // Fetch the member first so we can clear their lock code and check for
+  // state that deleting the member row would leave orphaned (see below).
   const { data: member } = await supabase
     .from("members")
-    .select("pin_code_slot")
+    .select("pin_code_slot, email")
     .eq("id", Number(id))
     .single();
 
@@ -174,6 +175,41 @@ export async function DELETE(
   // Service-role client for the write (members DELETE/UPDATE are revoked from
   // the authenticated role — migration 031). Route is requireAdmin-gated.
   const admin = createServiceClient();
+
+  // Deleting a member never touches auth.users or applications (see
+  // migration 050) — if this email can still sign in, or has an application
+  // on file, deleting the member row orphans that state. Non-blocking: warn
+  // rather than refuse the delete. This check is a nice-to-have, not a hard
+  // dependency — any failure here (RPC error, query error, thrown exception)
+  // is logged and swallowed so the delete itself always proceeds.
+  let warning: string | null = null;
+  if (member?.email) {
+    try {
+      const [{ data: liveAuthId, error: rpcErr }, { data: staleApplications, error: appsErr }] = await Promise.all([
+        admin.rpc("current_auth_user_for_email", { target_email: member.email }),
+        admin.from("applications").select("id").eq("email", member.email).limit(1),
+      ]);
+      if (rpcErr) console.error("[AdminMember DELETE] stale-link guard rpc failed:", rpcErr);
+      if (appsErr) console.error("[AdminMember DELETE] stale-link guard applications check failed:", appsErr);
+
+      const canStillSignIn = !rpcErr && !!liveAuthId;
+      const hasApplication = !appsErr && (staleApplications ?? []).length > 0;
+
+      if (canStillSignIn && hasApplication) {
+        warning =
+          "This member's email can still sign in and has an application on file — deleting only removed the member record. If they sign in again they may land on an unlinked-application screen; use the stale-links tool to relink them if that happens.";
+      } else if (canStillSignIn) {
+        warning =
+          "This member's email can still sign in — deleting only removed the member record. If they sign in again, use the stale-links tool to relink them if needed.";
+      } else if (hasApplication) {
+        warning =
+          "This member has an application on file under the same email — deleting only removed the member record. The application still refers to it.";
+      }
+    } catch (err) {
+      console.error("[AdminMember DELETE] stale-link guard failed:", err);
+    }
+  }
+
   const { error } = await admin
     .from("members")
     .delete()
@@ -183,5 +219,9 @@ export async function DELETE(
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  return NextResponse.json({ success: true, lock_status: lockStatus });
+  return NextResponse.json({
+    success: true,
+    lock_status: lockStatus,
+    ...(warning ? { warning } : {}),
+  });
 }

--- a/apps/web/src/app/api/admin/members/stale-links/route.test.ts
+++ b/apps/web/src/app/api/admin/members/stale-links/route.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeSupabaseMock } from "../../../../../../test/mockSupabase";
+
+vi.mock("@/lib/admin", () => ({ requireAdmin: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ createServiceClient: vi.fn() }));
+
+import { GET } from "./route";
+import { requireAdmin } from "@/lib/admin";
+import { createServiceClient } from "@/lib/supabase/admin";
+
+const ADMIN_USER = { id: "admin-1", email: "admin@example.com" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/admin/members/stale-links", () => {
+  it("returns 403 when the caller isn't an admin", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(null as never);
+
+    const res = await GET();
+    expect(res.status).toBe(403);
+  });
+
+  it("returns the stale members from find_stale_member_links", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(ADMIN_USER as never);
+    const staleRows = [
+      {
+        member_id: 7,
+        email: "ben@example.com",
+        name: "Benjamin Life",
+        supabase_user_id: "11111111-1111-1111-1111-111111111111",
+        has_did: true,
+      },
+    ];
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeSupabaseMock({
+        rpcs: { find_stale_member_links: { data: staleRows } },
+      }) as never,
+    );
+
+    const res = await GET();
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.members).toEqual(staleRows);
+  });
+
+  it("returns an empty list when nothing is stale", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(ADMIN_USER as never);
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeSupabaseMock({ rpcs: { find_stale_member_links: { data: [] } } }) as never,
+    );
+
+    const res = await GET();
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.members).toEqual([]);
+  });
+
+  it("returns 500 when the RPC errors", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(ADMIN_USER as never);
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeSupabaseMock({
+        rpcs: { find_stale_member_links: { error: { message: "function not found" } } },
+      }) as never,
+    );
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/web/src/app/api/admin/members/stale-links/route.ts
+++ b/apps/web/src/app/api/admin/members/stale-links/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/admin";
+import { createServiceClient } from "@/lib/supabase/admin";
+
+/**
+ * GET /api/admin/members/stale-links
+ *
+ * Lists members whose supabase_user_id points at an auth.users row that no
+ * longer exists — the general shape of the "delete member" orphaning bug
+ * (see migration 050). Admin-only diagnostic feed for /admin/members/stale-links.
+ */
+export async function GET() {
+  if (!(await requireAdmin())) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const admin = createServiceClient();
+  const { data, error } = await admin.rpc("find_stale_member_links");
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ members: data ?? [] });
+}

--- a/apps/web/src/components/admin/MemberForm.tsx
+++ b/apps/web/src/components/admin/MemberForm.tsx
@@ -85,8 +85,11 @@ export function MemberForm({ member, initialEmail, initialUserId }: Props) {
       const res = await fetch(`/api/admin/members/${member!.id}`, { method: "DELETE" });
       const json = await res.json();
       if (!res.ok) throw new Error(json.error ?? "Delete failed");
-      if (json.lock_status) {
-        alert(`Member deleted. Lock status: ${json.lock_status}`);
+      if (json.lock_status || json.warning) {
+        let msg = "Member deleted.";
+        if (json.lock_status) msg += ` Lock status: ${json.lock_status}`;
+        if (json.warning) msg += ` ${json.warning}`;
+        alert(msg);
       }
       router.push("/admin/members");
       router.refresh();

--- a/apps/web/src/lib/auditLog.ts
+++ b/apps/web/src/lib/auditLog.ts
@@ -16,6 +16,7 @@ export const AuditAction = {
   FULL_ACCESS_REVOKED:    "full_access_revoked",
   MEMBER_DISABLED:        "member_disabled",
   MEMBER_DELETED:         "member_deleted",
+  MEMBER_AUTH_RELINKED:   "member_auth_relinked",
   // Balance/credit changes
   PASSES_GRANTED:         "passes_granted",
   PASSES_ADJUSTED:        "passes_adjusted",

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -666,6 +666,20 @@ export interface Database {
           was_new: boolean;
         }>;
       };
+      find_stale_member_links: {
+        Args: Record<string, never>;
+        Returns: Array<{
+          member_id: number;
+          email: string | null;
+          name: string;
+          supabase_user_id: string | null;
+          has_did: boolean;
+        }>;
+      };
+      current_auth_user_for_email: {
+        Args: { target_email: string };
+        Returns: string | null;
+      };
     };
     CompositeTypes: { [_ in never]: never };
     Enums: {

--- a/apps/web/test/mockSupabase.ts
+++ b/apps/web/test/mockSupabase.ts
@@ -32,6 +32,10 @@ export type SupabaseMockOpts = {
   selects?: Record<string, Partial<CannedResponse> & { data?: unknown }>;
   /** Default response for INSERT / UPDATE / DELETE on any table. */
   mutations?: Partial<CannedResponse>;
+  /** Map of rpc function name → response returned when that function is called.
+   *  Falls back to { data: null, error: null } for any unlisted function, same
+   *  as the pre-existing unconditional default. */
+  rpcs?: Record<string, Partial<CannedResponse> & { data?: unknown }>;
 };
 
 export function makeSupabaseMock(opts: SupabaseMockOpts = {}) {
@@ -39,7 +43,10 @@ export function makeSupabaseMock(opts: SupabaseMockOpts = {}) {
     getUser: vi.fn().mockResolvedValue({ data: { user: opts.auth?.user ?? null } }),
   };
 
-  const rpc = vi.fn().mockResolvedValue({ data: null, error: null });
+  const rpc = vi.fn((fnName: string) => {
+    const resp = opts.rpcs?.[fnName];
+    return Promise.resolve({ data: resp?.data ?? null, error: resp?.error ?? null });
+  });
 
   function tableBuilder(table: string) {
     const selectResp: CannedResponse = {

--- a/supabase/migrations/050_stale_member_auth_links.sql
+++ b/supabase/migrations/050_stale_member_auth_links.sql
@@ -1,0 +1,75 @@
+-- Migration 050: find and repair stale members.supabase_user_id links
+--
+-- Incident: a member (omniharmonic) lost access to his old email, signed up
+-- fresh with a new one, and an admin deleted that new account via the portal
+-- "delete member" flow. That flow only ever deletes the `members` row —
+-- migration 004/013's auto-link triggers are one-directional (they populate
+-- supabase_user_id when it's NULL), and nothing in this codebase deletes the
+-- underlying `auth.users` row, so it stuck around orphaned. The admin then
+-- moved the new email onto the member's original (correct, DID-bearing) row.
+-- That row's supabase_user_id kept pointing at the OLD, now-orphaned
+-- auth.users id, while a NEW auth.users row was silently created for the new
+-- email the moment he signed up. Trigger 013 only relinks when
+-- supabase_user_id IS NULL, so it never fired — his real member row became
+-- unreachable via sign-in, and he landed on the "application approved, admin
+-- needs to set something up" screen instead of his account. Fixed by hand via
+-- direct SQL once; this migration makes that repeatable without DB surgery.
+--
+-- Both functions live in `public`, not `auth`, because PostgREST never
+-- exposes the `auth` schema over the REST API — not even to the service
+-- role. That's the same reason 004/013's triggers, and 046's
+-- bind_member_wallet, all read/write auth.users from `public`-schema
+-- SECURITY DEFINER functions rather than querying `auth.*` directly from a
+-- route. These two are read-only diagnostics/lookups (no writes to
+-- auth.users), called from admin API routes via the service-role client's
+-- .rpc(), so — same as 046 — they're locked to service_role only.
+--
+-- find_stale_member_links: the general shape of the bug above — any member
+-- whose supabase_user_id points at an auth.users row that no longer exists.
+-- Surfaced in an admin UI so this doesn't require someone to notice a support
+-- ticket and reach for psql.
+--
+-- current_auth_user_for_email: given a member's email, what auth.users row
+-- would sign-in currently resolve to. Used both by the relink action (find
+-- the live identity to point supabase_user_id at) and by the delete-member
+-- guardrail (warn an admin who deletes a member row that the email can still
+-- sign in via a live auth.users row that will now be orphaned).
+
+create or replace function public.find_stale_member_links()
+returns table (
+  member_id integer,
+  email text,
+  name text,
+  supabase_user_id uuid,
+  has_did boolean
+)
+language sql
+security definer
+set search_path = public
+as $$
+  select m.id, m.email, m.name, m.supabase_user_id, (m.did is not null)
+  from members m
+  where m.supabase_user_id is not null
+    and not exists (
+      select 1 from auth.users u where u.id = m.supabase_user_id
+    );
+$$;
+
+create or replace function public.current_auth_user_for_email(target_email text)
+returns uuid
+language sql
+security definer
+set search_path = public
+as $$
+  select u.id
+  from auth.users u
+  where lower(u.email) = lower(target_email)
+  order by u.created_at desc
+  limit 1;
+$$;
+
+revoke all on function public.find_stale_member_links() from public, anon, authenticated;
+grant execute on function public.find_stale_member_links() to service_role;
+
+revoke all on function public.current_auth_user_for_email(text) from public, anon, authenticated;
+grant execute on function public.current_auth_user_for_email(text) to service_role;


### PR DESCRIPTION
## Summary

A "delete member" only ever removes the `members` row — it never touches the underlying `auth.users` identity or any `applications` row tied to the same email. When an admin later moves a re-signup's email onto a different (correct) member row, that row's `supabase_user_id` keeps pointing at the now-orphaned auth identity; the auto-link trigger only fires when `supabase_user_id` is `NULL`, so it never self-heals. The member lands on "application approved, admin needs to set something up" instead of their real account.

This is the general-purpose fix for an incident already patched by hand in prod for one member (omniharmonic) — makes it self-service instead of requiring direct SQL next time.

## What's included

- **Migration 050**: two `service_role`-only `SECURITY DEFINER` functions — `find_stale_member_links()` and `current_auth_user_for_email(email)`. Same pattern already used elsewhere in this codebase (046's `bind_member_wallet`) for reaching `auth.users`, which PostgREST never exposes directly even to the service role.
- **`GET /api/admin/members/stale-links`** + **`/admin/members/stale-links`** admin page — lists members whose `supabase_user_id` points at a dead `auth.users` row, with a one-click "Relink to current sign-in" action.
- **`POST /api/admin/members/[id]/relink-auth`** — repoints `supabase_user_id` at whatever `auth.users` row the member's email currently resolves to. Optimistic-concurrency guarded (409 if the link changed between read and write), audited via `admin_actions`.
- **`DELETE /api/admin/members/[id]`** now returns a non-blocking `warning` when the deleted member's email can still sign in and/or has an application on file — so the next occurrence gets surfaced instead of silently recurring. Does not block the delete; a legitimate admin action (e.g. exactly what triggered the original incident) shouldn't be refused.

## Verification

- 36/36 test files, 265/265 tests (15 new, covering both routes' success/error/edge-case paths and the delete-guardrail's warning combinations)
- lint: 0 errors (2 pre-existing, unrelated warnings)
- shared package build + Next 16/Turbopack production build both pass
- `git diff --check` clean
- Independently reproduced all of the above myself in a clean worktree, not just taken from the implementation's own report

No changes to payment/onchain code or migrations 042–049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)