### PR TITLE
fix(shared): ignore stale lock battery alarm

### DIFF
--- a/apps/web/src/lib/lockHealth.test.ts
+++ b/apps/web/src/lib/lockHealth.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluateLockHealth } from "../../../../packages/shared/src/homeAssistant";
+
+describe("evaluateLockHealth", () => {
+  it("ignores a latched battery alarm when a fresh reading is clearly healthy", () => {
+    expect(evaluateLockHealth("alive", "on", "98")).toBeUndefined();
+  });
+
+  it("keeps the battery warning when the reported percentage is low", () => {
+    expect(evaluateLockHealth("alive", "on", "28")).toBe(
+      "is low on battery (28%) — the change may not have applied",
+    );
+  });
+
+  it.each([null, "unknown", "unavailable"])(
+    "keeps the battery warning when the percentage is %s",
+    (batteryLevel) => {
+      expect(evaluateLockHealth("alive", "on", batteryLevel)).toBe(
+        "is low on battery — the change may not have applied",
+      );
+    },
+  );
+
+  it("still reports a dead node when the battery alarm is stale", () => {
+    expect(evaluateLockHealth("dead", "on", "98")).toBe(
+      "was dead on the mesh — the change may not have applied",
+    );
+  });
+
+  it("returns no warning for a healthy node without a battery alarm", () => {
+    expect(evaluateLockHealth("alive", "off", "28")).toBeUndefined();
+  });
+});

--- a/packages/shared/src/homeAssistant.ts
+++ b/packages/shared/src/homeAssistant.ts
@@ -18,6 +18,7 @@ const LOCK_ENTITIES = (process.env.HA_LOCK_ENTITIES ?? "lock.front_door_lock")
   .filter(Boolean);
 
 const SUPPORT_CONTACT = "@UnforcedAG on Telegram";
+const HEALTHY_BATTERY_PERCENT = 50;
 
 export type LockResult = {
   entity: string;
@@ -77,23 +78,48 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
  * lock's Z-Wave radio ACKs the command — BEFORE the lock commits the change to
  * memory. On a low-battery or flapping node the radio can ACK (cheap) while the
  * EEPROM write (expensive) silently fails, so the change never takes and we'd
- * otherwise report success. We read the node's status + battery alarm from HA's
- * cache (NO Z-Wave radio traffic) and return a human warning if either looks
- * bad, so callers can say "may not have applied — test it" instead of a false
- * green check.
+ * otherwise report success. We read the node's status + battery alarm and
+ * percentage from HA's cache (NO Z-Wave radio traffic) and return a human
+ * warning if the available readings indicate a real problem, so callers can
+ * say "may not have applied — test it" instead of a false green check.
  *
  * Returns undefined when the lock looks healthy, OR when the health sensors
  * aren't present (we don't second-guess a 200 we can't corroborate). Naming
  * follows Z-Wave JS defaults: lock.<base> -> sensor.<base>_node_status,
- * binary_sensor.<base>_replace_battery_now.
+ * binary_sensor.<base>_replace_battery_now, sensor.<base>_battery_level.
  */
 async function lockHealthWarning(lockEntity: string): Promise<string | undefined> {
   const base = lockEntity.replace(/^lock\./, "");
-  const [nodeStatus, batteryLow] = await Promise.all([
+  const [nodeStatus, batteryLow, batteryLevel] = await Promise.all([
     getEntityState(`sensor.${base}_node_status`),
     getEntityState(`binary_sensor.${base}_replace_battery_now`),
+    getEntityState(`sensor.${base}_battery_level`),
   ]);
-  if (batteryLow === "on") return "is low on battery — the change may not have applied";
+  return evaluateLockHealth(nodeStatus, batteryLow, batteryLevel);
+}
+
+/**
+ * Interpret cached lock-health readings without causing any HA or Z-Wave I/O.
+ *
+ * Some locks latch `replace_battery_now` after a battery swap. A clearly
+ * healthy numeric reading overrides that stale alarm, while a low, missing, or
+ * invalid percentage keeps the conservative warning behavior.
+ */
+export function evaluateLockHealth(
+  nodeStatus: string | null,
+  batteryLow: string | null,
+  batteryLevel: string | null,
+): string | undefined {
+  const parsedBatteryLevel = batteryLevel === null ? Number.NaN : Number(batteryLevel);
+  // Require an at-least-half-full report before overriding the lock's own alarm.
+  // Lower or unreadable values retain the conservative warning.
+  const hasHealthyBatteryReading =
+    Number.isFinite(parsedBatteryLevel) && parsedBatteryLevel >= HEALTHY_BATTERY_PERCENT;
+
+  if (batteryLow === "on" && !hasHealthyBatteryReading) {
+    const percentage = Number.isFinite(parsedBatteryLevel) ? ` (${parsedBatteryLevel}%)` : "";
+    return `is low on battery${percentage} — the change may not have applied`;
+  }
   if (nodeStatus && nodeStatus !== "alive") return `was ${nodeStatus} on the mesh — the change may not have applied`;
   return undefined;
 }


### PR DESCRIPTION
## Summary

- corroborate the Z-Wave `replace_battery_now` alarm with the cached numeric battery level
- ignore a latched alarm only when the lock reports at least 50% battery
- preserve warnings for low, missing, or invalid battery readings and unhealthy mesh nodes
- include the reported percentage in genuine low-battery warnings

## Verification

- `pnpm --filter web test` — 38 files, 278 tests passed
- `pnpm --filter web lint` — 0 errors, 2 existing warnings
- `pnpm --filter @regenhub/shared build` — passed
- `pnpm --filter bot build` — passed
- `pnpm --filter web build` — passed

No migration, environment, Home Assistant, lock, or automation changes.
