### PR TITLE
fix(web): clarify auth doors on /auth/login, add regenOS door to /apply

### DIFF
--- a/apps/web/src/app/apply/page.tsx
+++ b/apps/web/src/app/apply/page.tsx
@@ -4,9 +4,11 @@ import Image from "next/image";
 import { createClient } from "@/lib/supabase/server";
 import { Card, CardContent } from "@/components/ui/card";
 import { LoginForm } from "@/components/auth/LoginForm";
+import { RegenosLoginPanel } from "@/components/auth/RegenosLoginPanel";
 import ApplyForm from "./ApplyForm";
 import regenHubFull from "@/assets/regenhub-full.svg";
 import { isSyntheticEmail } from "@/lib/regenos/syntheticEmail";
+import { isRegenosLoginEnabled } from "@/lib/regenos/config";
 
 export const metadata: Metadata = {
   title: "Apply for Membership — RegenHub",
@@ -23,6 +25,7 @@ export default async function ApplyPage() {
   // free-day/member folks upgrade against their real record. The magic link
   // creates an account for brand-new people too, then returns them here.
   if (!user) {
+    const regenosEnabled = isRegenosLoginEnabled();
     return (
       <div className="min-h-screen px-6 py-12">
         <div className="max-w-md mx-auto space-y-8">
@@ -39,7 +42,24 @@ export default async function ApplyPage() {
 
           <Card className="glass-panel">
             <CardContent className="p-8">
-              <LoginForm next="/apply" />
+              {regenosEnabled ? (
+                <>
+                  {/* Same regenOS front door as /auth/login — kept consistent so
+                      the sign-in experience doesn't change shape depending on
+                      which page sent you here. */}
+                  <RegenosLoginPanel next="/apply" />
+                  <details className="mt-6">
+                    <summary className="text-xs text-muted text-center cursor-pointer list-none hover:text-forest transition-colors">
+                      Having trouble signing in?
+                    </summary>
+                    <div className="mt-4">
+                      <LoginForm next="/apply" />
+                    </div>
+                  </details>
+                </>
+              ) : (
+                <LoginForm next="/apply" />
+              )}
             </CardContent>
           </Card>
 

--- a/apps/web/src/components/auth/OAuthSignInButton.tsx
+++ b/apps/web/src/components/auth/OAuthSignInButton.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import { RegenosOAuthError, requestAuthorizeUrl } from "@/lib/regenos/oauth";
 
 /**
@@ -55,9 +56,9 @@ export function OAuthSignInButton() {
   }
 
   return (
-    <form onSubmit={onSubmit} className="space-y-2">
+    <form onSubmit={onSubmit} className="glass-panel-subtle p-4 space-y-2">
       <div className="space-y-2">
-        <Label htmlFor="regenos-oauth-identifier">Or sign in with your atproto handle</Label>
+        <Label htmlFor="regenos-oauth-identifier">Sign in with your atproto handle</Label>
         <Input
           id="regenos-oauth-identifier"
           value={identifier}
@@ -75,7 +76,20 @@ export function OAuthSignInButton() {
           {error}
         </p>
       )}
-      <Button type="submit" disabled={!canSubmit} className="btn-glass w-full">
+      {/* `.btn-glass` alone is too close to its own `disabled:opacity-50` dimming
+          to read as "enabled but waiting for input" — once a handle is typed,
+          switch to a visibly brighter treatment so the button doesn't look
+          permanently disabled. */}
+      <Button
+        type="submit"
+        disabled={!canSubmit}
+        className={cn(
+          "w-full",
+          canSubmit
+            ? "bg-white/15 border border-sage/50 text-foreground hover:bg-white/20 hover:border-sage/70"
+            : "btn-glass",
+        )}
+      >
         {busy ? "Taking you there…" : "Sign in with atproto"}
       </Button>
     </form>

--- a/apps/web/src/components/auth/RegenosLoginPanel.tsx
+++ b/apps/web/src/components/auth/RegenosLoginPanel.tsx
@@ -187,7 +187,11 @@ export function RegenosLoginPanel({ next = "/portal" }: { next?: string }) {
 
   return (
     <Panel>
-      <form onSubmit={handleSubmit} className="space-y-4">
+      {/* One bordered card = one door: the "Continue with regenOS" button is
+          the submit action for the email field directly above it, not a
+          separate third option. Grouping them in a shared panel makes that
+          relationship visible instead of just structural. */}
+      <form onSubmit={handleSubmit} className="glass-panel-subtle p-4 space-y-4">
         <div className="space-y-2">
           <Label htmlFor="regenos-email">Sign in with your membership email</Label>
           <Input
@@ -208,6 +212,11 @@ export function RegenosLoginPanel({ next = "/portal" }: { next?: string }) {
           {busy ? "Checking…" : "Continue with regenOS"}
         </Button>
       </form>
+      <div className="flex items-center gap-3 text-xs text-muted" aria-hidden="true">
+        <span className="h-px flex-1 bg-white/10" />
+        or
+        <span className="h-px flex-1 bg-white/10" />
+      </div>
       <OAuthSignInButton />
     </Panel>
   );


### PR DESCRIPTION
## Summary

Live-site visual audit found two related bugs in the regenOS one-login flow, both fixed here since they're the same login UI:

1. **`/auth/login` was genuinely confusing.** Three sign-in affordances stacked with no visual grouping:
   - the email field (regenOS email-bridge) had its submit button ("Continue with regenOS") directly below it, but with no shared boundary — the button read as an unrelated third path rather than "submit the email above"
   - the atproto-handle form sat in the same stack with no separation from the email door
   - the "Sign in with atproto" button uses `.btn-glass`, which is already subtle (25% alpha bg/border); its *enabled* appearance was close enough to its own `disabled:opacity-50` dimming that it looked broken/disabled even once a handle was typed

2. **`/apply` only offered the classic email-magic-link door** — no "Continue with regenOS" option, inconsistent with `/auth/login` right next to it, even though regenOS is supposed to be the primary front door now (`REGENOS_LOGIN_ENABLED`).

## Changes

- `RegenosLoginPanel.tsx` — wraps the email-bridge form in its own bordered `glass-panel-subtle` card (so the field + "Continue with regenOS" button visibly read as one unit), and adds an "or" divider before the atproto door.
- `OAuthSignInButton.tsx` — wraps its own form in a matching bordered card (parallel door, not a continuation of the stack); once a handle is typed (`canSubmit`), the button switches to a visibly brighter treatment instead of relying solely on the native 50%-opacity disabled dimming to signal "enabled."
- `apply/page.tsx` — signed-out state now renders `RegenosLoginPanel` (reused, not reinvented) ahead of the classic `LoginForm`, gated by `isRegenosLoginEnabled()`, matching the same "Having trouble signing in?" collapsible fallback pattern already used on `/auth/login`.

No style redo — reused the existing `glass-panel-subtle` / `btn-glass` / `btn-primary-glass` tokens already in `globals.css`. A separate style pass is out of scope here per Aaron.

## Test plan

- [x] Reproduced both bugs on the live site (`https://regenhub.xyz/auth/login`, `https://regenhub.xyz/apply`) via Playwright screenshots before making any changes
- [x] `pnpm --filter web exec vitest run` — 289/289 passing (matches main baseline)
- [x] `pnpm --filter web lint` — 2 pre-existing warnings, 0 errors (matches main baseline, no new warnings)
- [x] `pnpm --filter web build` — succeeds
- [x] Local dev screenshots (desktop viewport) of both fixed pages, plus one showing the atproto button's enabled-state contrast, attached in a PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)