### PR TITLE
fix(web): bound Luma calendar fallback to a fixed height

### DIFF
--- a/apps/web/src/components/events/EventList.tsx
+++ b/apps/web/src/components/events/EventList.tsx
@@ -25,14 +25,12 @@ export const LUMA_EMBED_SRC = "https://lu.ma/embed/calendar/cal-ZCWMKx1NMCXGd7v/
 export function LumaEmbed() {
   return (
     <div className="glass-panel-subtle rounded-lg overflow-hidden">
-      <div className="relative w-full" style={{ paddingBottom: "75%" }}>
-        <iframe
-          src={LUMA_EMBED_SRC}
-          className="absolute top-0 left-0 w-full h-full"
-          frameBorder="0"
-          allowFullScreen
-        />
-      </div>
+      <iframe
+        src={LUMA_EMBED_SRC}
+        className="w-full h-[520px]"
+        frameBorder="0"
+        allowFullScreen
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Root cause

`LumaEmbed` (`apps/web/src/components/events/EventList.tsx`) wraps the Luma calendar iframe in a box sized with `paddingBottom: "75%"` of container width — a video-aspect-ratio placeholder pattern applied to a calendar list, whose natural height has nothing to do with container width.

That's wrong in both directions:
- **Sparse calendar** → the box (e.g. ~672-900px on desktop) is mostly empty below the one or two real events — the reported live-site bug: a huge dead dark block, reads like the page is still loading.
- **Busy calendar** → the fixed box is too short and clips content instead (verified locally: the box computes to 672px at 896px container width, while the current live calendar's actual embedded content is 2134px tall).

This component only renders when *both* regenOS and the Luma API return zero events (`lib/events.ts`), so it isn't reachable on regenhub.xyz/regenhub.xyz/events right now — the calendar is currently populated via regenOS (11 events, several recurring). That's why it wasn't visible when I loaded the live pages today. I reproduced the defect two ways instead of guessing:
1. An isolated harness using the *exact* production CSS and the real `https://lu.ma/embed/calendar/cal-ZCWMKx1NMCXGd7v/events?lt=dark` URL — confirmed the aspect-ratio box height is fixed independent of actual iframe content height.
2. Locally via `pnpm --filter web dev` with `REGENOS_BASE_URL`/`REGENOS_COLLECTIVE_DID`/`LUMA_API_KEY` unset (the default local-dev state), which naturally exercises this exact fallback component on both `/` and `/events`.

## Fix

Replaced the `paddingBottom: 75%` aspect-ratio box + absolutely-positioned iframe with a plain `w-full h-[520px]` iframe. Bounded height regardless of viewport width or event count; the iframe's own native scrollbar handles overflow when there's more content than fits, instead of an ever-growing (or ever-shrinking) box.

## Test plan

- [x] `pnpm --filter web exec vitest run` — 289/289 passing (matches main baseline)
- [x] `pnpm --filter web lint` — 0 errors, 2 pre-existing warnings (MemberDirectory.tsx img tag, stripeNet.test.ts unused var), unchanged from main
- [x] `pnpm --filter web build` — clean
- [x] Screenshots (before/after, local repro with the fallback forced on) attached in a PR comment