### PR TITLE
fix(db): scope day-pass balance RPCs to the service role

### DIFF
--- a/apps/web/src/app/api/admin/members/[id]/add-passes/route.ts
+++ b/apps/web/src/app/api/admin/members/[id]/add-passes/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/admin";
 import { requireAdmin } from "@/lib/admin";
 
 export async function POST(
@@ -10,7 +10,10 @@ export async function POST(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const supabase = await createClient();
+  // Migration 052 scoped the balance RPCs to the service role, matching how
+  // every other caller drives them. This route is requireAdmin-gated above
+  // and the count is bounded below, so the privileged client is safe here.
+  const admin = createServiceClient();
   const { id } = await params;
   const body = await request.json();
   const count = parseInt(body.count);
@@ -21,7 +24,7 @@ export async function POST(
 
   if (count > 0) {
     // Atomic increment
-    const { data: newBalance, error } = await supabase.rpc(
+    const { data: newBalance, error } = await admin.rpc(
       "increment_day_pass_balance",
       { p_member_id: Number(id), p_amount: count }
     );
@@ -37,7 +40,7 @@ export async function POST(
     return NextResponse.json({ balance: newBalance });
   } else {
     // Atomic decrement
-    const { data: newBalance, error } = await supabase.rpc(
+    const { data: newBalance, error } = await admin.rpc(
       "decrement_day_pass_balance",
       { p_member_id: Number(id), p_amount: Math.abs(count) }
     );

--- a/apps/web/src/app/api/portal/request-daypass/route.ts
+++ b/apps/web/src/app/api/portal/request-daypass/route.ts
@@ -67,11 +67,12 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Account not found or disabled" }, { status: 403 });
   }
 
-  // The day_codes table + balance RPCs have no INSERT/EXECUTE policy for
-  // regular members (RLS only grants them SELECT of their own codes), so all
-  // the privileged writes below go through the service-role client. The user
-  // is already authenticated and their member row resolved above, and every
-  // write is scoped explicitly to member.id — so this is safe.
+  // The day_codes table has no INSERT policy for regular members (RLS only
+  // grants them SELECT of their own codes), and migration 052 scoped the
+  // balance RPCs to service_role, so all the privileged writes below go
+  // through the service-role client. The user is already authenticated and
+  // their member row resolved above, and every write is scoped explicitly to
+  // member.id — so this is safe.
   const admin = createServiceClient();
 
   const isFullMember = member.member_type !== "day_pass";

--- a/supabase/migrations/052_day_pass_rpc_grants.sql
+++ b/supabase/migrations/052_day_pass_rpc_grants.sql
@@ -1,0 +1,30 @@
+-- Migration 052: scope the day-pass balance RPCs to the service role.
+--
+-- Migration 012 added the two atomic balance helpers and granted EXECUTE to
+-- anon, authenticated, and service_role. Both are SECURITY DEFINER and both
+-- write members.day_passes_balance directly, so the grant let the balance be
+-- moved through the public REST API by any role holding the anon key, with
+-- the member id as a plain argument.
+--
+-- Every caller in this repo drives them through the service-role client:
+--
+--   apps/web/src/app/api/portal/request-daypass/route.ts   (admin client)
+--   apps/web/src/app/api/admin/members/[id]/add-passes/route.ts
+--   apps/web/src/lib/passFulfillment.ts                    (admin client)
+--   apps/web/src/lib/subscriptionPasses.ts                 (admin client)
+--   apps/bot/src/bot.ts                                    (service-role db)
+--
+-- so narrowing the grant costs nothing. This is the same treatment 046's
+-- bind_member_wallet and 050's lookup helpers already get.
+--
+-- Both functions also lacked `set search_path`, which every other SECURITY
+-- DEFINER function in this schema sets (014, 016, 032, 050). Pinned to public
+-- here so the resolution of `members` can't depend on the caller's setting.
+
+revoke all on function public.decrement_day_pass_balance(integer, integer) from public, anon, authenticated;
+grant execute on function public.decrement_day_pass_balance(integer, integer) to service_role;
+alter function public.decrement_day_pass_balance(integer, integer) set search_path = public;
+
+revoke all on function public.increment_day_pass_balance(integer, integer) from public, anon, authenticated;
+grant execute on function public.increment_day_pass_balance(integer, integer) to service_role;
+alter function public.increment_day_pass_balance(integer, integer) set search_path = public;


### PR DESCRIPTION
## What changed

New migration `052_day_pass_rpc_grants.sql` tightens the grants on the two atomic day-pass balance helpers from migration 012:

- `revoke all ... from public, anon, authenticated` on both `increment_day_pass_balance(integer, integer)` and `decrement_day_pass_balance(integer, integer)`
- `grant execute ... to service_role`
- `alter function ... set search_path = public` on both

Plus two small code changes that go with it:

- `apps/web/src/app/api/admin/members/[id]/add-passes/route.ts` now uses `createServiceClient()` instead of the user's session client. It was the only caller reaching these RPCs as `authenticated`; it is `requireAdmin`-gated and bounds `count` to ±1000, so this matches how every other admin write in the app is done (see the PATCH handler in `[id]/route.ts`, which notes the same thing for migration 031).
- `apps/web/src/app/api/portal/request-daypass/route.ts` had a comment claiming the balance RPCs "have no INSERT/EXECUTE policy for regular members". That was not true of the RPCs before this migration. Reworded to describe the post-052 state accurately.

## Why

Both functions are `SECURITY DEFINER` and write `members.day_passes_balance` directly, taking the member id as a plain argument. Migration 012 granted EXECUTE to `anon` and `authenticated` alongside `service_role`, so they were reachable over the public REST API by any role holding the anon key. Neither pinned a `search_path`, unlike every other `SECURITY DEFINER` function in this schema (014, 016, 032, 050).

This is the same treatment 046's `bind_member_wallet` and 050's lookup helpers already get: service-role only, `search_path` pinned.

## Caller audit

Every call site of either RPC, from `grep -rn "crement_day_pass_balance" apps packages supabase`:

| Caller | Client | Status |
|---|---|---|
| `apps/web/src/app/api/portal/request-daypass/route.ts` (decrement + 2 refund increments) | `createServiceClient()` | unchanged |
| `apps/web/src/lib/passFulfillment.ts` | `createServiceClient()` | unchanged |
| `apps/web/src/lib/subscriptionPasses.ts` | `createServiceClient()` | unchanged |
| `apps/bot/src/bot.ts` (4 sites) | `db` from `src/db/supabase.ts`, built with `SUPABASE_SERVICE_ROLE_KEY` | unchanged |
| `apps/web/src/app/api/admin/members/[id]/add-passes/route.ts` | **was** `createClient()` (session) | **changed** to `createServiceClient()` |

`apps/web/src/lib/supabase/types.ts` carries the generated type entries only. No browser-side caller exists; the only `@/lib/supabase/client` import in the app is `components/auth/LoginForm.tsx`, which does auth only.

## Verification

From a clean worktree at this commit:

- `pnpm --filter web lint` — 0 errors, 2 pre-existing warnings (`MemberDirectory.tsx` no-img-element, `stripeNet.test.ts` unused var)
- `pnpm --filter web test` — 40 files, 289 tests, all passing
- `pnpm --filter web build` — succeeds

`052_day_pass_rpc_grants.sql` matches `MIGRATION_FILENAME_RE` in `apps/web/src/lib/migrations.ts` and checksums are computed from disk at read time, so `list_migrations` picks it up with no code change.

## Deploy

Per CLAUDE.md, the SQL ships in the Docker image, so **deploy web first, then run the migration**:

1. Merge and let the web deploy complete.
2. `list_migrations()` over the ops MCP — `052_day_pass_rpc_grants.sql` should be the lowest-numbered pending file.
3. `run_migration("052_day_pass_rpc_grants.sql")`.

Order matters in the other direction too: the add-passes route must be running the service-client version before the grants narrow, or that one admin action would start failing. Deploying web first covers this.

## Rollback

Revert the commit and redeploy for the app-side changes. For the database, the grants can be restored with:

```sql
grant execute on function public.decrement_day_pass_balance(integer, integer) to anon, authenticated;
grant execute on function public.increment_day_pass_balance(integer, integer) to anon, authenticated;
alter function public.decrement_day_pass_balance(integer, integer) reset search_path;
alter function public.increment_day_pass_balance(integer, integer) reset search_path;
```
