### PR TITLE
fix(db): close two day-pass balance escalation paths

### DIFF
--- a/apps/web/src/app/api/admin/members/[id]/add-passes/route.ts
+++ b/apps/web/src/app/api/admin/members/[id]/add-passes/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/admin";
 import { requireAdmin } from "@/lib/admin";
 
 export async function POST(
@@ -10,7 +10,10 @@ export async function POST(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const supabase = await createClient();
+  // Balance RPCs are service-role only (migration 052); requireAdmin() above
+  // is the authorization check, so the privileged call goes through the
+  // service client — same pattern as /api/portal/request-daypass.
+  const supabase = createServiceClient();
   const { id } = await params;
   const body = await request.json();
   const count = parseInt(body.count);

--- a/supabase/migrations/052_close_day_pass_balance_escalations.sql
+++ b/supabase/migrations/052_close_day_pass_balance_escalations.sql
@@ -1,0 +1,39 @@
+-- 052: close two day-pass balance escalation paths (RPC grants + claim policy).
+--
+-- 012 created increment_day_pass_balance / decrement_day_pass_balance as
+-- `security definer` (so they bypass RLS on members) and then granted EXECUTE
+-- to anon, authenticated, service_role. Neither function checks who is calling
+-- or whether p_member_id is the caller's own row. PostgREST exposes every
+-- function in `public`, and the anon key is committed on purpose — so anyone
+-- on the internet could POST /rest/v1/rpc/increment_day_pass_balance with any
+-- member id and mint passes (or drain a balance via decrement). Verified
+-- live 2026-09-01 with a no-op probe (p_member_id = -1 → 200, -1).
+--
+-- 031 closed the same escalation for direct UPDATEs on members but left the
+-- RPC path open. 046/050 already use the right pattern for newer functions.
+--
+-- Every real caller already uses the service-role client (bot `db`, web
+-- createServiceClient()); the one admin route that used the session client is
+-- switched in the same PR. So: revoke from everything except service_role,
+-- and pin search_path to match 032/036/050.
+
+revoke all on function public.increment_day_pass_balance(integer, integer) from public, anon, authenticated;
+revoke all on function public.decrement_day_pass_balance(integer, integer) from public, anon, authenticated;
+
+alter function public.increment_day_pass_balance(integer, integer) set search_path = public;
+alter function public.decrement_day_pass_balance(integer, integer) set search_path = public;
+
+grant execute on function public.increment_day_pass_balance(integer, integer) to service_role;
+grant execute on function public.decrement_day_pass_balance(integer, integer) to service_role;
+
+-- Second escalation path, same class. 014 gave authenticated users an
+-- unrestricted UPDATE policy on their own free_day_claims row ("for
+-- activation"), and 032's SECURITY DEFINER trigger bumps members.
+-- day_passes_balance by 1 on every transition to status = 'reserved'. A
+-- signed-in visitor with a claim row can flip status away and back through
+-- PostgREST as often as they like, +1 pass each time, or point `email` at
+-- another member's row. Every real writer (freeday/page.tsx,
+-- api/freeday/activate, api/admin/claims) already uses the service-role
+-- client, so nothing in the app depends on this policy. Admins keep
+-- admins_all_free_day; members keep own_claim_read.
+drop policy if exists "own_claim_update" on public.free_day_claims;


### PR DESCRIPTION
## What

Closes two ways to mint (or drain) day passes — which become real door codes — without being an admin.

**1. Balance RPCs callable with the public anon key (internet-reachable).**
`increment_day_pass_balance` / `decrement_day_pass_balance` (migration 012) are `security definer`, take any `member_id`, check nothing about the caller, and were granted to `anon` + `authenticated`. PostgREST exposes them at `/rest/v1/rpc/…`, and the anon key is committed by design. I verified this live with a no-op probe (`p_member_id: -1` → HTTP 200, returns -1); a real id would have credited passes. 031 closed this exact escalation for direct `UPDATE members` and left the RPC path open. Now `service_role` only, with `search_path` pinned to match 032/036/050.

**2. Any signed-in visitor with a free-day claim can re-trigger the +1 pass grant.**
014's `own_claim_update` policy lets a user update *any column* of their own `free_day_claims` row; 032's security-definer trigger adds +1 to `members.day_passes_balance` on every transition to `status = 'reserved'`. Flip it away and back through PostgREST → +1 each time, or point `email` at another member. Every real writer (`freeday/page.tsx`, `api/freeday/activate`, `api/admin/claims`) already uses the service client, so the policy was dead weight for the app. Dropped. Admins keep `admins_all_free_day`; members keep `own_claim_read`.

**Code change:** `/api/admin/members/[id]/add-passes` was the one caller using the session client for the RPC; switched to the service client (it's already behind `requireAdmin()`), the same pattern `request-daypass` uses.

## Rollout

Deploy first (the SQL ships in the image), then `run_migration("052_close_day_pass_balance_escalations.sql")` over the ops MCP. No data change; safe to run any time.

## Verification

- `pnpm --filter web test`: 40 files, 289 tests pass at `HEAD`.
- `pnpm --filter web lint`: 0 errors (2 pre-existing warnings).
- Every remaining caller of both RPCs confirmed on the service-role client: bot `db`, `passFulfillment.ts`, `subscriptionPasses.ts`, `request-daypass`, `add-passes`.

Found during the full-project review Aaron asked for in the regenhub.xyz channel; the review write-up is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
