### PR TITLE
fix(web): replace failed mobile signing transport

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@metamask/connect-evm": "2.1.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-separator": "^1.1.8",

--- a/apps/web/src/components/membership/CryptoSubscribeButton.tsx
+++ b/apps/web/src/components/membership/CryptoSubscribeButton.tsx
@@ -17,6 +17,8 @@ import { pollOnchainPayment } from "@/lib/onchain/clientConfirmation";
 import {
   assertExpectedAuthorization,
   relayAuthorizationRequest,
+  shouldUseMetaMaskConnectForAuthorization,
+  signAuthorizationWithMetaMaskConnect,
   type RelayAuthorization,
   withWalletTimeout,
 } from "@/lib/onchain/walletAuthorization";
@@ -129,11 +131,18 @@ function CryptoSubscribeButtonInner({ planKey, className }: Props) {
     setError(null);
     setPhase("signing");
     try {
+      const useMetaMaskConnect = shouldUseMetaMaskConnectForAuthorization(
+        connector?.id,
+        window.navigator.userAgent,
+        Boolean((window.ethereum as { isMetaMask?: boolean } | undefined)?.isMetaMask),
+      );
       const signature = await withWalletTimeout(
-        signTypedDataAsync({
-          account: address,
-          ...relayAuthorizationRequest(authorization),
-        }),
+        useMetaMaskConnect
+          ? signAuthorizationWithMetaMaskConnect(authorization, address)
+          : signTypedDataAsync({
+              account: address,
+              ...relayAuthorizationRequest(authorization),
+            }),
         "MetaMask did not respond. Open MetaMask and cancel any request still waiting there before trying again.",
       );
       signed = true;
@@ -143,7 +152,7 @@ function CryptoSubscribeButtonInner({ planKey, className }: Props) {
       setError(cause instanceof Error ? cause.message : "Payment authorization failed");
       setPhase(signed ? "idle" : "review");
     }
-  }, [address, authorization, setup, signTypedDataAsync, submitPayment]);
+  }, [address, authorization, connector?.id, setup, signTypedDataAsync, submitPayment]);
 
   const preparePayment = useCallback(async (nextSetup: Setup) => {
     if (!address) throw new Error("Connect your wallet to continue.");

--- a/apps/web/src/components/portal/OnchainBillingCard.tsx
+++ b/apps/web/src/components/portal/OnchainBillingCard.tsx
@@ -17,6 +17,8 @@ import { pollOnchainPayment } from "@/lib/onchain/clientConfirmation";
 import {
   assertExpectedAuthorization,
   relayAuthorizationRequest,
+  shouldUseMetaMaskConnectForAuthorization,
+  signAuthorizationWithMetaMaskConnect,
   type RelayAuthorization,
   withWalletTimeout,
 } from "@/lib/onchain/walletAuthorization";
@@ -179,11 +181,18 @@ function OnchainBillingCardInner(props: Props) {
     setMessage("Signature request sent. Open MetaMask if it did not appear automatically…");
     try {
       const checksummed = getAddress(address);
+      const useMetaMaskConnect = shouldUseMetaMaskConnectForAuthorization(
+        connector?.id,
+        window.navigator.userAgent,
+        Boolean((window.ethereum as { isMetaMask?: boolean } | undefined)?.isMetaMask),
+      );
       const signature = await withWalletTimeout(
-        signTypedDataAsync({
-          account: checksummed,
-          ...relayAuthorizationRequest(authorization),
-        }),
+        useMetaMaskConnect
+          ? signAuthorizationWithMetaMaskConnect(authorization, checksummed)
+          : signTypedDataAsync({
+              account: checksummed,
+              ...relayAuthorizationRequest(authorization),
+            }),
         "MetaMask did not respond. Open MetaMask and cancel any request still waiting there before trying again.",
       );
       signed = true;
@@ -197,7 +206,7 @@ function OnchainBillingCardInner(props: Props) {
     } finally {
       setBusy(false);
     }
-  }, [address, authorization, props.invoice, signTypedDataAsync, submitPayment]);
+  }, [address, authorization, connector?.id, props.invoice, signTypedDataAsync, submitPayment]);
 
   useEffect(() => {
     const invoice = props.invoice;

--- a/apps/web/src/lib/onchain/walletAuthorization.test.ts
+++ b/apps/web/src/lib/onchain/walletAuthorization.test.ts
@@ -3,7 +3,9 @@ import type { RelayAuthorization } from "./walletAuthorization";
 import {
   assertExpectedAuthorization,
   authorizationExpiresAt,
+  metaMaskConnectTypedData,
   relayAuthorizationRequest,
+  shouldUseMetaMaskConnectForAuthorization,
   withWalletTimeout,
 } from "./walletAuthorization";
 
@@ -80,5 +82,24 @@ describe("wallet authorization helpers", () => {
     const rejection = expect(result).rejects.toThrow("Open MetaMask");
     await vi.advanceTimersByTimeAsync(1_000);
     await rejection;
+  });
+
+  it("uses MetaMask Connect only for the deprecated external mobile connector", () => {
+    expect(shouldUseMetaMaskConnectForAuthorization("metaMaskSDK", "Mozilla/5.0 (Linux; Android 15)", false)).toBe(true);
+    expect(shouldUseMetaMaskConnectForAuthorization("metaMaskSDK", "Mozilla/5.0 (iPhone)", true)).toBe(false);
+    expect(shouldUseMetaMaskConnectForAuthorization("injected", "Mozilla/5.0 (Linux; Android 15)", false)).toBe(false);
+    expect(shouldUseMetaMaskConnectForAuthorization("metaMaskSDK", "Mozilla/5.0 (Macintosh)", false)).toBe(false);
+  });
+
+  it("serializes complete EIP-712 data for MetaMask Connect", () => {
+    const typedData = JSON.parse(metaMaskConnectTypedData(authorization));
+    expect(typedData.primaryType).toBe("TransferWithAuthorization");
+    expect(typedData.types.EIP712Domain).toEqual([
+      { name: "name", type: "string" },
+      { name: "version", type: "string" },
+      { name: "chainId", type: "uint256" },
+      { name: "verifyingContract", type: "address" },
+    ]);
+    expect(typedData.message).toEqual(authorization.message);
   });
 });

--- a/apps/web/src/lib/onchain/walletAuthorization.ts
+++ b/apps/web/src/lib/onchain/walletAuthorization.ts
@@ -1,4 +1,4 @@
-import type { Address, Hex } from "viem";
+import { isHex, size, type Address, type Hex } from "viem";
 
 export type RelayAuthorization = {
   domain: {
@@ -35,6 +35,64 @@ export function relayAuthorizationRequest(authorization: RelayAuthorization) {
       validBefore: BigInt(authorization.message.validBefore),
     },
   } as const;
+}
+
+export function shouldUseMetaMaskConnectForAuthorization(
+  connectorId: string | undefined,
+  userAgent: string,
+  hasInjectedMetaMask: boolean,
+) {
+  return connectorId === "metaMaskSDK"
+    && /Android|iPhone|iPad|iPod/i.test(userAgent)
+    && !hasInjectedMetaMask;
+}
+
+export function metaMaskConnectTypedData(authorization: RelayAuthorization) {
+  return JSON.stringify({
+    domain: authorization.domain,
+    types: {
+      EIP712Domain: [
+        { name: "name", type: "string" },
+        { name: "version", type: "string" },
+        { name: "chainId", type: "uint256" },
+        { name: "verifyingContract", type: "address" },
+      ],
+      ...authorization.types,
+    },
+    primaryType: authorization.primaryType,
+    message: authorization.message,
+  });
+}
+
+/** Sign through MetaMask's supported mobile transport, bypassing its deprecated SDK. */
+export async function signAuthorizationWithMetaMaskConnect(
+  authorization: RelayAuthorization,
+  expectedAccount: Address,
+): Promise<Hex> {
+  const { createEVMClient } = await import("@metamask/connect-evm");
+  const client = await createEVMClient({
+    dapp: { name: "RegenHub Boulder", url: window.location.origin },
+    api: { supportedNetworks: { "0xa": "https://mainnet.optimism.io" } },
+    analytics: { enabled: false },
+    skipAutoAnnounce: true,
+  });
+  const typedData = metaMaskConnectTypedData(authorization);
+  const connected = await client.connectWith({
+    account: expectedAccount,
+    chainIds: ["0xa"],
+    method: "eth_signTypedData_v4",
+    params: (account) => [account, typedData],
+  });
+  const selected = connected.accounts.some(
+    (account) => account.toLowerCase() === expectedAccount.toLowerCase(),
+  );
+  if (!selected || Number.parseInt(connected.chainId, 16) !== 10) {
+    throw new Error("MetaMask connected a different wallet or network. Nothing was signed.");
+  }
+  if (typeof connected.result !== "string" || !isHex(connected.result) || size(connected.result) !== 65) {
+    throw new Error("MetaMask returned an invalid payment authorization. Nothing was submitted.");
+  }
+  return connected.result as Hex;
 }
 
 export function authorizationExpiresAt(authorization: RelayAuthorization) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@metamask/connect-evm':
+        specifier: 2.1.1
+        version: 2.1.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@3.25.76)
@@ -724,6 +727,23 @@ packages:
   '@lit/reactive-element@2.1.2':
     resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
 
+  '@metamask/analytics@0.6.0':
+    resolution: {integrity: sha512-L250lV3PANTcKqhZkmRV1Obkyddm6JDQvDBuUVAi+7TmPdOVdpavWNXyEh7ErscjwG0z2wiF9Ne0ihK/nCdX0w==}
+    engines: {node: '>=20.19.0'}
+
+  '@metamask/connect-evm@2.1.1':
+    resolution: {integrity: sha512-pkaY0EslsWHe1slSsFSFMAHTqwSa1Twd4hBMe2KLuf+D01h0Al8X7YOYZnT6Zd2Ck0KmQGLSTUh7hZyHT4n0nw==}
+    engines: {node: '>=20.19.0'}
+
+  '@metamask/connect-multichain@1.2.0':
+    resolution: {integrity: sha512-EoRXtP8cpLhY/YRlQ8rSjzYrc+ykJjMYPL6sF2U9b8Ron9yAVjZCPfSftBjee/tXxQDJ8BupmZbkv4af/vVuSQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@react-native-async-storage/async-storage': ^1.23
+    peerDependenciesMeta:
+      '@react-native-async-storage/async-storage':
+        optional: true
+
   '@metamask/eth-json-rpc-provider@1.0.1':
     resolution: {integrity: sha512-whiUMPlAOrVGmX8aKYVPvlKyG4CpQXiNNyt74vE1xb5sPvmx5oA7B/kOi/JdBvhGQq97U1/AVdXEdk2zkP8qyA==}
     engines: {node: '>=14.0.0'}
@@ -739,6 +759,22 @@ packages:
   '@metamask/json-rpc-middleware-stream@7.0.2':
     resolution: {integrity: sha512-yUdzsJK04Ev98Ck4D7lmRNQ8FPioXYhEUZOMS01LXW8qTvPGiRVXmVltj2p4wrLkh0vW7u6nv0mNl5xzC5Qmfg==}
     engines: {node: '>=16.0.0'}
+
+  '@metamask/mobile-wallet-protocol-core@0.4.0':
+    resolution: {integrity: sha512-rB1wMogvSUsFaxyH/eVUCczIkTxVaPPETlD/wgm+gw7EbWP0LlZPY7Bh+DICSfUCJ0zqnoFuwr77WNJvZ6ZiWw==}
+    engines: {node: '>=20'}
+
+  '@metamask/mobile-wallet-protocol-dapp-client@0.3.0':
+    resolution: {integrity: sha512-rXStrvIa57a8OaeM+3HeR6Z9ETHOvmQi/9s6CLplDwH2hn2MWjI6WW3EUrxq2KGmGuhbO5Oo21ANnD23QKfduw==}
+    engines: {node: '>=20'}
+
+  '@metamask/multichain-api-client@0.10.1':
+    resolution: {integrity: sha512-LsqO2SiDcTgOuXyVYEB0zgBaVNhryhP2tYI3L7tLa7PoeDqMkNIreFhDeu8jM5tPWkCimQvMwCkG3DF4P5dD3A==}
+    engines: {node: ^18.20 || ^20.17 || >=22}
+
+  '@metamask/multichain-ui@0.4.1':
+    resolution: {integrity: sha512-tJgTot8Pfkda895A6biJu7rE+jlQdVCNVzGgW+2wM9aFG20G+GEbQy3KO7uC4ImUvaKV4SyJ45r6Ir/Yf55mqw==}
+    engines: {node: '>=20.19.0'}
 
   '@metamask/object-multiplex@2.1.0':
     resolution: {integrity: sha512-4vKIiv0DQxljcXwfpnbsXcfa5glMj5Zg9mqn4xpIWqkv6uJ2ma5/GtUfLFSxhlxnR8asRMv8dDmWya1Tc1sDFA==}
@@ -757,6 +793,10 @@ packages:
 
   '@metamask/rpc-errors@7.0.2':
     resolution: {integrity: sha512-YYYHsVYd46XwY2QZzpGeU4PSdRhHdxnzkB8piWGvJW2xbikZ3R+epAYEL4q/K8bh9JPTucsUdwRFnACor1aOYw==}
+    engines: {node: ^18.20 || ^20.17 || >=22}
+
+  '@metamask/rpc-errors@7.0.3':
+    resolution: {integrity: sha512-nrEaeBawm8yFU7hetJKok/CUs0tQsWtTqp3OLbFhPUMXYqU7uI5LAV5vi9o7rTjFkUyof7Nzbw5bea5+1ou+dg==}
     engines: {node: ^18.20 || ^20.17 || >=22}
 
   '@metamask/safe-event-emitter@2.0.0':
@@ -950,6 +990,33 @@ packages:
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
     deprecated: 'Switch to "qr" (new package name) for security updates: npm install qr'
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
@@ -2256,6 +2323,9 @@ packages:
   async-mutex@0.2.6:
     resolution: {integrity: sha512-Hs4R+4SPgamu6rSGW8C7cV9gaWUKEHykfzCCvIRuaVv636Ju10ZdeUbvb4TBEW0INuq2DHZqXbK4Nd3yG4RaRw==}
 
+  async-mutex@0.5.0:
+    resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -2384,6 +2454,9 @@ packages:
 
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
+
+  centrifuge@5.7.2:
+    resolution: {integrity: sha512-7NClNCeUxVY+zTO1XIZBgULTM2JsCZDXWWw2FD/WfNvJEZ9yawCeXhCbyxgJIcFpMuHwH8V+hYFIitmix4N5dg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -2651,6 +2724,10 @@ packages:
 
   ecc-jsbn@0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
+
+  eciesjs@0.4.17:
+    resolution: {integrity: sha512-TOOURki4G7sD1wDCjj7NfLaXZZ49dFOeEb5y39IXpb8p0hRzVvfvzZHOi5JcT+PpyAbi/Y+lxPb8eTag2WYH8w==}
+    engines: {bun: '>=1', deno: '>=2', node: '>=16'}
 
   eciesjs@0.4.18:
     resolution: {integrity: sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ==}
@@ -3671,6 +3748,9 @@ packages:
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -3972,6 +4052,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  pako@2.2.0:
+    resolution: {integrity: sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -4170,6 +4253,10 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  protobufjs@7.6.6:
+    resolution: {integrity: sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==}
+    engines: {node: '>=12.0.0'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -4194,9 +4281,16 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qr-code-styling@1.9.2:
+    resolution: {integrity: sha512-RgJaZJ1/RrXJ6N0j7a+pdw3zMBmzZU4VN2dtAZf8ZggCfRB5stEQ3IoDNGaNhYY3nnZKYlYSLl5YkfWN5dPutg==}
+    engines: {node: '>=18.18.0'}
+
   qr@0.6.0:
     resolution: {integrity: sha512-P23VoX7SipHALdiIYG+D+LT/6n22dNKwV92FAb3d+Nlki/5WisSsfLt0UDFz2XEBtuwrECTznvu+chKKFCSYhA==}
     engines: {node: '>= 20.19.0'}
+
+  qrcode-generator@1.5.2:
+    resolution: {integrity: sha512-pItrW0Z9HnDBnFmgiNrY1uxRdri32Uh9EjNYLPVC2zZ3ZRIIEqBoDgm4DkvDwNNDHTK7FNkmr8zAa77BYc9xNw==}
 
   qrcode@1.5.3:
     resolution: {integrity: sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==}
@@ -4886,6 +4980,10 @@ packages:
 
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
+
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
@@ -5783,6 +5881,48 @@ snapshots:
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.6.0
 
+  '@metamask/analytics@0.6.0':
+    dependencies:
+      openapi-fetch: 0.13.8
+
+  '@metamask/connect-evm@2.1.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@metamask/analytics': 0.6.0
+      '@metamask/connect-multichain': 1.2.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@metamask/utils': 11.11.0
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@metamask/connect-multichain@1.2.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@metamask/analytics': 0.6.0
+      '@metamask/mobile-wallet-protocol-core': 0.4.0
+      '@metamask/mobile-wallet-protocol-dapp-client': 0.3.0
+      '@metamask/multichain-api-client': 0.10.1
+      '@metamask/multichain-ui': 0.4.1
+      '@metamask/onboarding': 1.0.1
+      '@metamask/rpc-errors': 7.0.3
+      '@metamask/utils': 11.11.0
+      '@paulmillr/qr': 0.2.1
+      bowser: 2.14.1
+      buffer: 6.0.3
+      cross-fetch: 4.1.0
+      eciesjs: 0.4.17
+      eventemitter3: 5.0.1
+      pako: 2.2.0
+      uuid: 11.1.1
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
   '@metamask/eth-json-rpc-provider@1.0.1':
     dependencies:
       '@metamask/json-rpc-engine': 7.3.3
@@ -5815,6 +5955,28 @@ snapshots:
       readable-stream: 3.6.2
     transitivePeerDependencies:
       - supports-color
+
+  '@metamask/mobile-wallet-protocol-core@0.4.0':
+    dependencies:
+      async-mutex: 0.5.0
+      centrifuge: 5.7.2
+      eventemitter3: 5.0.1
+      uuid: 11.1.1
+
+  '@metamask/mobile-wallet-protocol-dapp-client@0.3.0':
+    dependencies:
+      '@metamask/mobile-wallet-protocol-core': 0.4.0
+      '@metamask/utils': 9.3.0
+      uuid: 11.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@metamask/multichain-api-client@0.10.1': {}
+
+  '@metamask/multichain-ui@0.4.1':
+    dependencies:
+      '@paulmillr/qr': 0.2.1
+      qr-code-styling: 1.9.2
 
   '@metamask/object-multiplex@2.1.0':
     dependencies:
@@ -5850,6 +6012,13 @@ snapshots:
       - supports-color
 
   '@metamask/rpc-errors@7.0.2':
+    dependencies:
+      '@metamask/utils': 11.11.0
+      fast-safe-stringify: 2.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@metamask/rpc-errors@7.0.3':
     dependencies:
       '@metamask/utils': 11.11.0
       fast-safe-stringify: 2.1.1
@@ -6083,6 +6252,26 @@ snapshots:
   '@oxc-project/types@0.127.0': {}
 
   '@paulmillr/qr@0.2.1': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.3)':
     dependencies:
@@ -8202,6 +8391,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  async-mutex@0.5.0:
+    dependencies:
+      tslib: 2.8.1
+
   asynckit@0.4.0: {}
 
   atomic-sleep@1.0.0: {}
@@ -8332,6 +8525,11 @@ snapshots:
   caniuse-lite@1.0.30001774: {}
 
   caseless@0.12.0: {}
+
+  centrifuge@5.7.2:
+    dependencies:
+      events: 3.3.0
+      protobufjs: 7.6.6
 
   chai@6.2.2: {}
 
@@ -8550,6 +8748,13 @@ snapshots:
     dependencies:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
+
+  eciesjs@0.4.17:
+    dependencies:
+      '@ecies/ciphers': 0.2.6(@noble/ciphers@1.3.0)
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
 
   eciesjs@0.4.18:
     dependencies:
@@ -9718,6 +9923,8 @@ snapshots:
 
   lodash@4.17.23: {}
 
+  long@5.3.2: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -9995,7 +10202,7 @@ snapshots:
   ox@0.6.7(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
@@ -10052,6 +10259,8 @@ snapshots:
       p-limit: 3.1.0
 
   p-try@2.2.0: {}
+
+  pako@2.2.0: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -10213,6 +10422,20 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  protobufjs@7.6.6:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 22.19.13
+      long: 5.3.2
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -10238,7 +10461,13 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qr-code-styling@1.9.2:
+    dependencies:
+      qrcode-generator: 1.5.2
+
   qr@0.6.0: {}
+
+  qrcode-generator@1.5.2: {}
 
   qrcode@1.5.3:
     dependencies:
@@ -11030,6 +11259,8 @@ snapshots:
       is-generator-function: 1.1.2
       is-typed-array: 1.1.15
       which-typed-array: 1.1.20
+
+  uuid@11.1.1: {}
 
   uuid@3.4.0: {}
 


### PR DESCRIPTION
## Summary
- route only external-mobile MetaMask payment authorization through MetaMask Connect
- retain existing injected, desktop, invoice, validation, and relay paths
- validate the connected account, OP chain, complete EIP-712 payload, and 65-byte signature before submission

## Verification
- 37/37 web test files, 271/271 tests
- lint: 0 errors (2 existing warnings)
- Next 16/Turbopack production build passed
- no migration or environment change