### PR TITLE
feat(web): informed regenOS membership-claim sync

### DIFF
--- a/apps/web/src/app/api/admin/membership-sync/preview/route.test.ts
+++ b/apps/web/src/app/api/admin/membership-sync/preview/route.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeSupabaseMock } from "../../../../../../../test/mockSupabase";
+
+vi.mock("@/lib/admin", () => ({ requireAdmin: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ createServiceClient: vi.fn() }));
+vi.mock("@/lib/regenos/config", () => ({
+  isRegenosLoginEnabled: vi.fn(() => true),
+  regenosBaseUrl: vi.fn(() => "https://appview.test"),
+  regenosCollectiveDid: vi.fn(() => "did:plc:collective"),
+}));
+vi.mock("@/lib/regenos/auth", () => ({
+  fetchRegenosIdentity: vi.fn(),
+  fetchRegenosSceneStanding: vi.fn(),
+}));
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({ toString: () => "__Host-rs_session=opaque" })),
+}));
+
+import { GET } from "./route";
+import { requireAdmin } from "@/lib/admin";
+import { createServiceClient } from "@/lib/supabase/admin";
+import { isRegenosLoginEnabled, regenosBaseUrl, regenosCollectiveDid } from "@/lib/regenos/config";
+import { fetchRegenosIdentity, fetchRegenosSceneStanding } from "@/lib/regenos/auth";
+
+const ADMIN_USER = { id: "admin-1", email: "admin@example.com" };
+const STEWARD_DID = "did:plc:steward";
+
+function makeAdminClient(opts: {
+  members?: Record<string, unknown>[];
+  subs?: { member_id: number }[];
+}) {
+  const base = makeSupabaseMock({
+    selects: {
+      members: { data: opts.members ?? [] },
+      subscriptions: { data: opts.subs ?? [] },
+    },
+  });
+  return base;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(isRegenosLoginEnabled).mockReturnValue(true);
+  vi.mocked(regenosBaseUrl).mockReturnValue("https://appview.test");
+  vi.mocked(regenosCollectiveDid).mockReturnValue("did:plc:collective");
+  vi.mocked(requireAdmin).mockResolvedValue(ADMIN_USER as never);
+  vi.mocked(fetchRegenosIdentity).mockResolvedValue({
+    did: STEWARD_DID,
+    handle: "steward.test",
+    email: "steward@example.com",
+  });
+  vi.mocked(fetchRegenosSceneStanding).mockResolvedValue({
+    role: "steward",
+    steward: true,
+    canManageEvents: true,
+  });
+});
+
+describe("GET /api/admin/membership-sync/preview", () => {
+  it("returns 403 when the caller isn't a RegenHub admin", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(null as never);
+
+    const res = await GET();
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 401 when there is no regenOS session", async () => {
+    vi.mocked(fetchRegenosIdentity).mockResolvedValue(null);
+
+    const res = await GET();
+    const json = await res.json();
+    expect(res.status).toBe(401);
+    expect(json.error).toMatch(/Sign in with regenOS/);
+  });
+
+  it("returns 403 when the caller is not a regenOS steward", async () => {
+    vi.mocked(fetchRegenosSceneStanding).mockResolvedValue({
+      role: "member",
+      steward: false,
+      canManageEvents: false,
+    });
+
+    const res = await GET();
+    const json = await res.json();
+    expect(res.status).toBe(403);
+    expect(json.error).toMatch(/steward/);
+  });
+
+  it("returns an empty pending list when every member's synced role already matches its plan", async () => {
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeAdminClient({
+        members: [
+          {
+            id: 1,
+            name: "Cold Desk Carla",
+            did: "did:plc:carla",
+            disabled: false,
+            is_admin: false,
+            is_ops_admin: false,
+            member_type: "cold_desk",
+            regenos_synced_role: "member",
+          },
+          {
+            id: 2,
+            name: "Admin Amy",
+            did: "did:plc:amy",
+            disabled: false,
+            is_admin: true,
+            is_ops_admin: false,
+            member_type: "day_pass",
+            regenos_synced_role: "steward",
+          },
+        ],
+        subs: [],
+      }) as never,
+    );
+
+    const res = await GET();
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.pending).toEqual([]);
+    expect(json.upToDateCount).toBe(2);
+  });
+
+  it("lists members whose current plan disagrees with their last-synced role — set and revoke cases", async () => {
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeAdminClient({
+        members: [
+          // Never synced (null), plan says set → member. Pending "set".
+          {
+            id: 3,
+            name: "Hot Desk Hank",
+            did: "did:plc:hank",
+            disabled: false,
+            is_admin: false,
+            is_ops_admin: false,
+            member_type: "hot_desk",
+            regenos_synced_role: null,
+          },
+          // Synced as member, now disabled → plan says revoke. Pending "revoke".
+          {
+            id: 4,
+            name: "Disabled Dana",
+            did: "did:plc:dana",
+            disabled: true,
+            is_admin: false,
+            is_ops_admin: false,
+            member_type: "hub_friend",
+            regenos_synced_role: "member",
+          },
+          // Already up to date: synced null, plan is day_pass w/o sub → revoke target null.
+          {
+            id: 5,
+            name: "Day Pass Dee",
+            did: "did:plc:dee",
+            disabled: false,
+            is_admin: false,
+            is_ops_admin: false,
+            member_type: "day_pass",
+            regenos_synced_role: null,
+          },
+        ],
+        subs: [],
+      }) as never,
+    );
+
+    const res = await GET();
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.upToDateCount).toBe(1);
+    expect(json.pending).toEqual([
+      {
+        member_id: 3,
+        name: "Hot Desk Hank",
+        current_synced_role: null,
+        target_action: "set",
+        target_role: "member",
+      },
+      {
+        member_id: 4,
+        name: "Disabled Dana",
+        current_synced_role: "member",
+        target_action: "revoke",
+        target_role: null,
+      },
+    ]);
+  });
+});

--- a/apps/web/src/app/api/admin/membership-sync/preview/route.ts
+++ b/apps/web/src/app/api/admin/membership-sync/preview/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { requireAdmin } from "@/lib/admin";
+import { createServiceClient } from "@/lib/supabase/admin";
+import { fetchRegenosIdentity, fetchRegenosSceneStanding } from "@/lib/regenos/auth";
+import { isRegenosLoginEnabled, regenosCollectiveDid, regenosBaseUrl } from "@/lib/regenos/config";
+import { planMembership } from "@/lib/regenos/membershipRole";
+
+/**
+ * GET /api/admin/membership-sync/preview
+ *
+ * The read-only half of the informed-sync feature (see migration 051): for
+ * every member with a DID, compute what POST /api/admin/membership-sync
+ * would plan for them right now via planMembership(), and diff that plan's
+ * implied target role against `regenos_synced_role` — the role we last
+ * *confirmed* was set on regenOS. Only members where those disagree are
+ * "pending" — a real sync would actually change something for them.
+ *
+ * Same auth gates as the POST route (RegenHub admin AND regenOS steward),
+ * reused identically, because this route decides who gets to know what a
+ * sync would do — same trust boundary as running the sync itself. It never
+ * writes to `members` or calls the regenOS AppView's mutating endpoints.
+ */
+export async function GET() {
+  if (!isRegenosLoginEnabled() || !regenosBaseUrl() || !regenosCollectiveDid()) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  if (!(await requireAdmin())) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const scene = regenosCollectiveDid()!;
+  const cookieHeader = (await cookies()).toString();
+  const identity = await fetchRegenosIdentity(cookieHeader);
+  if (!identity) {
+    return NextResponse.json({ error: "Sign in with regenOS as a steward first." }, { status: 401 });
+  }
+  const standing = await fetchRegenosSceneStanding(cookieHeader, scene, identity.did);
+  if (!standing.steward) {
+    return NextResponse.json({ error: "Only a collective steward can sync membership claims." }, { status: 403 });
+  }
+
+  const admin = createServiceClient();
+  const { data: rows, error } = await admin
+    .from("members")
+    .select("id, name, did, disabled, is_admin, is_ops_admin, member_type, regenos_synced_role")
+    .not("did", "is", null);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const { data: subs, error: subErr } = await admin
+    .from("subscriptions")
+    .select("member_id")
+    .in("status", ["active", "trialing", "past_due"]);
+  if (subErr) {
+    return NextResponse.json({ error: subErr.message }, { status: 500 });
+  }
+  const liveSub = new Set((subs ?? []).map((s) => s.member_id));
+
+  const pending: Array<{
+    member_id: number;
+    name: string;
+    current_synced_role: string | null;
+    target_action: "set" | "revoke";
+    target_role: string | null;
+  }> = [];
+  let upToDateCount = 0;
+
+  for (const row of rows ?? []) {
+    const plan = planMembership({
+      ...row,
+      hasLiveSubscription: liveSub.has(row.id),
+    });
+    if (plan.action === "skip") continue;
+
+    const targetRole = plan.action === "set" ? plan.role : null;
+    if (targetRole === row.regenos_synced_role) {
+      upToDateCount++;
+      continue;
+    }
+    pending.push({
+      member_id: row.id,
+      name: row.name,
+      current_synced_role: row.regenos_synced_role,
+      target_action: plan.action,
+      target_role: targetRole,
+    });
+  }
+
+  return NextResponse.json({ pending, upToDateCount });
+}

--- a/apps/web/src/app/api/admin/membership-sync/route.test.ts
+++ b/apps/web/src/app/api/admin/membership-sync/route.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { makeSupabaseMock } from "../../../../../test/mockSupabase";
+
+vi.mock("@/lib/admin", () => ({ requireAdmin: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ createServiceClient: vi.fn() }));
+vi.mock("@/lib/regenos/config", () => ({
+  isRegenosLoginEnabled: vi.fn(() => true),
+  regenosBaseUrl: vi.fn(() => "https://appview.test"),
+  regenosCollectiveDid: vi.fn(() => "did:plc:collective"),
+}));
+vi.mock("@/lib/regenos/auth", () => ({
+  fetchRegenosIdentity: vi.fn(),
+  fetchRegenosSceneStanding: vi.fn(),
+}));
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({ toString: () => "__Host-rs_session=opaque" })),
+}));
+
+import { POST } from "./route";
+import { requireAdmin } from "@/lib/admin";
+import { createServiceClient } from "@/lib/supabase/admin";
+import { fetchRegenosIdentity, fetchRegenosSceneStanding } from "@/lib/regenos/auth";
+
+const ADMIN_USER = { id: "admin-1", email: "admin@example.com" };
+const STEWARD_DID = "did:plc:steward";
+
+/**
+ * Only the tracking-column write introduced alongside migration 051 is
+ * covered here (this route had no test file before this change — see the
+ * PR notes for why a full suite wasn't added from scratch). Every other
+ * `.from("members")` call in the route is a plain select, so this wrapper
+ * only needs to intercept `.update(...)` and record its payload.
+ */
+function makeAdminClient(opts: { members: Record<string, unknown>[] }) {
+  const updates: { table: string; payload: unknown; id: unknown }[] = [];
+  const base = makeSupabaseMock({
+    selects: {
+      members: { data: opts.members },
+      subscriptions: { data: [] },
+    },
+  });
+  const innerFrom = base.from;
+  const from = vi.fn((table: string) => {
+    const builder = innerFrom(table) as Record<string, unknown>;
+    builder.update = vi.fn((payload: unknown) => {
+      const chain: Record<string, unknown> = {
+        eq: vi.fn((_col: string, id: unknown) => {
+          updates.push({ table, payload, id });
+          return Promise.resolve({ data: null, error: null });
+        }),
+      };
+      return chain;
+    });
+    return builder;
+  });
+  return { ...base, from, __updates: updates };
+}
+
+const upstream = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(requireAdmin).mockResolvedValue(ADMIN_USER as never);
+  vi.mocked(fetchRegenosIdentity).mockResolvedValue({
+    did: STEWARD_DID,
+    handle: "steward.test",
+    email: "steward@example.com",
+  });
+  vi.mocked(fetchRegenosSceneStanding).mockResolvedValue({
+    role: "steward",
+    steward: true,
+    canManageEvents: true,
+  });
+  vi.stubGlobal("fetch", upstream);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("POST /api/admin/membership-sync — tracking-column write", () => {
+  it("records regenos_synced_role/regenos_synced_at after a successful set", async () => {
+    upstream.mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const admin = makeAdminClient({
+      members: [
+        {
+          id: 1,
+          name: "Hot Desk Hank",
+          did: "did:plc:hank",
+          disabled: false,
+          is_admin: false,
+          is_ops_admin: false,
+          member_type: "hot_desk",
+        },
+      ],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+
+    const res = await POST();
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.synced).toBe(1);
+    expect(admin.__updates).toEqual([
+      {
+        table: "members",
+        payload: expect.objectContaining({ regenos_synced_role: "member" }),
+        id: 1,
+      },
+    ]);
+  });
+
+  it("records a null synced role after a successful revoke", async () => {
+    upstream.mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const admin = makeAdminClient({
+      members: [
+        {
+          id: 2,
+          name: "Disabled Dana",
+          did: "did:plc:dana",
+          disabled: true,
+          is_admin: false,
+          is_ops_admin: false,
+          member_type: "hub_friend",
+        },
+      ],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+
+    const res = await POST();
+    await res.json();
+
+    expect(admin.__updates).toEqual([
+      {
+        table: "members",
+        payload: expect.objectContaining({ regenos_synced_role: null }),
+        id: 2,
+      },
+    ]);
+  });
+
+  it("records a null synced role when revoke 404s (already absent)", async () => {
+    upstream.mockResolvedValue(new Response(JSON.stringify({ error: "not found" }), { status: 404 }));
+    const admin = makeAdminClient({
+      members: [
+        {
+          id: 3,
+          name: "Already Gone Gary",
+          did: "did:plc:gary",
+          disabled: true,
+          is_admin: false,
+          is_ops_admin: false,
+          member_type: "hub_friend",
+        },
+      ],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+
+    const res = await POST();
+    const json = await res.json();
+
+    expect(json.synced).toBe(1);
+    expect(admin.__updates).toEqual([
+      {
+        table: "members",
+        payload: expect.objectContaining({ regenos_synced_role: null }),
+        id: 3,
+      },
+    ]);
+  });
+
+  it("does not touch the tracking columns when the regenOS call fails", async () => {
+    upstream.mockResolvedValue(new Response(JSON.stringify({ error: "boom" }), { status: 500 }));
+    const admin = makeAdminClient({
+      members: [
+        {
+          id: 4,
+          name: "Flaky Fran",
+          did: "did:plc:fran",
+          disabled: false,
+          is_admin: false,
+          is_ops_admin: false,
+          member_type: "hot_desk",
+        },
+      ],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(admin as never);
+
+    const res = await POST();
+    const json = await res.json();
+
+    expect(json.failed).toBe(1);
+    expect(admin.__updates).toEqual([]);
+  });
+});

--- a/apps/web/src/app/api/admin/membership-sync/route.ts
+++ b/apps/web/src/app/api/admin/membership-sync/route.ts
@@ -92,6 +92,10 @@ export async function POST() {
         const json = (await res.json().catch(() => null)) as { message?: string; error?: string } | null;
         // revokeMembership 404s when there was nothing to delete — already not a scene member.
         if (plan.action === "revoke" && res.status === 404) {
+          await admin
+            .from("members")
+            .update({ regenos_synced_role: null, regenos_synced_at: new Date().toISOString() })
+            .eq("id", row.id);
           results.push({
             id: row.id,
             name: row.name,
@@ -111,6 +115,15 @@ export async function POST() {
         });
         continue;
       }
+      // Only a confirmed regenOS success updates our record of its state —
+      // a failed call tells us nothing about what regenOS actually holds.
+      await admin
+        .from("members")
+        .update({
+          regenos_synced_role: plan.action === "set" ? plan.role : null,
+          regenos_synced_at: new Date().toISOString(),
+        })
+        .eq("id", row.id);
       results.push({
         id: row.id,
         name: row.name,

--- a/apps/web/src/components/admin/MembershipSyncButton.tsx
+++ b/apps/web/src/components/admin/MembershipSyncButton.tsx
@@ -4,19 +4,55 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Loader2, RefreshCw } from "lucide-react";
 
+interface PendingChange {
+  member_id: number;
+  name: string;
+  current_synced_role: string | null;
+  target_action: "set" | "revoke";
+  target_role: string | null;
+}
+
+function describeChange(p: PendingChange): string {
+  if (p.target_action === "revoke" || !p.target_role) return "→ revoked";
+  return `→ ${p.target_role}`;
+}
+
 export function MembershipSyncButton() {
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [pending, setPending] = useState<PendingChange[] | null>(null);
 
-  async function run() {
-    if (
-      !window.confirm(
-        "Admit paid desk, hub friends, and contributing-member subscriptions ($30/$50/$100) with a DID as scene members? One-off day-pass buyers are not. Admins/ops as steward. Disabled members are revoked.",
-      )
-    ) {
-      return;
+  async function preview() {
+    setBusy(true);
+    setMsg(null);
+    setErr(null);
+    setPending(null);
+    try {
+      const res = await fetch("/api/admin/membership-sync/preview");
+      const json = (await res.json().catch(() => ({}))) as {
+        pending?: PendingChange[];
+        upToDateCount?: number;
+        error?: string;
+      };
+      if (!res.ok) {
+        setErr(json.error ?? `Preview failed (${res.status})`);
+        return;
+      }
+      const changes = json.pending ?? [];
+      if (changes.length === 0) {
+        setMsg(`Nothing to sync — ${json.upToDateCount ?? 0} members already up to date.`);
+        return;
+      }
+      setPending(changes);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
     }
+  }
+
+  async function confirmSync() {
     setBusy(true);
     setMsg(null);
     setErr(null);
@@ -33,6 +69,7 @@ export function MembershipSyncButton() {
         setErr(json.error ?? `Sync failed (${res.status})`);
         return;
       }
+      setPending(null);
       setMsg(
         `Synced ${json.synced ?? 0} · skipped ${json.skipped ?? 0}` +
           ((json.failed ?? 0) > 0 ? ` · ${json.failed} failed` : ""),
@@ -44,14 +81,51 @@ export function MembershipSyncButton() {
     }
   }
 
+  function cancel() {
+    setPending(null);
+  }
+
   return (
-    <div className="flex items-center gap-3 flex-wrap">
-      <Button type="button" size="sm" className="btn-glass" onClick={run} disabled={busy}>
-        {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <RefreshCw className="w-3.5 h-3.5" />}
-        Sync claims to regenOS
-      </Button>
-      {msg && <p className="text-xs text-sage">{msg}</p>}
-      {err && <p className="text-xs text-red-400">{err}</p>}
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-3 flex-wrap">
+        <Button type="button" size="sm" className="btn-glass" onClick={preview} disabled={busy}>
+          {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <RefreshCw className="w-3.5 h-3.5" />}
+          Sync claims to regenOS
+        </Button>
+        {msg && <p className="text-xs text-sage">{msg}</p>}
+        {err && <p className="text-xs text-red-400">{err}</p>}
+      </div>
+
+      {pending && (
+        <div className="glass-panel rounded-xl p-4 space-y-3 max-w-lg">
+          <p className="text-sm font-medium text-forest">
+            {pending.length} member{pending.length === 1 ? "" : "s"} would change
+          </p>
+          <div className="glass-panel-subtle rounded-lg divide-y divide-white/5 max-h-64 overflow-y-auto">
+            {pending.map((p) => (
+              <div key={p.member_id} className="px-3 py-2 flex items-center justify-between text-xs gap-2">
+                <span className="text-foreground">{p.name}</span>
+                <span className="text-muted whitespace-nowrap">{describeChange(p)}</span>
+              </div>
+            ))}
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              className="btn-primary-glass"
+              onClick={confirmSync}
+              disabled={busy}
+            >
+              {busy && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+              Confirm and sync {pending.length} members
+            </Button>
+            <Button type="button" size="sm" variant="ghost" onClick={cancel} disabled={busy}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -123,6 +123,8 @@ export interface Database {
           approved_for_full: boolean;
           approved_for_full_at: string | null;
           approved_for_full_by: number | null;
+          regenos_synced_role: string | null;
+          regenos_synced_at: string | null;
           created_at: string;
           updated_at: string;
         };
@@ -153,6 +155,8 @@ export interface Database {
           approved_for_full?: boolean;
           approved_for_full_at?: string | null;
           approved_for_full_by?: number | null;
+          regenos_synced_role?: string | null;
+          regenos_synced_at?: string | null;
         };
         Update: Partial<Database["public"]["Tables"]["members"]["Insert"]>;
         Relationships: [];

--- a/supabase/migrations/051_regenos_sync_tracking.sql
+++ b/supabase/migrations/051_regenos_sync_tracking.sql
@@ -1,0 +1,45 @@
+-- Migration 051: members.regenos_synced_role / regenos_synced_at
+--
+-- The only way today's app authenticates to regenOS for setMembership /
+-- revokeMembership is by relaying the admin's own live browser session
+-- cookie (see api/admin/membership-sync/route.ts) — there is no service
+-- credential a webhook could use, so this can't run automatically off a
+-- Stripe event yet (flagged upstream to regenOS's maintainer). Until that
+-- exists, "Sync claims to regenOS" stays a manual admin button, and it has
+-- been a *blind* one: every click re-pushes every member with a DID, with
+-- no way to see beforehand which of them would actually change. Aaron:
+-- "I dont always quite know what these sync buttons do... it's a bit
+-- intimidating."
+--
+-- These two columns are the memory that turns the blind bulk button into an
+-- informed one. They record the regenOS role we last *confirmed* was set
+-- for a member via a real, successful sync call — written back by
+-- membership-sync/route.ts immediately after each per-member set/revoke
+-- succeeds, never on failure (a failed call tells us nothing about what
+-- regenOS's state actually is now, so it must not overwrite what we last
+-- knew for sure).
+--
+-- regenos_synced_role holds 'steward' or 'member' after a confirmed `set`,
+-- or NULL after a confirmed `revoke` — and NULL is also simply what every
+-- row starts as before its first sync. Those two NULL cases (confirmed
+-- revoked vs. never synced) are indistinguishable by design: both mean
+-- "regenOS should currently show no claim for this member as far as we
+-- know," which is exactly the fact the new preview route
+-- (api/admin/membership-sync/preview/route.ts) needs — it diffs each
+-- member's current locally-computed target (planMembership()) against
+-- regenos_synced_role and only surfaces the members where they disagree,
+-- so the admin sees a real, specific list of what a sync would change
+-- instead of the RULE restated in a confirm() dialog.
+--
+-- Nullable, unbackfilled, no RLS: written only by the existing service-role
+-- sync route (same posture as the columns in 042/046), read only by that
+-- route and the new preview route.
+
+alter table members add column regenos_synced_role text;
+alter table members add column regenos_synced_at timestamptz;
+
+comment on column members.regenos_synced_role is
+  'regenOS lexicon role (steward/member) last confirmed set for this member by a successful membership-sync call, or null if last confirmed revoked (or never synced). Server-written only, by api/admin/membership-sync/route.ts on success.';
+
+comment on column members.regenos_synced_at is
+  'When regenos_synced_role was last confirmed by a successful membership-sync call.';


### PR DESCRIPTION
## Summary

"Sync claims to regenOS" was a blind bulk button — every click re-pushed every member with a DID, and the confirm dialog just restated the general rule ("desk members and paid subscribers become scene members...") rather than what would actually happen for the specific members it's about to touch right now. Aaron: *"I dont always quite know what these sync buttons do and what actions they might take... it's a bit intimidating."*

I looked into full webhook-driven auto-sync first and found it's not currently possible: the only way this app authenticates to regenOS for `setMembership`/`revokeMembership` is by relaying the admin's own live browser session cookie — a webhook has no cookie, and there's no service credential anywhere in this codebase that could stand in. That's a real regenOS-side gap, flagged upstream to the maintainer. This PR is the part that's ours to fix in the meantime: turn the blind button into an informed one.

## What's included

- **Migration 051**: `members.regenos_synced_role` / `regenos_synced_at` — the regenOS role we last *confirmed* was set for a member via a real successful sync call. Written back by the sync route immediately after each per-member success (including the existing "404 = already absent" revoke case), never on failure — a failed call tells us nothing about what regenOS's state actually is.
- **`GET /api/admin/membership-sync/preview`** — read-only, same admin+steward auth gates as the existing sync route. For every member with a DID, diffs their current `planMembership()` target against `regenos_synced_role` and returns only the ones that would actually change, with the specific transition (`set → member`, `set → steward`, or `revoke`).
- **`MembershipSyncButton.tsx`** now previews first: clicking "Sync claims to regenOS" fetches the preview. If nothing's pending, it says so and stops there — no write attempted. If there are changes, it shows the specific member list before a second, explicit "Confirm and sync N members" click runs the real sync (unchanged endpoint/behavior).

## Verification

- 39/39 test files, 280/280 tests (8 new: 5 for the preview route's auth/empty/mixed-set-revoke cases, 3 for the sync route's new tracking-write behavior)
- lint: 0 errors (2 pre-existing, unrelated warnings)
- shared package build + Next 16/Turbopack production build both pass
- `git diff --check` clean
- Independently reproduced all of the above myself in a clean worktree, not just taken from the implementation's own report

No changes to payment/onchain code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)