### PR TITLE
fix(web): backfill descriptions on Luma calendar-page imports

### DIFF
--- a/apps/web/src/app/api/portal/events/import-luma/route.ts
+++ b/apps/web/src/app/api/portal/events/import-luma/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 import {
+  backfillMissingDescriptions,
   extractLumaUrls,
   fetchLumaHtml,
   parseLumaHtml,
@@ -75,5 +76,7 @@ export async function POST(request: Request) {
     unique.push(e);
   }
 
-  return NextResponse.json({ events: unique, errors });
+  const enriched = await backfillMissingDescriptions(unique);
+
+  return NextResponse.json({ events: enriched, errors });
 }

--- a/apps/web/src/lib/lumaImport.test.ts
+++ b/apps/web/src/lib/lumaImport.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { isoToLocalInput } from "@/lib/regenos/eventForm";
 import {
+  backfillMissingDescriptions,
   extractLumaUrls,
   fetchLumaHtml,
   isAllowedLumaUrl,
   lumaEventToFormValues,
   parseLumaHtml,
   splitAddress,
+  type ParsedLumaEvent,
 } from "./lumaImport";
 
 const CALENDAR_LD = JSON.stringify({
@@ -165,6 +167,59 @@ describe("lumaEventToFormValues", () => {
     expect(form.startsAt).toBe(isoToLocalInput("2026-08-14T15:00:00.000-06:00"));
     expect(form.endsAt).toBe(isoToLocalInput("2026-08-14T20:30:00.000-06:00"));
     expect(form.startsAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+  });
+});
+
+describe("backfillMissingDescriptions", () => {
+  it("fetches the individual event page for a listing item missing a description", async () => {
+    const events: ParsedLumaEvent[] = [
+      {
+        url: "https://luma.com/regenhub-mp3c",
+        name: "Co-op Launch Party at RegenHub",
+        startAt: "2026-08-14T15:00:00.000-06:00",
+        endAt: null,
+        placeName: "RegenHub",
+        street: "1515 Walnut St",
+        description: "",
+      },
+    ];
+    const fetcher = async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "https://luma.com/regenhub-mp3c") {
+        return new Response(
+          JSON.stringify({
+            "@type": "Event",
+            name: "Co-op Launch Party at RegenHub",
+            url: "https://luma.com/regenhub-mp3c",
+            startDate: "2026-08-14T15:00:00.000-06:00",
+            description: "Come celebrate the launch!",
+          }),
+          { status: 200, headers: { "content-type": "text/html" } },
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    };
+    const [result] = await backfillMissingDescriptions(events, fetcher as typeof fetch);
+    expect(result?.description).toBe("Come celebrate the launch!");
+  });
+
+  it("leaves the event alone when it already has a description, has no URL, or the follow-up fails", async () => {
+    const already: ParsedLumaEvent = {
+      url: "https://luma.com/a",
+      name: "A",
+      startAt: null,
+      endAt: null,
+      placeName: "",
+      street: "",
+      description: "already set",
+    };
+    const noUrl: ParsedLumaEvent = { ...already, url: "", description: "" };
+    const failing: ParsedLumaEvent = { ...already, url: "https://luma.com/b", description: "" };
+    const fetcher = async () => {
+      throw new Error("network down");
+    };
+    const result = await backfillMissingDescriptions([already, noUrl, failing], fetcher as typeof fetch);
+    expect(result).toEqual([already, noUrl, failing]);
   });
 });
 

--- a/apps/web/src/lib/lumaImport.ts
+++ b/apps/web/src/lib/lumaImport.ts
@@ -193,6 +193,33 @@ export async function fetchLumaHtml(
   throw new Error(`${startUrl}: too many redirects`);
 }
 
+/**
+ * A Luma calendar/listing page's JSON-LD `Event` items never carry a
+ * `description` — only an individual event's own page does. Bulk-importing
+ * a listing (paste a calendar URL/HTML, get many events) otherwise ships
+ * every one of them with no description at all. Best-effort, one follow-up
+ * fetch per event missing a description: a failed follow-up leaves that
+ * event as parsed rather than failing the whole import.
+ */
+export async function backfillMissingDescriptions(
+  events: ParsedLumaEvent[],
+  fetcher: typeof fetch = fetch,
+): Promise<ParsedLumaEvent[]> {
+  return Promise.all(
+    events.map(async (e) => {
+      if (e.description || !e.url || !isAllowedLumaUrl(e.url)) return e;
+      try {
+        const { html } = await fetchLumaHtml(e.url, fetcher);
+        const [detail] = parseLumaHtml(html);
+        if (detail?.description) return { ...e, description: detail.description };
+      } catch {
+        // best-effort — keep the event without a description rather than fail the import
+      }
+      return e;
+    }),
+  );
+}
+
 export function lumaEventToFormValues(e: ParsedLumaEvent): EventFormValues {
   return {
     name: e.name,


### PR DESCRIPTION
## Summary

Fixes the missing-description bug from the recent Luma calendar import: a Luma **calendar/listing page**'s JSON-LD `Event` entries never carry a `description` field — only an individual event's own page does. Pasting a calendar page (the natural way to bulk-import) into **Manage Events → Import from Luma** therefore shipped every event to regenOS with no description at all.

Verified live: fetched the actual RegenHub Luma calendar (`lu.ma/regenhub`) and the actual regenOS calendar (`getEvents` for the collective) — all 11 currently-published events have empty descriptions, and the pattern matches exactly: the calendar page's `ItemList` items omit `description`, but each event's own page (`luma.com/<slug>`) has it.

## Fix

`backfillMissingDescriptions()` in `lumaImport.ts`: for any parsed candidate missing a description but carrying a `url`, do one best-effort follow-up fetch of that event's own page (reusing the existing allowed-host-only `fetchLumaHtml`/`parseLumaHtml`) and merge in the description it finds. A failed follow-up leaves the event exactly as originally parsed rather than failing the whole import. Wired into `POST /api/portal/events/import-luma` right before the response goes back to the preview UI, so this is transparent to `ImportLumaCard` — the steward just sees descriptions show up in the preview that weren't there before.

No new network surface: every follow-up URL was already produced by our own parser (`isAllowedLumaUrl`-gated), never user-supplied.

## Existing events

This PR only fixes **future** imports. The 11 events already live with blank descriptions need a manual touch-up in **Manage Events → Edit → Description** (the edit form + `updateEvent` already round-trip description correctly — confirmed in `eventForm.ts`). Posting the ready-to-paste text for those 11 in the originating Buzz thread.

## Test plan

- [x] New unit tests: fetches the individual page when description is missing; leaves the event alone when it already has one, has no URL, or the follow-up fails
- [x] `pnpm --filter web exec vitest run`: 40/40 files, 289/289 tests passed (exact head)
- [x] `pnpm --filter web lint`: 0 errors, 2 pre-existing warnings (unrelated files)
- [x] `pnpm --filter web build`: production build passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)