### PR TITLE
fix(web): stage mobile wallet authorization

### DIFF
--- a/apps/web/src/components/membership/CryptoSubscribeButton.tsx
+++ b/apps/web/src/components/membership/CryptoSubscribeButton.tsx
@@ -12,7 +12,14 @@ import {
 import { Button } from "@/components/ui/button";
 import { CheckCircle2, Loader2, Wallet } from "lucide-react";
 import { RegenHubWalletProvider } from "@/components/web3/RegenHubWalletProvider";
+import { GaslessPaymentReview } from "@/components/web3/GaslessPaymentReview";
 import { pollOnchainPayment } from "@/lib/onchain/clientConfirmation";
+import {
+  assertExpectedAuthorization,
+  relayAuthorizationRequest,
+  type RelayAuthorization,
+  withWalletTimeout,
+} from "@/lib/onchain/walletAuthorization";
 
 type Setup = {
   subscription_id: number;
@@ -31,28 +38,7 @@ type Setup = {
   };
 };
 
-type Phase = "idle" | "connecting" | "verifying" | "preparing" | "sending" | "confirming" | "received" | "complete";
-
-type RelayAuthorization = {
-  domain: {
-    name: string;
-    version: string;
-    chainId: number;
-    verifyingContract: Address;
-  };
-  types: {
-    TransferWithAuthorization: readonly { name: string; type: string }[];
-  };
-  primaryType: "TransferWithAuthorization";
-  message: {
-    from: Address;
-    to: Address;
-    value: string;
-    validAfter: string;
-    validBefore: string;
-    nonce: Hex;
-  };
-};
+type Phase = "idle" | "connecting" | "verifying" | "switching" | "preparing" | "review" | "signing" | "submitting" | "confirming" | "received" | "complete";
 
 const PENDING_PAYMENT_KEY = "regenhub:onchain:pending-payment";
 
@@ -64,14 +50,17 @@ type Props = {
 const PHASE_LABELS: Record<Exclude<Phase, "idle" | "complete">, string> = {
   connecting: "Connecting wallet…",
   verifying: "Verifying wallet ownership…",
+  switching: "Switching to OP Mainnet…",
   preparing: "Preparing your membership invoice…",
-  sending: "Authorizing gasless USDC payment…",
+  review: "Review payment authorization",
+  signing: "Open MetaMask to authorize…",
+  submitting: "Submitting gasless USDC payment…",
   confirming: "Confirming on OP Mainnet…",
   received: "Payment received",
 };
 
 function CryptoSubscribeButtonInner({ planKey, className }: Props) {
-  const { address, connector, isConnected } = useAccount();
+  const { address, chainId, connector, isConnected } = useAccount();
   const { openConnectModal, connectModalOpen } = useConnectModal();
   const { signMessageAsync } = useSignMessage();
   const { signTypedDataAsync } = useSignTypedData();
@@ -80,6 +69,7 @@ function CryptoSubscribeButtonInner({ planKey, className }: Props) {
   const [connectIntent, setConnectIntent] = useState(false);
   const [connectModalSeen, setConnectModalSeen] = useState(false);
   const [setup, setSetup] = useState<Setup | null>(null);
+  const [authorization, setAuthorization] = useState<RelayAuthorization | null>(null);
   const [txHash, setTxHash] = useState<Hash | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -109,10 +99,63 @@ function CryptoSubscribeButtonInner({ planKey, className }: Props) {
     }
   }, []);
 
-  const sendPayment = useCallback(async (nextSetup: Setup) => {
+  const submitPayment = useCallback(async (nextSetup: Setup, signature?: Hex) => {
+    setPhase("submitting");
+    const relayRes = await fetch("/api/portal/onchain/relay", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ invoice_id: nextSetup.invoice.id, signature }),
+    });
+    const relayed = await relayRes.json() as {
+      status?: string;
+      txHash?: Hash;
+      error?: string;
+      warning?: string;
+    };
+    if (!relayRes.ok && relayRes.status !== 202) {
+      throw new Error(relayed.error ?? "Could not submit gasless payment");
+    }
+    if (relayed.txHash) {
+      setAuthorization(null);
+      await confirmSubmittedPayment(nextSetup.invoice.id, relayed.txHash);
+      return;
+    }
+    throw new Error(relayed.warning ?? "Payment authorization is queued; RegenHub will keep retrying it. Do not authorize again.");
+  }, [confirmSubmittedPayment]);
+
+  const authorizePayment = useCallback(async () => {
+    if (!address || !setup || !authorization) return;
+    let signed = false;
+    setError(null);
+    setPhase("signing");
+    try {
+      const signature = await withWalletTimeout(
+        signTypedDataAsync({
+          account: address,
+          ...relayAuthorizationRequest(authorization),
+        }),
+        "MetaMask did not respond. Open MetaMask and cancel any request still waiting there before trying again.",
+      );
+      signed = true;
+      setAuthorization(null);
+      await submitPayment(setup, signature);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Payment authorization failed");
+      setPhase(signed ? "idle" : "review");
+    }
+  }, [address, authorization, setup, signTypedDataAsync, submitPayment]);
+
+  const preparePayment = useCallback(async (nextSetup: Setup) => {
     if (!address) throw new Error("Connect your wallet to continue.");
-    setPhase("sending");
-    await switchChainAsync({ chainId: nextSetup.payment.chain_id });
+    setAuthorization(null);
+    if (chainId !== nextSetup.payment.chain_id) {
+      setPhase("switching");
+      await withWalletTimeout(
+        switchChainAsync({ chainId: nextSetup.payment.chain_id }),
+        "MetaMask did not switch networks. Open MetaMask, switch to OP Mainnet, then return and try again.",
+      );
+    }
+    setPhase("preparing");
     const prepareRes = await fetch("/api/portal/onchain/relay/prepare", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -129,44 +172,19 @@ function CryptoSubscribeButtonInner({ planKey, className }: Props) {
       await confirmSubmittedPayment(nextSetup.invoice.id, prepared.txHash);
       return;
     }
-
-    let signature: Hex | undefined;
     if (prepared.authorization) {
-      const authorization = prepared.authorization;
-      signature = await signTypedDataAsync({
-        account: address,
-        domain: authorization.domain,
-        types: authorization.types,
-        primaryType: authorization.primaryType,
-        message: {
-          ...authorization.message,
-          value: BigInt(authorization.message.value),
-          validAfter: BigInt(authorization.message.validAfter),
-          validBefore: BigInt(authorization.message.validBefore),
-        },
-      });
-    }
-
-    const relayRes = await fetch("/api/portal/onchain/relay", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ invoice_id: nextSetup.invoice.id, signature }),
-    });
-    const relayed = await relayRes.json() as {
-      status?: string;
-      txHash?: Hash;
-      error?: string;
-      warning?: string;
-    };
-    if (!relayRes.ok && relayRes.status !== 202) {
-      throw new Error(relayed.error ?? "Could not submit gasless payment");
-    }
-    if (relayed.txHash) {
-      await confirmSubmittedPayment(nextSetup.invoice.id, relayed.txHash);
+      setAuthorization(assertExpectedAuthorization(prepared.authorization, {
+        from: address,
+        treasury: nextSetup.payment.treasury_address,
+        token: nextSetup.payment.token_address,
+        amountMicros: nextSetup.invoice.amount_usdc_micros,
+        chainId: nextSetup.payment.chain_id,
+      }));
+      setPhase("review");
       return;
     }
-    throw new Error(relayed.warning ?? "Payment authorization is queued; RegenHub will keep retrying it. Do not authorize again.");
-  }, [address, confirmSubmittedPayment, signTypedDataAsync, switchChainAsync]);
+    await submitPayment(nextSetup);
+  }, [address, chainId, confirmSubmittedPayment, submitPayment, switchChainAsync]);
 
   const verifyAndPay = useCallback(async () => {
     if (!address) return;
@@ -181,7 +199,10 @@ function CryptoSubscribeButtonInner({ planKey, className }: Props) {
       const challenge = await challengeRes.json();
       if (!challengeRes.ok) throw new Error(challenge.error ?? "Could not create wallet challenge");
 
-      const signature = await signMessageAsync({ account: address, message: challenge.message });
+      const signature = await withWalletTimeout(
+        signMessageAsync({ account: address, message: challenge.message }),
+        "MetaMask did not respond to the ownership check. Open MetaMask and cancel any request still waiting there before trying again.",
+      );
       const verifyRes = await fetch("/api/portal/onchain/wallet/verify", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -212,12 +233,12 @@ function CryptoSubscribeButtonInner({ planKey, className }: Props) {
         await confirmSubmittedPayment(nextSetup.invoice.id, pendingHash);
         return;
       }
-      await sendPayment(nextSetup);
+      await preparePayment(nextSetup);
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : "Could not start crypto membership");
       setPhase("idle");
     }
-  }, [address, confirmSubmittedPayment, planKey, sendPayment, signMessageAsync]);
+  }, [address, confirmSubmittedPayment, planKey, preparePayment, signMessageAsync]);
 
   useEffect(() => {
     if (!connectIntent || !isConnected || !address) return;
@@ -251,22 +272,34 @@ function CryptoSubscribeButtonInner({ planKey, className }: Props) {
     openConnectModal?.();
   }
 
-  const busy = phase !== "idle" && phase !== "complete";
+  const busy = !["idle", "review", "complete"].includes(phase);
   const amountCents = setup?.invoice.amount_cents ?? 25_000;
+
+  function handlePaymentClick() {
+    if (authorization) {
+      void authorizePayment();
+      return;
+    }
+    if (setup) {
+      void preparePayment(setup).catch((cause) => {
+        setError(cause instanceof Error ? cause.message : "Payment could not be prepared");
+        setPhase("idle");
+      });
+      return;
+    }
+    start();
+  }
 
   return (
     <div className="space-y-2">
       <Button
         type="button"
-        onClick={setup ? () => void sendPayment(setup).catch((cause) => {
-          setError(cause instanceof Error ? cause.message : "Payment could not be submitted");
-          setPhase("idle");
-        }) : start}
+        onClick={handlePaymentClick}
         disabled={busy || phase === "complete"}
         className={className ?? "btn-glass w-full gap-2"}
       >
         {phase === "complete" || phase === "received" ? <CheckCircle2 className="w-4 h-4" /> : busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Wallet className="w-4 h-4" />}
-        {phase === "complete" ? "Payment confirmed" : busy ? PHASE_LABELS[phase as Exclude<Phase, "idle" | "complete">] : txHash ? "Check payment confirmation" : setup ? `Retry $${(amountCents / 100).toFixed(2)} USDC payment` : "Pay with crypto"}
+        {phase === "complete" ? "Payment confirmed" : busy ? PHASE_LABELS[phase as Exclude<Phase, "idle" | "complete">] : phase === "review" ? `Authorize $${(amountCents / 100).toFixed(2)} USDC in MetaMask` : txHash ? "Check payment confirmation" : setup ? `Prepare $${(amountCents / 100).toFixed(2)} USDC payment` : "Pay with crypto"}
       </Button>
 
       {isConnected && address && (
@@ -279,7 +312,14 @@ function CryptoSubscribeButtonInner({ planKey, className }: Props) {
         </ConnectButton.Custom>
       )}
 
-      {setup && phase !== "complete" && (
+      {setup && authorization && phase === "review" && (
+        <GaslessPaymentReview
+          amountCents={amountCents}
+          authorization={authorization}
+        />
+      )}
+
+      {setup && !authorization && phase !== "complete" && (
         <div className="rounded-lg border border-sage/20 bg-sage/5 p-3 text-left space-y-1">
           <p className="text-xs font-medium">${(amountCents / 100).toFixed(2)} USDC · OP Mainnet</p>
           <p className="text-[11px] text-muted">Direct to the RegenHub treasury. Access begins only after server verification.</p>

--- a/apps/web/src/components/portal/OnchainBillingCard.tsx
+++ b/apps/web/src/components/portal/OnchainBillingCard.tsx
@@ -12,7 +12,14 @@ import {
 import { Button } from "@/components/ui/button";
 import { CheckCircle2, Loader2, Wallet } from "lucide-react";
 import { RegenHubWalletProvider } from "@/components/web3/RegenHubWalletProvider";
+import { GaslessPaymentReview } from "@/components/web3/GaslessPaymentReview";
 import { pollOnchainPayment } from "@/lib/onchain/clientConfirmation";
+import {
+  assertExpectedAuthorization,
+  relayAuthorizationRequest,
+  type RelayAuthorization,
+  withWalletTimeout,
+} from "@/lib/onchain/walletAuthorization";
 
 type Props = {
   walletAddress: string | null;
@@ -32,29 +39,8 @@ type Props = {
 
 type WalletAction = "verify" | "pay";
 
-type RelayAuthorization = {
-  domain: {
-    name: string;
-    version: string;
-    chainId: number;
-    verifyingContract: Address;
-  };
-  types: {
-    TransferWithAuthorization: readonly { name: string; type: string }[];
-  };
-  primaryType: "TransferWithAuthorization";
-  message: {
-    from: Address;
-    to: Address;
-    value: string;
-    validAfter: string;
-    validBefore: string;
-    nonce: Hex;
-  };
-};
-
 function OnchainBillingCardInner(props: Props) {
-  const { address, connector, isConnected } = useAccount();
+  const { address, chainId, connector, isConnected } = useAccount();
   const { openConnectModal, connectModalOpen } = useConnectModal();
   const { signMessageAsync } = useSignMessage();
   const { signTypedDataAsync } = useSignTypedData();
@@ -62,6 +48,7 @@ function OnchainBillingCardInner(props: Props) {
   const [busy, setBusy] = useState(false);
   const [pendingAction, setPendingAction] = useState<WalletAction | null>(null);
   const [connectModalSeen, setConnectModalSeen] = useState(false);
+  const [authorization, setAuthorization] = useState<RelayAuthorization | null>(null);
   const [submittedTxHash, setSubmittedTxHash] = useState<Hash | null>(null);
   const [paymentDetected, setPaymentDetected] = useState(props.invoice?.status === "detected");
   const [message, setMessage] = useState<string | null>(null);
@@ -77,7 +64,10 @@ function OnchainBillingCardInner(props: Props) {
       });
       const challenge = await challengeRes.json();
       if (!challengeRes.ok) throw new Error(challenge.error ?? "Could not create wallet challenge");
-      const signature = await signMessageAsync({ account: checksummed, message: challenge.message });
+      const signature = await withWalletTimeout(
+        signMessageAsync({ account: checksummed, message: challenge.message }),
+        "MetaMask did not respond to the ownership check. Open MetaMask and cancel any request still waiting there before trying again.",
+      );
       const verifyRes = await fetch("/api/portal/onchain/wallet/verify", {
         method: "POST", headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ challenge_id: challenge.id, address: checksummed, signature }),
@@ -92,16 +82,61 @@ function OnchainBillingCardInner(props: Props) {
     } finally { setBusy(false); }
   }, [address, signMessageAsync]);
 
-  const pay = useCallback(async () => {
+  const confirmPayment = useCallback(async (txHash: Hash) => {
+    if (!props.invoice) return;
+    setSubmittedTxHash(txHash);
+    setAuthorization(null);
+    setMessage("Transaction submitted. RegenHub is checking OP confirmation…");
+    if (await pollOnchainPayment({
+      invoiceId: props.invoice.id,
+      txHash,
+      onStatus: (status) => {
+        if (status === "detected") {
+          setPaymentDetected(true);
+          setMessage("Payment received. RegenHub is completing OP verification…");
+        }
+      },
+    })) {
+      setMessage("Payment confirmed — membership is active.");
+      setTimeout(() => window.location.reload(), 1_500);
+      return;
+    }
+    setMessage("Payment is still being verified. Do not pay again; reopen this page to resume checking.");
+  }, [props.invoice]);
+
+  const submitPayment = useCallback(async (signature?: Hex) => {
+    if (!props.invoice) return;
+    setMessage("Submitting the authorized payment — RegenHub covers the OP gas…");
+    const relayRes = await fetch("/api/portal/onchain/relay", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ invoice_id: props.invoice.id, signature }),
+    });
+    const relayed = await relayRes.json() as { txHash?: Hash; error?: string; warning?: string };
+    if (!relayRes.ok && relayRes.status !== 202) {
+      throw new Error(relayed.error ?? "Could not submit gasless payment");
+    }
+    if (!relayed.txHash) {
+      throw new Error(relayed.warning ?? "Payment authorization is queued; RegenHub will keep retrying it. Do not authorize again.");
+    }
+    await confirmPayment(relayed.txHash);
+  }, [confirmPayment, props.invoice]);
+
+  const preparePayment = useCallback(async () => {
     if (!props.invoice || !props.walletAddress || !address) return;
-    let transferHash: Hash | null = null;
-    setBusy(true); setError(null); setMessage("Authorize the exact USDC payment — RegenHub covers the OP gas…");
+    setBusy(true); setError(null); setAuthorization(null);
     try {
       const checksummed = getAddress(address);
       if (checksummed.toLowerCase() !== props.walletAddress.toLowerCase()) {
         throw new Error(`Connect the verified wallet ${props.walletAddress.slice(0, 8)}…${props.walletAddress.slice(-4)}`);
       }
-      await switchChainAsync({ chainId: 10 });
+      if (chainId !== 10) {
+        setMessage("Open MetaMask and switch to OP Mainnet…");
+        await withWalletTimeout(
+          switchChainAsync({ chainId: 10 }),
+          "MetaMask did not switch networks. Open MetaMask, switch to OP Mainnet, then return and try again.",
+        );
+      }
+      setMessage("Checking the exact amount and your OP USDC balance…");
       const prepareRes = await fetch("/api/portal/onchain/relay/prepare", {
         method: "POST", headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ invoice_id: props.invoice.id }),
@@ -113,64 +148,56 @@ function OnchainBillingCardInner(props: Props) {
         error?: string;
       };
       if (!prepareRes.ok) throw new Error(prepared.error ?? "Could not prepare gasless payment");
-
-      let signature: Hex | undefined;
-      if (prepared.authorization) {
-        const authorization = prepared.authorization;
-        signature = await signTypedDataAsync({
-          account: checksummed,
-          domain: authorization.domain,
-          types: authorization.types,
-          primaryType: authorization.primaryType,
-          message: {
-            ...authorization.message,
-            value: BigInt(authorization.message.value),
-            validAfter: BigInt(authorization.message.validAfter),
-            validBefore: BigInt(authorization.message.validBefore),
-          },
-        });
-      }
-
-      let txHash = prepared.txHash ?? null;
-      if (!txHash) {
-        const relayRes = await fetch("/api/portal/onchain/relay", {
-          method: "POST", headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ invoice_id: props.invoice.id, signature }),
-        });
-        const relayed = await relayRes.json() as { txHash?: Hash; error?: string; warning?: string };
-        if (!relayRes.ok && relayRes.status !== 202) {
-          throw new Error(relayed.error ?? "Could not submit gasless payment");
-        }
-        txHash = relayed.txHash ?? null;
-        if (!txHash) {
-          throw new Error(relayed.warning ?? "Payment authorization is queued; RegenHub will keep retrying it. Do not authorize again.");
-        }
-      }
-      transferHash = txHash;
-      setSubmittedTxHash(txHash);
-      setMessage("Transaction submitted. RegenHub is checking OP confirmation…");
-      if (await pollOnchainPayment({
-        invoiceId: props.invoice.id,
-        txHash,
-        onStatus: (status) => {
-          if (status === "detected") {
-            setPaymentDetected(true);
-            setMessage("Payment received. RegenHub is completing safe OP confirmation…");
-          }
-        },
-      })) {
-        setMessage("Payment confirmed — membership is active.");
-        setTimeout(() => window.location.reload(), 1_500);
+      if (prepared.txHash) {
+        await confirmPayment(prepared.txHash);
         return;
       }
-      setMessage("Payment is still awaiting OP safe confirmation. Do not pay again; reopen this page to resume checking.");
+      if (prepared.authorization) {
+        setAuthorization(assertExpectedAuthorization(prepared.authorization, {
+          from: checksummed,
+          treasury: props.treasuryAddress,
+          token: props.tokenAddress,
+          amountMicros: props.invoice.amountMicros,
+          chainId: 10,
+        }));
+        setMessage("Review the exact authorization below, then open MetaMask from the next button.");
+        return;
+      }
+      await submitPayment();
     } catch (cause) {
-      setError(transferHash
-        ? `${cause instanceof Error ? cause.message : "Confirmation is delayed"}. Your transaction was submitted; do not pay again.`
-        : cause instanceof Error ? cause.message : "Payment could not be submitted");
+      setError(cause instanceof Error ? cause.message : "Payment could not be prepared");
       setMessage(null);
-    } finally { setBusy(false); }
-  }, [address, props.invoice, props.walletAddress, signTypedDataAsync, switchChainAsync]);
+    } finally {
+      setBusy(false);
+    }
+  }, [address, chainId, confirmPayment, props.invoice, props.tokenAddress, props.treasuryAddress, props.walletAddress, submitPayment, switchChainAsync]);
+
+  const authorizePayment = useCallback(async () => {
+    if (!props.invoice || !address || !authorization) return;
+    let signed = false;
+    setBusy(true); setError(null);
+    setMessage("Signature request sent. Open MetaMask if it did not appear automatically…");
+    try {
+      const checksummed = getAddress(address);
+      const signature = await withWalletTimeout(
+        signTypedDataAsync({
+          account: checksummed,
+          ...relayAuthorizationRequest(authorization),
+        }),
+        "MetaMask did not respond. Open MetaMask and cancel any request still waiting there before trying again.",
+      );
+      signed = true;
+      setAuthorization(null);
+      await submitPayment(signature);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Payment authorization failed");
+      setMessage(signed
+        ? "Your authorization was saved. Do not authorize again; RegenHub will retry the gas-sponsored submission."
+        : "The payment was not submitted. Review the authorization before trying again.");
+    } finally {
+      setBusy(false);
+    }
+  }, [address, authorization, props.invoice, signTypedDataAsync, submitPayment]);
 
   useEffect(() => {
     const invoice = props.invoice;
@@ -213,8 +240,8 @@ function OnchainBillingCardInner(props: Props) {
     const action = pendingAction;
     setPendingAction(null);
     setConnectModalSeen(false);
-    void (action === "verify" ? connectAndVerify() : pay());
-  }, [address, connectAndVerify, isConnected, pay, pendingAction]);
+    void (action === "verify" ? connectAndVerify() : preparePayment());
+  }, [address, connectAndVerify, isConnected, pendingAction, preparePayment]);
 
   useEffect(() => {
     if (!pendingAction) return;
@@ -231,7 +258,7 @@ function OnchainBillingCardInner(props: Props) {
   function begin(action: WalletAction) {
     setError(null); setMessage(null);
     if (isConnected && address) {
-      void (action === "verify" ? connectAndVerify() : pay());
+      void (action === "verify" ? connectAndVerify() : preparePayment());
       return;
     }
     setPendingAction(action);
@@ -267,15 +294,21 @@ function OnchainBillingCardInner(props: Props) {
             <p className="font-medium">${(props.invoice.amountCents / 100).toFixed(2)} USDC</p>
             <p className="text-xs text-muted">Due {new Date(props.invoice.dueAt).toLocaleDateString()}</p>
           </div>
-          <Button disabled={busy || Boolean(submittedTxHash) || !props.configured || ["submitted", "detected"].includes(props.invoice.status)} onClick={() => begin("pay")} className="bg-sage/20 hover:bg-sage/40 text-sage border border-sage/30 text-xs gap-2">
+          <Button disabled={busy || Boolean(submittedTxHash) || !props.configured || ["submitted", "detected"].includes(props.invoice.status)} onClick={() => authorization ? void authorizePayment() : begin("pay")} className="bg-sage/20 hover:bg-sage/40 text-sage border border-sage/30 text-xs gap-2">
             {busy && !paymentDetected && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
-            {paymentDetected || props.invoice.status === "detected" ? "Payment received" : props.invoice.status === "submitted" ? "Confirming…" : "Review & pay"}
+            {paymentDetected || props.invoice.status === "detected" ? "Payment received" : props.invoice.status === "submitted" ? "Confirming…" : authorization ? `Authorize $${(props.invoice.amountCents / 100).toFixed(2)} in MetaMask` : "Prepare payment"}
           </Button>
         </div>
       ) : props.invoice?.status === "paid" ? (
         <p className="text-xs text-emerald-400 flex items-center gap-1.5"><CheckCircle2 className="w-3.5 h-3.5" /> Payment confirmed.</p>
       ) : (
         <p className="text-xs text-emerald-400">Wallet verified. Your next invoice appears here seven days before renewal.</p>
+      )}
+      {props.invoice && authorization && (
+        <GaslessPaymentReview
+          amountCents={props.invoice.amountCents}
+          authorization={authorization}
+        />
       )}
       {props.walletAddress && <p className="text-[11px] text-muted font-mono break-all">Verified wallet: {props.walletAddress}</p>}
       {props.invoice?.txHash && <a className="text-xs text-sage underline" href={`https://optimistic.etherscan.io/tx/${props.invoice.txHash}`} target="_blank" rel="noreferrer">View transaction</a>}

--- a/apps/web/src/components/web3/GaslessPaymentReview.tsx
+++ b/apps/web/src/components/web3/GaslessPaymentReview.tsx
@@ -1,0 +1,33 @@
+import type { RelayAuthorization } from "@/lib/onchain/walletAuthorization";
+import { authorizationExpiresAt } from "@/lib/onchain/walletAuthorization";
+
+type Props = {
+  amountCents: number;
+  authorization: RelayAuthorization;
+};
+
+function shortAddress(address: string) {
+  return `${address.slice(0, 8)}…${address.slice(-6)}`;
+}
+
+export function GaslessPaymentReview({ amountCents, authorization }: Props) {
+  return (
+    <div className="rounded-lg border border-sage/30 bg-sage/5 p-3 text-left space-y-2">
+      <p className="text-xs font-medium">Review the exact wallet authorization</p>
+      <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[11px]">
+        <dt className="text-muted">Amount</dt>
+        <dd>${(amountCents / 100).toFixed(2)} native USDC on OP Mainnet</dd>
+        <dt className="text-muted">Recipient</dt>
+        <dd>RegenHub Treasury Safe · {shortAddress(authorization.message.to)}</dd>
+        <dt className="text-muted">Expires</dt>
+        <dd>{authorizationExpiresAt(authorization).toLocaleTimeString([], { hour: "numeric", minute: "2-digit", timeZoneName: "short" })}</dd>
+      </dl>
+      <p className="text-[11px] text-muted">
+        This is a single-use authorization for this exact amount. It is not an unlimited allowance and does not authorize future renewals.
+      </p>
+      <p className="text-[11px] text-amber-300">
+        If MetaMask labels the request deceptive or untrusted, cancel it and tell RegenHub. Do not confirm a wallet security warning.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/lib/onchain/walletAuthorization.test.ts
+++ b/apps/web/src/lib/onchain/walletAuthorization.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RelayAuthorization } from "./walletAuthorization";
+import {
+  assertExpectedAuthorization,
+  authorizationExpiresAt,
+  relayAuthorizationRequest,
+  withWalletTimeout,
+} from "./walletAuthorization";
+
+const authorization: RelayAuthorization = {
+  domain: {
+    name: "USD Coin",
+    version: "2",
+    chainId: 10,
+    verifyingContract: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
+  },
+  types: {
+    TransferWithAuthorization: [
+      { name: "from", type: "address" },
+      { name: "to", type: "address" },
+      { name: "value", type: "uint256" },
+      { name: "validAfter", type: "uint256" },
+      { name: "validBefore", type: "uint256" },
+      { name: "nonce", type: "bytes32" },
+    ],
+  },
+  primaryType: "TransferWithAuthorization",
+  message: {
+    from: "0x1111111111111111111111111111111111111111",
+    to: "0xA594263e0449A28eAEf5BA6420E81cC1996b7782",
+    value: "250000000",
+    validAfter: "1787869263",
+    validBefore: "1787871123",
+    nonce: `0x${"ab".repeat(32)}`,
+  },
+};
+
+afterEach(() => vi.useRealTimers());
+
+describe("wallet authorization helpers", () => {
+  it("converts only EIP-712 integer fields to bigint", () => {
+    expect(relayAuthorizationRequest(authorization)).toEqual({
+      domain: authorization.domain,
+      types: authorization.types,
+      primaryType: "TransferWithAuthorization",
+      message: {
+        ...authorization.message,
+        value: 250000000n,
+        validAfter: 1787869263n,
+        validBefore: 1787871123n,
+      },
+    });
+  });
+
+  it("exposes the server-defined authorization expiry", () => {
+    expect(authorizationExpiresAt(authorization).toISOString()).toBe("2026-08-27T22:52:03.000Z");
+  });
+
+  it("accepts only the exact wallet, token, treasury, chain, and amount", () => {
+    expect(assertExpectedAuthorization(authorization, {
+      from: authorization.message.from,
+      treasury: authorization.message.to,
+      token: authorization.domain.verifyingContract,
+      amountMicros: 250_000_000,
+      chainId: 10,
+    })).toBe(authorization);
+
+    expect(() => assertExpectedAuthorization(authorization, {
+      from: authorization.message.from,
+      treasury: authorization.message.to,
+      token: authorization.domain.verifyingContract,
+      amountMicros: 30_000_000,
+      chainId: 10,
+    })).toThrow("does not match this RegenHub invoice");
+  });
+
+  it("bounds a wallet request that never settles", async () => {
+    vi.useFakeTimers();
+    const result = withWalletTimeout(new Promise<never>(() => undefined), "Open MetaMask", 1_000);
+    const rejection = expect(result).rejects.toThrow("Open MetaMask");
+    await vi.advanceTimersByTimeAsync(1_000);
+    await rejection;
+  });
+});

--- a/apps/web/src/lib/onchain/walletAuthorization.ts
+++ b/apps/web/src/lib/onchain/walletAuthorization.ts
@@ -1,0 +1,84 @@
+import type { Address, Hex } from "viem";
+
+export type RelayAuthorization = {
+  domain: {
+    name: string;
+    version: string;
+    chainId: number;
+    verifyingContract: Address;
+  };
+  types: {
+    TransferWithAuthorization: readonly { name: string; type: string }[];
+  };
+  primaryType: "TransferWithAuthorization";
+  message: {
+    from: Address;
+    to: Address;
+    value: string;
+    validAfter: string;
+    validBefore: string;
+    nonce: Hex;
+  };
+};
+
+export const WALLET_REQUEST_TIMEOUT_MS = 60_000;
+
+export function relayAuthorizationRequest(authorization: RelayAuthorization) {
+  return {
+    domain: authorization.domain,
+    types: authorization.types,
+    primaryType: authorization.primaryType,
+    message: {
+      ...authorization.message,
+      value: BigInt(authorization.message.value),
+      validAfter: BigInt(authorization.message.validAfter),
+      validBefore: BigInt(authorization.message.validBefore),
+    },
+  } as const;
+}
+
+export function authorizationExpiresAt(authorization: RelayAuthorization) {
+  return new Date(Number(authorization.message.validBefore) * 1_000);
+}
+
+type ExpectedAuthorization = {
+  from: Address;
+  treasury: Address;
+  token: Address;
+  amountMicros: number;
+  chainId: number;
+};
+
+export function assertExpectedAuthorization(
+  authorization: RelayAuthorization,
+  expected: ExpectedAuthorization,
+) {
+  const sameAddress = (left: Address, right: Address) => left.toLowerCase() === right.toLowerCase();
+  if (
+    authorization.primaryType !== "TransferWithAuthorization"
+    || authorization.domain.chainId !== expected.chainId
+    || !sameAddress(authorization.domain.verifyingContract, expected.token)
+    || !sameAddress(authorization.message.from, expected.from)
+    || !sameAddress(authorization.message.to, expected.treasury)
+    || authorization.message.value !== String(expected.amountMicros)
+  ) {
+    throw new Error("The wallet authorization does not match this RegenHub invoice. Nothing was signed.");
+  }
+  return authorization;
+}
+
+export async function withWalletTimeout<T>(
+  request: Promise<T>,
+  message: string,
+  timeoutMs = WALLET_REQUEST_TIMEOUT_MS,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const expired = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  try {
+    return await Promise.race([request, expired]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}


### PR DESCRIPTION
## Summary

- split OP checkout into preparation/review and a separate direct MetaMask authorization click
- show the exact amount, RegenHub Treasury Safe, expiry, single-use scope, and security-warning guidance before signing
- bound ownership, chain-switch, and typed-data wallet requests with actionable MetaMask recovery messages
- independently validate wallet, chain, token, treasury, and amount in the browser before enabling the authorization
- preserve server idempotency and prevent a second signature after an authorization has been saved

## Validation

- `pnpm --filter web test` — 37 files, 269 tests passed
- `pnpm --filter web lint` — 0 errors, 2 pre-existing warnings
- `pnpm build` — shared TypeScript and Next 16/Turbopack production build passed
- `git diff --check` — clean

No migration or server configuration change. A WalletConnect project ID remains an independent deployment credential follow-up; this PR fixes the currently deployed MetaMask/injected-wallet path without inventing one.
